### PR TITLE
Add code whitespace formatter, with test

### DIFF
--- a/Google.Api.Generator.Tests/Google.Api.Generator.Tests.csproj
+++ b/Google.Api.Generator.Tests/Google.Api.Generator.Tests.csproj
@@ -17,6 +17,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Update="WhitespaceFormatterTest.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="ProtoTest.proto">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Google.Api.Generator.Tests/ProtoTest.cs
+++ b/Google.Api.Generator.Tests/ProtoTest.cs
@@ -93,14 +93,20 @@ namespace Google.Api.Generator.Tests
             var clientCs = files.FirstOrDefault(x => x.RelativePath == "TestClient.cs");
             Assert.NotNull(clientCs);
             var clientCsContent = Encoding.UTF8.GetString(clientCs.Content);
-            // Even though this isn't valid C#, the Roslyn parser should not fail.
+            // TODO: Create helper methods for much of this Roslyn testing.
+            // Parse the C# source.
             var root = CSharpSyntaxTree.ParseText(clientCsContent).GetCompilationUnitRoot();
             Assert.NotNull(root);
-            // The generator has produced something. Check for a couple of expected strings.
-            Assert.Contains("namespace", clientCsContent);
-            Assert.Contains("Testing", clientCsContent);
-            Assert.Contains("class", clientCsContent);
-            Assert.Contains("TestSettings", clientCsContent);
+            // Check there is at least one `using` directive.
+            Assert.NotEmpty(root.Usings);
+            // Check there is only one `namespace` statement.
+            Assert.Single(root.Members);
+            var ns = root.Members[0] as NamespaceDeclarationSyntax;
+            Assert.NotNull(ns);
+            // Check there is one settings class.
+            Assert.NotEmpty(ns.Members);
+            var settingsCls = ns.Members.Where(x => (x as ClassDeclarationSyntax)?.Identifier.Text == "TestSettings").ToList();
+            Assert.Single(settingsCls);
         }
     }
 }

--- a/Google.Api.Generator.Tests/WhitespaceFormatterTest.cs
+++ b/Google.Api.Generator.Tests/WhitespaceFormatterTest.cs
@@ -15,13 +15,17 @@
 // This test loads this source file during the test, parses it into
 // Roslyn, removes all trivia, passes it through the Whitespace formatter,
 // then checks that the input source and re-formatted source are identical.
-// Code at the start, end, and between IGNORE_START/IGNORE_END markers
-// are ignored.
+// Code between the TEST_SOURCE_START and TEST_SOURCE_END comments are used
+// as source for this test.
 // So some of the source code looks a bit odd, as it needs to test every
 // code construct is formatted correctly.
 // TODO: Add further code as WhitespaceFormatter adds more formatting.
 
-// IGNORE_END
+// TODO: Consider splitting this test into multiple files; possibly
+// putting the test source separately, or splitting the test source
+// into multiple source files, and/or multiple tests.
+
+// TEST_SOURCE_START
 using Google.Api.Generator.Formatting;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -95,7 +99,7 @@ namespace Google.Api.Generator.Tests
         {
             // Test class that has no members.
         }
-        // IGNORE_START
+        // TEST_SOURCE_END
 
         private class TriviaRemover : CSharpSyntaxRewriter
         {
@@ -120,8 +124,8 @@ namespace Google.Api.Generator.Tests
             var testSourceLines = sourceLines.Aggregate((ignoring: true, lines: new List<string>()), (acc, line) =>
             {
                 var ignoring =
-                    line.Trim() == "// IGNORE_START" ? true :
-                    line.Trim() == "// IGNORE_END" ? false : (bool?)null;
+                    line.Trim() == "// TEST_SOURCE_END" ? true :
+                    line.Trim() == "// TEST_SOURCE_START" ? false : (bool?)null;
                 if (!acc.ignoring && ignoring != true && !line.Trim().StartsWith("//"))
                 {
                     acc.lines.Add(line);
@@ -143,8 +147,8 @@ namespace Google.Api.Generator.Tests
             // Check that the sources are identical.
             Assert.Equal(testSource, testSourceFormatter);
         }
-        // IGNORE_END
+        // TEST_SOURCE_START
     }
 }
 
-// IGNORE_START
+// TEST_SOURCE_END

--- a/Google.Api.Generator.Tests/WhitespaceFormatterTest.cs
+++ b/Google.Api.Generator.Tests/WhitespaceFormatterTest.cs
@@ -1,0 +1,150 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This test loads this source file during the test, parses it into
+// Roslyn, removes all trivia, passes it through the Whitespace formatter,
+// then checks that the input source and re-formatted source are identical.
+// Code at the start, end, and between IGNORE_START/IGNORE_END markers
+// are ignored.
+// So some of the source code looks a bit odd, as it needs to test every
+// code construct is formatted correctly.
+// TODO: Add further code as WhitespaceFormatter adds more formatting.
+
+// IGNORE_END
+using Google.Api.Generator.Formatting;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Xunit;
+using sys = System;
+
+namespace Google.Api.Generator.Tests
+{
+    public class WhitespaceFormatterTest
+    {
+        // Test nested class; base-list with multiple items.
+        // Test aliased type.
+        private class Inner : List<sys::String>, IEnumerable<string>, IList<string>
+        {
+            // Test ctor with no parameters.
+            // Test ctor calling another ctor with multiple parameters.
+            // Test empty bock body.
+            public Inner() : this(0, 1, 2)
+            {
+            }
+
+            // Test ctor with single parameter.
+            // Test ctor calling ctor with no args.
+            // Test expression body.
+            public Inner(int a) : this() => _a = a + 1;
+
+            // Test ctor with multiple parameters.
+            // Test non-empty block body.
+            public Inner(int a, int b, int c)
+            {
+                // Test assignment.
+                _a = a;
+                // Test binary operator.
+                _b = b + c;
+            }
+
+            // Test instance field with an initializer.
+            private readonly int _a = -1;
+
+            // Test instance field with no intializer.
+            private readonly int _b;
+
+            // Test get-only auto-property.
+            public string P1 { get; }
+
+            // Test get/set auto-property with initializer.
+            public string P2 { get; set; } = "Hello_world!";
+
+            // Test get-only expression-bodied property.
+            public string P3
+            {
+                get => "Hello_another_world!";
+            }
+
+            private string _p4 = "";
+
+            // Test get/set expression-bodied property.
+            public string P4
+            {
+                get => _p4 + _p4;
+                set => _p4 = value;
+            }
+        }
+
+        // Test base-list with one item.
+        private class EmptyInner : List<string>
+        {
+            // Test class that has no members.
+        }
+        // IGNORE_START
+
+        private class TriviaRemover : CSharpSyntaxRewriter
+        {
+            public TriviaRemover() : base(visitIntoStructuredTrivia: false) { }
+            public override SyntaxNode Visit(SyntaxNode node)
+            {
+                return base.Visit(node)?.WithoutTrivia();
+            }
+            public override SyntaxToken VisitToken(SyntaxToken token)
+            {
+                return base.VisitToken(token).WithoutTrivia();
+            }
+        }
+
+        private static string ThisFilename([CallerFilePath] string filePath = null) => Path.GetFileName(filePath);
+
+        [Fact]
+        public void ThisSourceFile()
+        {
+            // Read source file and remove all ignored lines.
+            var sourceLines = File.ReadAllLines(ThisFilename());
+            var testSourceLines = sourceLines.Aggregate((ignoring: true, lines: new List<string>()), (acc, line) =>
+            {
+                var ignoring =
+                    line.Trim() == "// IGNORE_START" ? true :
+                    line.Trim() == "// IGNORE_END" ? false : (bool?)null;
+                if (!acc.ignoring && ignoring != true && !line.Trim().StartsWith("//"))
+                {
+                    acc.lines.Add(line);
+                }
+                return (ignoring ?? acc.ignoring, acc.lines);
+            });
+            var testSource = string.Join("\r\n", testSourceLines.lines);
+            // Parse source using Roslyn.
+            var root = CSharpSyntaxTree.ParseText(testSource).GetCompilationUnitRoot();
+            // Remove all trivia (including whitespace) from Roslyn tree.
+            var rootWithoutWhitespace = new TriviaRemover().Visit(root);
+            // Confirm that the source now contains no whitspace.
+            var testSourceWithoutWhitespace = rootWithoutWhitespace.ToFullString();
+            Assert.DoesNotContain(" ", testSourceWithoutWhitespace);
+            Assert.DoesNotContain("\n", testSourceWithoutWhitespace);
+            // Use the WhitespaceFormatter.
+            var rootFormatter = new WhitespaceFormatter().Visit(rootWithoutWhitespace);
+            var testSourceFormatter = rootFormatter.ToFullString();
+            // Check that the sources are identical.
+            Assert.Equal(testSource, testSourceFormatter);
+        }
+        // IGNORE_END
+    }
+}
+
+// IGNORE_START

--- a/Google.Api.Generator/CodeGenerator.cs
+++ b/Google.Api.Generator/CodeGenerator.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Api.Generator.Formatting;
 using Google.Api.Generator.Generation;
 using Google.Api.Generator.ProtoUtils;
 using Google.Protobuf;
@@ -46,10 +47,10 @@ namespace Google.Api.Generator
                     var serviceDetails = new ServiceDetails(catalog, ns, service);
                     var ctx = new SourceFileContext(SourceFileContext.ImportStyle.FullyAliased);
                     var code = ServiceCodeGenerator.Generate(ctx, serviceDetails);
-                    // TODO: Format the code.
+                    var formattedCode = CodeFormatter.Format(code);
                     // TODO: Place the generated code in the correct directory.
                     var filename = $"{serviceDetails.ClientAbstractTyp.Name}.cs";
-                    var content = Encoding.UTF8.GetBytes(code.ToFullString());
+                    var content = Encoding.UTF8.GetBytes(formattedCode.ToFullString());
                     // May not use `yield return` later, but it's fine for now.
                     yield return new ResultFile(filename, content);
                 }

--- a/Google.Api.Generator/Formatting/CodeFormatter.cs
+++ b/Google.Api.Generator/Formatting/CodeFormatter.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Google.Api.Generator.Formatting
+{
+    internal static class CodeFormatter
+    {
+        public static CompilationUnitSyntax Format(CompilationUnitSyntax code)
+        {
+            var whitespace = new WhitespaceFormatter();
+            code = (CompilationUnitSyntax)whitespace.Visit(code);
+            // TODO: Line length formatting
+            return code;
+        }
+    }
+}

--- a/Google.Api.Generator/Formatting/WhitespaceFormatter.cs
+++ b/Google.Api.Generator/Formatting/WhitespaceFormatter.cs
@@ -1,0 +1,273 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Generator.RoslynUtils;
+using Google.Api.Generator.Utils;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Google.Api.Generator.Formatting
+{
+    internal class WhitespaceFormatter : CSharpSyntaxRewriter
+    {
+        private static readonly SyntaxToken s_commaSpace = Token(SyntaxKind.CommaToken).WithTrailingSpace();
+        private IEnumerable<SyntaxToken> CommaSpaces(int count) => Enumerable.Repeat(s_commaSpace, Math.Max(0, count));
+
+        public WhitespaceFormatter() : base(visitIntoStructuredTrivia: false) { }
+
+        private SyntaxTrivia _indentTrivia = SyntaxTrivia(SyntaxKind.WhitespaceTrivia, "");
+
+        private IDisposable WithIndent()
+        {
+            var orgIndentTrivia = _indentTrivia;
+            _indentTrivia = SyntaxTrivia(SyntaxKind.WhitespaceTrivia, new string(' ', orgIndentTrivia.Span.Length + 4));
+            return new Disposable(() => _indentTrivia = orgIndentTrivia);
+        }
+
+        private SyntaxTriviaList FormatXmlDoc(SyntaxTriviaList trivList)
+        {
+            // Minimal XML formatting, just to make sure the result is valid C#, indented correctly.
+            return TriviaList(trivList.Select(triv =>
+            {
+                if (triv.HasStructure && triv.GetStructure() is DocumentationCommentTriviaSyntax doc)
+                {
+                    doc = doc.WithContent(List(doc.Content.Select(x =>
+                        x.WithLeadingTrivia(new[] { _indentTrivia }.Concat(x.GetLeadingTrivia())).WithTrailingCrLf())));
+                    return Trivia(doc);
+                }
+                return triv;
+            }));
+        }
+
+        public override SyntaxNode VisitCompilationUnit(CompilationUnitSyntax node)
+        {
+            node = (CompilationUnitSyntax)base.VisitCompilationUnit(node);
+            node = node.WithMembers(List(node.Members.Take(1).Select(m => m.WithLeadingCrLf())
+                .Concat(node.Members.Skip(1))));
+            return node;
+        }
+
+        public override SyntaxNode VisitUsingDirective(UsingDirectiveSyntax node)
+        {
+            node = (UsingDirectiveSyntax)base.VisitUsingDirective(node);
+            node = node.WithLeadingTrivia(_indentTrivia);
+            node = node.WithUsingKeyword(node.UsingKeyword.WithTrailingSpace());
+            node = node.WithSemicolonToken(node.SemicolonToken.WithTrailingCrLf());
+            return node;
+        }
+
+        public override SyntaxNode VisitNameEquals(NameEqualsSyntax node)
+        {
+            node = (NameEqualsSyntax)base.VisitNameEquals(node);
+            node = node.WithEqualsToken(node.EqualsToken.WithLeadingSpace().WithTrailingSpace());
+            return node;
+        }
+
+        public override SyntaxNode VisitNamespaceDeclaration(NamespaceDeclarationSyntax node)
+        {
+            using (WithIndent())
+            {
+                node = (NamespaceDeclarationSyntax)base.VisitNamespaceDeclaration(node);
+            }
+            node = node.WithLeadingTrivia(_indentTrivia);
+            node = node.WithNamespaceKeyword(node.NamespaceKeyword.WithTrailingSpace());
+            node = node.WithOpenBraceToken(node.OpenBraceToken.WithLeadingTrivia(CarriageReturnLineFeed, _indentTrivia).WithTrailingCrLf());
+            node = node.WithCloseBraceToken(node.CloseBraceToken.WithLeadingTrivia(_indentTrivia).WithTrailingCrLf());
+            node = node.WithMembers(List(
+                node.Members.SkipLast(1).Select(m => m.WithTrailingCrLf(count: 2))
+                    .Concat(node.Members.TakeLast(1).Select(m => m.WithTrailingCrLf(count: 1)))));
+            return node;
+        }
+
+        public override SyntaxNode VisitClassDeclaration(ClassDeclarationSyntax node)
+        {
+            using (WithIndent())
+            {
+                node = (ClassDeclarationSyntax)base.VisitClassDeclaration(node);
+            }
+            node = node.WithLeadingTrivia(FormatXmlDoc(node.GetLeadingTrivia()).Append(_indentTrivia));
+            node = node.WithModifiers(TokenList(node.Modifiers.Select(m => m.WithTrailingSpace())));
+            node = node.WithKeyword(node.Keyword.WithTrailingSpace());
+            node = node.WithOpenBraceToken(node.OpenBraceToken.WithLeadingTrivia(CarriageReturnLineFeed, _indentTrivia).WithTrailingCrLf());
+            node = node.WithCloseBraceToken(node.CloseBraceToken.WithLeadingTrivia(_indentTrivia).WithTrailingCrLf());
+            node = node.WithMembers(List(
+                node.Members.SkipLast(1).Select(m => m.WithTrailingCrLf(count: 2))
+                    .Concat(node.Members.TakeLast(1).Select(m => m.WithTrailingCrLf(count: 1)))));
+            return node;
+        }
+
+        public override SyntaxNode VisitBaseList(BaseListSyntax node)
+        {
+            node = (BaseListSyntax)base.VisitBaseList(node);
+            node = node.WithColonToken(node.ColonToken.WithLeadingSpace().WithTrailingSpace());
+            node = node.WithTypes(SeparatedList(node.Types, CommaSpaces(node.Types.Count - 1)));
+            return node;
+        }
+
+        public override SyntaxNode VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
+        {
+            node = (ConstructorDeclarationSyntax)base.VisitConstructorDeclaration(node);
+            node = node.WithLeadingTrivia(FormatXmlDoc(node.GetLeadingTrivia()).Append(_indentTrivia));
+            node = node.WithModifiers(TokenList(node.Modifiers.Select(m => m.WithTrailingSpace())));
+            return node;
+        }
+
+        public override SyntaxNode VisitConstructorInitializer(ConstructorInitializerSyntax node)
+        {
+            node = (ConstructorInitializerSyntax)base.VisitConstructorInitializer(node);
+            node = node.WithColonToken(node.ColonToken.WithLeadingSpace().WithTrailingSpace());
+            return node;
+        }
+
+        public override SyntaxNode VisitMethodDeclaration(MethodDeclarationSyntax node)
+        {
+            node = (MethodDeclarationSyntax)base.VisitMethodDeclaration(node);
+            node = node.WithLeadingTrivia(FormatXmlDoc(node.GetLeadingTrivia()).Append(_indentTrivia));
+            node = node.WithModifiers(TokenList(node.Modifiers.Select(m => m.WithTrailingSpace())));
+            node = node.WithReturnType(node.ReturnType.WithTrailingSpace());
+            return node;
+        }
+
+        public override SyntaxNode VisitArgumentList(ArgumentListSyntax node)
+        {
+            node = (ArgumentListSyntax)base.VisitArgumentList(node);
+            node = node.WithArguments(SeparatedList(node.Arguments, CommaSpaces(node.Arguments.Count - 1)));
+            return node;
+        }
+
+        public override SyntaxNode VisitParameter(ParameterSyntax node)
+        {
+            node = (ParameterSyntax)base.VisitParameter(node);
+            node = node.WithType(node.Type.WithTrailingSpace());
+            node = node.WithModifiers(TokenList(node.Modifiers.Select(x => x.WithTrailingSpace())));
+            return node;
+        }
+
+        public override SyntaxNode VisitParameterList(ParameterListSyntax node)
+        {
+            node = (ParameterListSyntax)base.VisitParameterList(node);
+            node = node.WithParameters(SeparatedList(node.Parameters, CommaSpaces(node.Parameters.Count - 1)));
+            return node;
+        }
+
+        public override SyntaxNode VisitArrowExpressionClause(ArrowExpressionClauseSyntax node)
+        {
+            node = (ArrowExpressionClauseSyntax)base.VisitArrowExpressionClause(node);
+            node = node.WithArrowToken(node.ArrowToken.WithLeadingSpace().WithTrailingSpace());
+            return node;
+        }
+
+        public override SyntaxNode VisitBlock(BlockSyntax node)
+        {
+            using (WithIndent())
+            {
+                node = node.WithStatements(List(node.Statements.Select(s =>
+                    Visit(s).WithLeadingTrivia(_indentTrivia).WithTrailingCrLf())));
+            }
+            node = node.WithOpenBraceToken(node.OpenBraceToken.WithLeadingTrivia(CarriageReturnLineFeed, _indentTrivia).WithTrailingCrLf());
+            node = node.WithCloseBraceToken(node.CloseBraceToken.WithLeadingTrivia(_indentTrivia).WithTrailingCrLf());
+            return node;
+        }
+
+        public override SyntaxNode VisitAssignmentExpression(AssignmentExpressionSyntax node)
+        {
+            node = (AssignmentExpressionSyntax)base.VisitAssignmentExpression(node);
+            node = node.WithOperatorToken(node.OperatorToken.WithLeadingSpace().WithTrailingSpace());
+            return node;
+        }
+
+        public override SyntaxNode VisitBinaryExpression(BinaryExpressionSyntax node)
+        {
+            node = (BinaryExpressionSyntax)base.VisitBinaryExpression(node);
+            node = node.WithOperatorToken(node.OperatorToken.WithLeadingSpace().WithTrailingSpace());
+            return node;
+        }
+
+        public override SyntaxNode VisitFieldDeclaration(FieldDeclarationSyntax node)
+        {
+            node = (FieldDeclarationSyntax)base.VisitFieldDeclaration(node);
+            node = node.WithLeadingTrivia(FormatXmlDoc(node.GetLeadingTrivia()).Append(_indentTrivia));
+            node = node.WithModifiers(TokenList(node.Modifiers.Select(m => m.WithTrailingSpace())));
+            return node;
+        }
+
+        public override SyntaxNode VisitVariableDeclaration(VariableDeclarationSyntax node)
+        {
+            node = (VariableDeclarationSyntax)base.VisitVariableDeclaration(node);
+            node = node.WithType(node.Type.WithTrailingSpace());
+            return node;
+        }
+
+        public override SyntaxNode VisitEqualsValueClause(EqualsValueClauseSyntax node)
+        {
+            node = (EqualsValueClauseSyntax)base.VisitEqualsValueClause(node);
+            node = node.WithEqualsToken(node.EqualsToken.WithLeadingSpace().WithTrailingSpace());
+            return node;
+        }
+
+        public override SyntaxNode VisitPropertyDeclaration(PropertyDeclarationSyntax node)
+        {
+            node = (PropertyDeclarationSyntax)base.VisitPropertyDeclaration(node);
+            node = node.WithLeadingTrivia(FormatXmlDoc(node.GetLeadingTrivia()).Append(_indentTrivia));
+            node = node.WithModifiers(TokenList(node.Modifiers.Select(m => m.WithTrailingSpace())));
+            node = node.WithType(node.Type.WithTrailingSpace());
+            return node;
+        }
+
+        public override SyntaxNode VisitAccessorList(AccessorListSyntax node)
+        {
+            var anyBodies = node.Accessors.Any(x => x.Body != null || x.ExpressionBody != null);
+            if (anyBodies)
+            {
+                using (WithIndent())
+                {
+                    node = (AccessorListSyntax)base.VisitAccessorList(node);
+                }
+                node = node.WithOpenBraceToken(node.OpenBraceToken.WithLeadingTrivia(CarriageReturnLineFeed, _indentTrivia).WithTrailingCrLf());
+                node = node.WithCloseBraceToken(node.CloseBraceToken.WithLeadingTrivia(_indentTrivia));
+            }
+            else
+            {
+                node = (AccessorListSyntax)base.VisitAccessorList(node);
+                node = node.WithOpenBraceToken(node.OpenBraceToken.WithLeadingSpace().WithTrailingSpace());
+            }
+            return node;
+        }
+
+        public override SyntaxNode VisitAccessorDeclaration(AccessorDeclarationSyntax node)
+        {
+            node = (AccessorDeclarationSyntax)base.VisitAccessorDeclaration(node);
+            if (node.Body != null)
+            {
+                // TODO: Implement this if/when required.
+                throw new NotImplementedException();
+            }
+            else if (node.ExpressionBody != null)
+            {
+                node = node.WithKeyword(node.Keyword.WithLeadingTrivia(_indentTrivia));
+                node = node.WithSemicolonToken(node.SemicolonToken.WithTrailingCrLf());
+            }
+            else
+            {
+                node = node.WithSemicolonToken(node.SemicolonToken.WithTrailingSpace());
+            }
+            return node;
+        }
+    }
+}

--- a/Google.Api.Generator/RoslynUtils/RoslynExtensions.cs
+++ b/Google.Api.Generator/RoslynUtils/RoslynExtensions.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.CodeAnalysis;
+using System.Linq;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Google.Api.Generator.RoslynUtils
+{
+    internal static class RoslynExtensions
+    {
+        public static T WithTrailingSpace<T>(this T node) where T : SyntaxNode => node.WithTrailingTrivia(Space);
+        public static T WithLeadingCrLf<T>(this T node) where T : SyntaxNode => node.WithLeadingTrivia(CarriageReturnLineFeed);
+        public static T WithTrailingCrLf<T>(this T node, int count = 1) where T : SyntaxNode => node.WithTrailingTrivia(Enumerable.Repeat(CarriageReturnLineFeed, count));
+
+        public static SyntaxToken WithLeadingSpace(this SyntaxToken token) => token.WithLeadingTrivia(Space);
+        public static SyntaxToken WithTrailingSpace(this SyntaxToken token) => token.WithTrailingTrivia(Space);
+        public static SyntaxToken WithTrailingCrLf(this SyntaxToken token) => token.WithTrailingTrivia(CarriageReturnLineFeed);
+    }
+}


### PR DESCRIPTION
Proto test can now use Roslyn to check generated code.