### PR TITLE
Initial code generation

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTest.cs
+++ b/Google.Api.Generator.Tests/ProtoTest.cs
@@ -1,8 +1,26 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using Xunit;
 using Xunit.Sdk;
 
@@ -12,10 +30,8 @@ namespace Google.Api.Generator.Tests
     // TODO: Move this proto-base functionality into a helper method/class, and probably remove this test.
     public class ProtoTest
     {
-        [Fact]
-        public void TestProtocExecution()
+        private IEnumerable<CodeGenerator.ResultFile> Run(string protoFilename, string package)
         {
-            // Test that protoc executes successfully, and the generator works correctly on the resulting proto descriptor
             var rootPath = Environment.CurrentDirectory;
             while (!rootPath.EndsWith("Google.Api.Generator.Tests"))
             {
@@ -28,7 +44,7 @@ namespace Google.Api.Generator.Tests
             var descOutputPath = Path.GetTempFileName();
             try
             {
-                var protocArgs = $"-o {descOutputPath} --include_imports --include_source_info -I. -I{commonProtosPath} ProtoTest.proto";
+                var protocArgs = $"-o {descOutputPath} --include_imports --include_source_info -I. -I{commonProtosPath} {protoFilename}";
                 var processStart = new ProcessStartInfo(protocPath, protocArgs)
                 {
                     RedirectStandardError = true
@@ -44,9 +60,8 @@ namespace Google.Api.Generator.Tests
                         throw new XunitException($"protoc failed:\n{string.Join('\n', protocErrors)}");
                     }
                 }
-                var descBytes = File.ReadAllBytes(descOutputPath);
-                var files = CodeGenerator.Generate(descBytes, "testing");
-                Assert.Empty(files);
+                var descriptorBytes = File.ReadAllBytes(descOutputPath);
+                return CodeGenerator.Generate(descriptorBytes, package);
             }
             catch (Exception e)
             {
@@ -56,6 +71,36 @@ namespace Google.Api.Generator.Tests
             {
                 File.Delete(descOutputPath);
             }
+        }
+
+        [Fact]
+        public void TestProtocExecution()
+        {
+            // Test that protoc executes successfully,
+            // and the generator processes the descriptors without crashing!
+            // TODO: Remove this test.
+            Run("ProtoTest.proto", "testing");
+        }
+
+        [Fact]
+        public void TestThatSomeCodeIsGenerated()
+        {
+            // Test that the code generator executes, and produces *something*.
+            // At the moment the code produced is not formatted, which means all
+            // whitespace is missing, and is therefore unparsable as C# code.
+            // TODO: Remove this test.
+            var files = Run("ProtoTest.proto", "testing");
+            var clientCs = files.FirstOrDefault(x => x.RelativePath == "TestClient.cs");
+            Assert.NotNull(clientCs);
+            var clientCsContent = Encoding.UTF8.GetString(clientCs.Content);
+            // Even though this isn't valid C#, the Roslyn parser should not fail.
+            var root = CSharpSyntaxTree.ParseText(clientCsContent).GetCompilationUnitRoot();
+            Assert.NotNull(root);
+            // The generator has produced something. Check for a couple of expected strings.
+            Assert.Contains("namespace", clientCsContent);
+            Assert.Contains("Testing", clientCsContent);
+            Assert.Contains("class", clientCsContent);
+            Assert.Contains("TestSettings", clientCsContent);
         }
     }
 }

--- a/Google.Api.Generator/Generation/ServiceCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceCodeGenerator.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Google.Api.Generator.RoslynUtils.RoslynBuilder;
+
+namespace Google.Api.Generator.Generation
+{
+    /// <summary>
+    /// Generate all code related to a proto-defined service.
+    /// </summary>
+    internal static class ServiceCodeGenerator
+    {
+        public static CompilationUnitSyntax Generate(SourceFileContext ctx, ServiceDetails svc)
+        {
+            var ns = Namespace(svc.Namespace);
+            using (ctx.InNamespace(ns))
+            {
+                var settingsClass = ServiceSettingsCodeGenerator.Generate(ctx, svc);
+                ns = ns.AddMembers(settingsClass);
+            }
+            return ctx.CreateCompilationUnit(ns);
+        }
+    }
+}

--- a/Google.Api.Generator/Generation/ServiceDetails.cs
+++ b/Google.Api.Generator/Generation/ServiceDetails.cs
@@ -1,0 +1,75 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Generator.ProtoUtils;
+using Google.Api.Generator.Utils;
+using Google.Protobuf.Reflection;
+
+namespace Google.Api.Generator.Generation
+{
+    internal class ServiceDetails
+    {
+        public ServiceDetails(ProtoCatalog catalog, string ns, ServiceDescriptor desc)
+        {
+            Catalog = catalog;
+            Namespace = ns;
+            ProtoTyp = Typ.Manual(ns, desc.Name);
+            GrpcClientTyp = Typ.Nested(ProtoTyp, $"{desc.Name}Client");
+            SettingsTyp = Typ.Manual(ns, $"{desc.Name}Settings");
+            ClientAbstractTyp = Typ.Manual(ns, $"{desc.Name}Client");
+            ClientImplTyp = Typ.Manual(ns, $"{desc.Name}ClientImpl");
+            desc.CustomOptions.TryGetString(ProtoConsts.ServiceOption.DefaultHost, out var defaultHost);
+            DefaultHost = defaultHost;
+            DefaultPort = 443; // Hardcoded; this is not specifiable by proto annotation.
+        }
+
+        public ProtoCatalog Catalog { get; }
+        public string Namespace { get; }
+
+        /// <summary>
+        /// The outer typ of the protoc-generated C# code.
+        /// </summary>
+        public Typ ProtoTyp { get; }
+
+        /// <summary>
+        /// The typ of the grpc-protoc-generated C# gRPC client code.
+        /// </summary>
+        public Typ GrpcClientTyp { get; }
+
+        /// <summary>
+        /// The typ of the GAPIC settings class for this service.
+        /// </summary>
+        public Typ SettingsTyp { get; }
+
+        /// <summary>
+        /// The typ of the GAPIC abstract client for this service.
+        /// </summary>
+        public Typ ClientAbstractTyp { get; }
+
+        /// <summary>
+        /// The typ of the GAPIC client implementation for this service.
+        /// </summary>
+        public Typ ClientImplTyp { get; }
+
+        /// <summary>
+        /// The default hostname for this service.
+        /// </summary>
+        public string DefaultHost { get; }
+
+        /// <summary>
+        /// The default port for this service.
+        /// </summary>
+        public int DefaultPort { get; }
+    }
+}

--- a/Google.Api.Generator/Generation/ServiceSettingsCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceSettingsCodeGenerator.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax.Grpc;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Google.Api.Generator.RoslynUtils.Modifier;
+using static Google.Api.Generator.RoslynUtils.RoslynBuilder;
+
+namespace Google.Api.Generator.Generation
+{
+    /// <summary>
+    /// Generate all code for the `Settings` class of a proto-defined service.
+    /// </summary>
+    internal class ServiceSettingsCodeGenerator
+    {
+        public static ClassDeclarationSyntax Generate(SourceFileContext ctx, ServiceDetails svc) =>
+            new ServiceSettingsCodeGenerator(ctx, svc).Generate();
+
+        private ServiceSettingsCodeGenerator(SourceFileContext ctx, ServiceDetails svc) =>
+            (_ctx, _svc) = (ctx, svc);
+
+        private readonly SourceFileContext _ctx;
+        private readonly ServiceDetails _svc;
+
+        private ClassDeclarationSyntax Generate()
+        {
+            var cls = Class(Public | Sealed | Partial, _svc.SettingsTyp, baseType: _ctx.Type<ServiceSettingsBase>());
+            // TODO: Fill the settings class.
+            return cls;
+        }
+    }
+}

--- a/Google.Api.Generator/Generation/SourceFileContext.cs
+++ b/Google.Api.Generator/Generation/SourceFileContext.cs
@@ -1,0 +1,148 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Generator.Utils;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Google.Api.Generator.Generation
+{
+    internal class SourceFileContext
+    {
+        public enum ImportStyle
+        {
+            FullyAliased,
+            // TODO: Unaliased
+        }
+
+        private static readonly IReadOnlyDictionary<string, string> s_wellknownNamespaceAliases = new Dictionary<string, string>
+        {
+            { typeof(System.Int32).Namespace, "sys" }, // Don't use "s"; one-letter alias cause a compilation error!
+            { typeof(System.Collections.Generic.IEnumerable<>).Namespace, "scg" },
+            { typeof(Google.Api.Gax.Expiration).Namespace, "gax" },
+            { typeof(Google.Api.Gax.Grpc.CallSettings).Namespace, "gaxgrpc" },
+            { typeof(Grpc.Core.CallCredentials).Namespace, "grpccore" },
+            { typeof(Grpc.Core.Interceptors.Interceptor).Namespace, "grpcinter" },
+            { typeof(Google.Protobuf.WellKnownTypes.Any).Namespace, "wkt" },
+        };
+
+        public SourceFileContext(ImportStyle importStyle) => _importStyle = importStyle;
+
+        private readonly ImportStyle _importStyle;
+
+        // Namespace -> alias
+        private readonly Dictionary<string, string> _namespaceAliases = new Dictionary<string, string>();
+        private readonly HashSet<string> _namespaceAliasesOnly = new HashSet<string>();
+
+        /// <summary>
+        /// The current namespace. This will change depending on code location.
+        /// </summary>
+        public string Namespace { get; private set; } = "";
+
+        /// <summary>
+        /// The stack of typ nesting. Element 0 is the outermost typ.
+        /// </summary>
+        public IReadOnlyList<Typ> Typs { get; private set; } = new Typ[0];
+
+        /// <summary>
+        /// The current typ. This will change depending on code location.
+        /// </summary>
+        public Typ CurrentTyp => Typs.Last();
+
+        /// <summary>
+        /// The current TypeSyntax. This will change depending on code location.
+        /// </summary>
+        public TypeSyntax CurrentType => Type(CurrentTyp);
+
+        public IDisposable InNamespace(NamespaceDeclarationSyntax ns)
+        {
+            var restoreNamespace = Namespace;
+            Namespace = $"{Namespace}.{ns.Name}".Trim('.');
+            return new Disposable(() => Namespace = restoreNamespace);
+        }
+
+        public TypeSyntax Type<T>() => Type(Typ.Of<T>());
+
+        public TypeSyntax Type(Typ typ)
+        {
+            if (_importStyle != ImportStyle.FullyAliased)
+            {
+                // TODO: Remove when other import style(s) are implemented.
+                throw new NotImplementedException();
+            }
+            string namespaceAlias;
+            if ($"{Namespace}.".StartsWith($"{typ.Namespace}."))
+            {
+                // Within the current namespace, no import required.
+                namespaceAlias = null;
+            }
+            else if (!_namespaceAliases.TryGetValue(typ.Namespace, out namespaceAlias))
+            {
+                // A namespace that hasn't been seen before. Create an alias for it.
+                if (!s_wellknownNamespaceAliases.TryGetValue(typ.Namespace, out var rawAlias))
+                {
+                    // If it's not a well-known namespace (e.g. "System"), then create an alias 
+                    // using the first character of each namespace part.
+                    rawAlias = typ.Namespace
+                        .Split('.', StringSplitOptions.RemoveEmptyEntries)
+                        .Select(x => char.ToLowerInvariant(x[0]))
+                        .Aggregate("", (a, c) => a + c);
+                }
+                // Make sure all aliases are unique by adding a numeric suffix if necessary.
+                int index = 0;
+                namespaceAlias = rawAlias;
+                while (_namespaceAliasesOnly.Contains(namespaceAlias))
+                {
+                    namespaceAlias = $"{rawAlias}{++index}";
+                }
+                // Record the alias for later.
+                _namespaceAliases.Add(typ.Namespace, namespaceAlias);
+                _namespaceAliasesOnly.Add(namespaceAlias);
+            }
+            var name = typ.Name;
+            // If in a nested typ, set the name correctly.
+            var declaringTyp = typ.DeclaringTyp;
+            while (declaringTyp != null && declaringTyp != CurrentTyp)
+            {
+                name = $"{declaringTyp.Name}.{name}";
+                declaringTyp = declaringTyp.DeclaringTyp;
+            }
+            SimpleNameSyntax result = IdentifierName(name);
+            if (typ.GenericArgTyps != null)
+            {
+                // Generic typ, so return a generic name by recursively calling this method on all type args.
+                result = GenericName(result.Identifier, TypeArgumentList(SeparatedList(typ.GenericArgTyps.Select(Type))));
+            }
+            // Return the final TypeSyntax, aliased on not as required.
+            return namespaceAlias == null ? (TypeSyntax)result : AliasQualifiedName(namespaceAlias, result);
+        }
+
+        public CompilationUnitSyntax CreateCompilationUnit(NamespaceDeclarationSyntax ns)
+        {
+            switch (_importStyle)
+            {
+                case ImportStyle.FullyAliased:
+                    var usings = _namespaceAliases
+                        .OrderBy(x => x.Key)
+                        .Select(x => UsingDirective(NameEquals(x.Value), IdentifierName(x.Key)));
+                    return CompilationUnit().AddUsings(usings.ToArray()).AddMembers(ns);
+                default:
+                    throw new InvalidOperationException();
+            }
+        }
+    }
+}

--- a/Google.Api.Generator/Generation/SourceFileContext.cs
+++ b/Google.Api.Generator/Generation/SourceFileContext.cs
@@ -31,7 +31,7 @@ namespace Google.Api.Generator.Generation
 
         private static readonly IReadOnlyDictionary<string, string> s_wellknownNamespaceAliases = new Dictionary<string, string>
         {
-            { typeof(System.Int32).Namespace, "sys" }, // Don't use "s"; one-letter alias cause a compilation error!
+            { typeof(System.Int32).Namespace, "sys" }, // Don't use "s"; one-letter aliases cause a compilation error!
             { typeof(System.Collections.Generic.IEnumerable<>).Namespace, "scg" },
             { typeof(Google.Api.Gax.Expiration).Namespace, "gax" },
             { typeof(Google.Api.Gax.Grpc.CallSettings).Namespace, "gaxgrpc" },
@@ -127,7 +127,7 @@ namespace Google.Api.Generator.Generation
                 // Generic typ, so return a generic name by recursively calling this method on all type args.
                 result = GenericName(result.Identifier, TypeArgumentList(SeparatedList(typ.GenericArgTyps.Select(Type))));
             }
-            // Return the final TypeSyntax, aliased on not as required.
+            // Return the final TypeSyntax, aliased or not as required.
             return namespaceAlias == null ? (TypeSyntax)result : AliasQualifiedName(namespaceAlias, result);
         }
 

--- a/Google.Api.Generator/Google.Api.Generator.csproj
+++ b/Google.Api.Generator/Google.Api.Generator.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,6 +8,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\protobuf\csharp\src\Google.Protobuf\Google.Protobuf.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
   </ItemGroup>
 
 </Project>

--- a/Google.Api.Generator/ProtoUtils/ProtoConsts.cs
+++ b/Google.Api.Generator/ProtoUtils/ProtoConsts.cs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Google.Api.Generator
+namespace Google.Api.Generator.ProtoUtils
 {
-    public class Program
+    internal static class ProtoConsts
     {
-        static void Main(string[] args)
+        public static class ServiceOption
         {
-            // TODO...
+            public const int DefaultHost = 1049;
         }
     }
 }

--- a/Google.Api.Generator/RoslynUtils/Modifier.cs
+++ b/Google.Api.Generator/RoslynUtils/Modifier.cs
@@ -41,33 +41,33 @@ namespace Google.Api.Generator.RoslynUtils
 
     internal static class ModifierExtensions
     {
-        private static readonly SyntaxToken PUBLIC_TOKEN = SyntaxFactory.Token(SyntaxKind.PublicKeyword);
-        private static readonly SyntaxToken ABSTRACT_TOKEN = SyntaxFactory.Token(SyntaxKind.AbstractKeyword);
-        private static readonly SyntaxToken PARTIAL_TOKEN = SyntaxFactory.Token(SyntaxKind.PartialKeyword);
-        private static readonly SyntaxToken STATIC_TOKEN = SyntaxFactory.Token(SyntaxKind.StaticKeyword);
-        private static readonly SyntaxToken READONLY_TOKEN = SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword);
-        private static readonly SyntaxToken PRIVATE_TOKEN = SyntaxFactory.Token(SyntaxKind.PrivateKeyword);
-        private static readonly SyntaxToken ASYNC_TOKEN = SyntaxFactory.Token(SyntaxKind.AsyncKeyword);
-        private static readonly SyntaxToken SEALED_TOKEN = SyntaxFactory.Token(SyntaxKind.SealedKeyword);
-        private static readonly SyntaxToken VIRTUAL_TOKEN = SyntaxFactory.Token(SyntaxKind.VirtualKeyword);
-        private static readonly SyntaxToken OVERRIDE_TOKEN = SyntaxFactory.Token(SyntaxKind.OverrideKeyword);
-        private static readonly SyntaxToken INTERNAL_TOKEN = SyntaxFactory.Token(SyntaxKind.InternalKeyword);
+        private static readonly SyntaxToken s_publicToken = SyntaxFactory.Token(SyntaxKind.PublicKeyword);
+        private static readonly SyntaxToken s_abstractToken = SyntaxFactory.Token(SyntaxKind.AbstractKeyword);
+        private static readonly SyntaxToken s_partialToken = SyntaxFactory.Token(SyntaxKind.PartialKeyword);
+        private static readonly SyntaxToken s_staticToken = SyntaxFactory.Token(SyntaxKind.StaticKeyword);
+        private static readonly SyntaxToken s_readonlyToken = SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword);
+        private static readonly SyntaxToken s_privateToken = SyntaxFactory.Token(SyntaxKind.PrivateKeyword);
+        private static readonly SyntaxToken s_asyncToken = SyntaxFactory.Token(SyntaxKind.AsyncKeyword);
+        private static readonly SyntaxToken s_sealedToken = SyntaxFactory.Token(SyntaxKind.SealedKeyword);
+        private static readonly SyntaxToken s_virtualToken = SyntaxFactory.Token(SyntaxKind.VirtualKeyword);
+        private static readonly SyntaxToken s_overrideToken = SyntaxFactory.Token(SyntaxKind.OverrideKeyword);
+        private static readonly SyntaxToken s_internalToken = SyntaxFactory.Token(SyntaxKind.InternalKeyword);
 
         public static SyntaxToken[] ToSyntaxTokens(this Modifier m)
         {
             var result = new List<SyntaxToken>();
             // Order here matters; it's the order in which the modifiers will be placed in the generated source.
-            if ((m & Modifier.Public) != 0) result.Add(PUBLIC_TOKEN);
-            if ((m & Modifier.Private) != 0) result.Add(PRIVATE_TOKEN);
-            if ((m & Modifier.Internal) != 0) result.Add(INTERNAL_TOKEN);
-            if ((m & Modifier.Abstract) != 0) result.Add(ABSTRACT_TOKEN);
-            if ((m & Modifier.Virtual) != 0) result.Add(VIRTUAL_TOKEN);
-            if ((m & Modifier.Override) != 0) result.Add(OVERRIDE_TOKEN);
-            if ((m & Modifier.Readonly) != 0) result.Add(READONLY_TOKEN);
-            if ((m & Modifier.Static) != 0) result.Add(STATIC_TOKEN);
-            if ((m & Modifier.Sealed) != 0) result.Add(SEALED_TOKEN);
-            if ((m & Modifier.Async) != 0) result.Add(ASYNC_TOKEN);
-            if ((m & Modifier.Partial) != 0) result.Add(PARTIAL_TOKEN);
+            if ((m & Modifier.Public) != 0) result.Add(s_publicToken);
+            if ((m & Modifier.Private) != 0) result.Add(s_privateToken);
+            if ((m & Modifier.Internal) != 0) result.Add(s_internalToken);
+            if ((m & Modifier.Abstract) != 0) result.Add(s_abstractToken);
+            if ((m & Modifier.Virtual) != 0) result.Add(s_virtualToken);
+            if ((m & Modifier.Override) != 0) result.Add(s_overrideToken);
+            if ((m & Modifier.Readonly) != 0) result.Add(s_readonlyToken);
+            if ((m & Modifier.Static) != 0) result.Add(s_staticToken);
+            if ((m & Modifier.Sealed) != 0) result.Add(s_sealedToken);
+            if ((m & Modifier.Async) != 0) result.Add(s_asyncToken);
+            if ((m & Modifier.Partial) != 0) result.Add(s_partialToken);
             return result.ToArray();
         }
     }

--- a/Google.Api.Generator/RoslynUtils/Modifier.cs
+++ b/Google.Api.Generator/RoslynUtils/Modifier.cs
@@ -1,0 +1,74 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Google.Api.Generator.RoslynUtils
+{
+    [Flags]
+    internal enum Modifier
+    {
+        DontCare = 0,
+        NoModifiers = 0,
+
+        Public = 0x1,
+        Static = 0x2,
+        Private = 0x4,
+        Readonly = 0x8,
+        Async = 0x10,
+        Sealed = 0x20,
+        Partial = 0x40,
+        Abstract = 0x80,
+        Virtual = 0x100,
+        Override = 0x200,
+        Internal = 0x400,
+    }
+
+    internal static class ModifierExtensions
+    {
+        private static readonly SyntaxToken PUBLIC_TOKEN = SyntaxFactory.Token(SyntaxKind.PublicKeyword);
+        private static readonly SyntaxToken ABSTRACT_TOKEN = SyntaxFactory.Token(SyntaxKind.AbstractKeyword);
+        private static readonly SyntaxToken PARTIAL_TOKEN = SyntaxFactory.Token(SyntaxKind.PartialKeyword);
+        private static readonly SyntaxToken STATIC_TOKEN = SyntaxFactory.Token(SyntaxKind.StaticKeyword);
+        private static readonly SyntaxToken READONLY_TOKEN = SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword);
+        private static readonly SyntaxToken PRIVATE_TOKEN = SyntaxFactory.Token(SyntaxKind.PrivateKeyword);
+        private static readonly SyntaxToken ASYNC_TOKEN = SyntaxFactory.Token(SyntaxKind.AsyncKeyword);
+        private static readonly SyntaxToken SEALED_TOKEN = SyntaxFactory.Token(SyntaxKind.SealedKeyword);
+        private static readonly SyntaxToken VIRTUAL_TOKEN = SyntaxFactory.Token(SyntaxKind.VirtualKeyword);
+        private static readonly SyntaxToken OVERRIDE_TOKEN = SyntaxFactory.Token(SyntaxKind.OverrideKeyword);
+        private static readonly SyntaxToken INTERNAL_TOKEN = SyntaxFactory.Token(SyntaxKind.InternalKeyword);
+
+        public static SyntaxToken[] ToSyntaxTokens(this Modifier m)
+        {
+            var result = new List<SyntaxToken>();
+            // Order here matters; it's the order in which the modifiers will be placed in the generated source.
+            if ((m & Modifier.Public) != 0) result.Add(PUBLIC_TOKEN);
+            if ((m & Modifier.Private) != 0) result.Add(PRIVATE_TOKEN);
+            if ((m & Modifier.Internal) != 0) result.Add(INTERNAL_TOKEN);
+            if ((m & Modifier.Abstract) != 0) result.Add(ABSTRACT_TOKEN);
+            if ((m & Modifier.Virtual) != 0) result.Add(VIRTUAL_TOKEN);
+            if ((m & Modifier.Override) != 0) result.Add(OVERRIDE_TOKEN);
+            if ((m & Modifier.Readonly) != 0) result.Add(READONLY_TOKEN);
+            if ((m & Modifier.Static) != 0) result.Add(STATIC_TOKEN);
+            if ((m & Modifier.Sealed) != 0) result.Add(SEALED_TOKEN);
+            if ((m & Modifier.Async) != 0) result.Add(ASYNC_TOKEN);
+            if ((m & Modifier.Partial) != 0) result.Add(PARTIAL_TOKEN);
+            return result.ToArray();
+        }
+    }
+}

--- a/Google.Api.Generator/RoslynUtils/RoslynBuilder.cs
+++ b/Google.Api.Generator/RoslynUtils/RoslynBuilder.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Generator.Utils;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Google.Api.Generator.RoslynUtils
+{
+    internal static class RoslynBuilder
+    {
+        public static NamespaceDeclarationSyntax Namespace(string ns) => NamespaceDeclaration(IdentifierName(ns));
+
+        public static ClassDeclarationSyntax Class(Modifier modifier, Typ typ, TypeSyntax baseType = null)
+        {
+            var cls = ClassDeclaration(typ.Name).AddModifiers(modifier.ToSyntaxTokens());
+            if (baseType != null)
+            {
+                cls = cls.WithBaseList(BaseList(SingletonSeparatedList<BaseTypeSyntax>(SimpleBaseType(baseType))));
+            }
+            return cls;
+        }
+    }
+}

--- a/Google.Api.Generator/Utils/Disposable.cs
+++ b/Google.Api.Generator/Utils/Disposable.cs
@@ -16,6 +16,10 @@ using System;
 
 namespace Google.Api.Generator.Utils
 {
+    /// <summary>
+    /// A general implementation of IDisposable that allows an arbitrary
+    /// action to be executed on disposal.
+    /// </summary>
     internal class Disposable : IDisposable
     {
         public Disposable(Action action) => _action = action;

--- a/Google.Api.Generator/Utils/Disposable.cs
+++ b/Google.Api.Generator/Utils/Disposable.cs
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Google.Api.Generator
+using System;
+
+namespace Google.Api.Generator.Utils
 {
-    public class Program
+    internal class Disposable : IDisposable
     {
-        static void Main(string[] args)
-        {
-            // TODO...
-        }
+        public Disposable(Action action) => _action = action;
+        private readonly Action _action;
+        public void Dispose() => _action();
     }
 }

--- a/Google.Api.Generator/Utils/Typ.cs
+++ b/Google.Api.Generator/Utils/Typ.cs
@@ -1,0 +1,86 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Google.Api.Generator.Utils
+{
+    /// <summary>
+    /// Abstraction of a .NET type.
+    /// </summary>
+    internal abstract class Typ
+    {
+        private sealed class FromType : Typ
+        {
+            public FromType(System.Type type) => _type = type;
+            private System.Type _type;
+            public override string Namespace => _type.Namespace;
+            public override string Name => _type.Name.Split('`')[0];
+            public override bool IsPrimitive => _type.IsPrimitive;
+            public override Typ ElementTyp => _type.IsArray ? Of(_type.GetElementType()) : null;
+            public override Typ DeclaringTyp => _type.IsNested ? Of(_type.DeclaringType) : null;
+            public override IEnumerable<Typ> GenericArgTyps => _type.IsGenericType ? _type.GetGenericArguments().Select(Of) : null;
+        }
+
+        private sealed class FromManual : Typ
+        {
+            public FromManual(string ns, string name) => (Namespace, Name) = (ns, name);
+            public override string Namespace { get; }
+            public override string Name { get; }
+        }
+
+        private sealed class FromNested : Typ
+        {
+            public FromNested(Typ declaringTyp, string name) => (DeclaringTyp, Name) = (declaringTyp, name);
+            public override string Namespace => DeclaringTyp.Namespace;
+            public override string Name { get; }
+            public override Typ DeclaringTyp { get; }
+            public override string FullName => $"{DeclaringTyp.FullName}+{Name}";
+        }
+
+        public static Typ Of<T>() => Of(typeof(T));
+        public static Typ Of(System.Type type) => new FromType(type);
+        public static Typ Manual(string ns, string name) => new FromManual(ns, name);
+        public static Typ Nested(Typ declaringTyp, string name) => new FromNested(declaringTyp, name);
+
+        /// <summary> the namespace of this typ. </summary>
+        public abstract string Namespace { get; }
+
+        /// <summary> The name of this typ. </summary>
+        public abstract string Name { get; }
+
+        /// <summary> Whether this typ is a primitive. </summary>
+        public virtual bool IsPrimitive => false;
+
+        /// <summary> The array element typ; or <c>null</c> if not an array. </summary>
+        public virtual Typ ElementTyp => null;
+
+        /// <summary> The declaring typ; or <c>null</c> if not nested. </summary>
+        public virtual Typ DeclaringTyp => null;
+
+        /// <summary> The generic arguments of this typ; or <c>null</c> if not a generic typ.  </summary>
+        public virtual IEnumerable<Typ> GenericArgTyps => null;
+
+        public virtual string FullName => $"{Namespace}.{Name}";
+
+        public override string ToString() => FullName;
+        public override int GetHashCode() => FullName.GetHashCode();
+        public override bool Equals(object obj) => obj is Typ other && FullName == other.FullName;
+
+        public static bool operator ==(Typ a, Typ b) => a?.FullName == b?.FullName;
+        public static bool operator !=(Typ a, Typ b) => !(a == b);
+    }
+}

--- a/Google.Api.Generator/Utils/Typ.cs
+++ b/Google.Api.Generator/Utils/Typ.cs
@@ -18,8 +18,12 @@ using System.Linq;
 
 namespace Google.Api.Generator.Utils
 {
+    // TODO: If this name causes too much confusion change it to something
+    // more descriptive, possibly "ClrType".
     /// <summary>
     /// Abstraction of a .NET type.
+    /// The name "Typ" is delibrately concise as this type is used extensively
+    /// throughout the rest of the code.
     /// </summary>
     internal abstract class Typ
     {


### PR DESCRIPTION
Just enough implemented to generate the structure of the client Settings class, with a test.
Code formatting not yet implemented, which is why the test can't use the Roslyn parser yet to check the result.