### PR TITLE
Fix naming errors

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTest.cs
+++ b/Google.Api.Generator.Tests/ProtoTest.cs
@@ -103,6 +103,7 @@ namespace Google.Api.Generator.Tests
                 {
                     int blockIndex = 0;
                     (int lineNumber, string line) missing = default;
+                    string missingActualLine = null;
                     int missingBestLength = -1;
                     foreach (var actualLine in actualLines)
                     {
@@ -120,6 +121,7 @@ namespace Google.Api.Generator.Tests
                             if (blockIndex > missingBestLength)
                             {
                                 missing = block[blockIndex];
+                                missingActualLine = actualLine;
                                 missingBestLength = blockIndex;
                             }
                             blockIndex = 0;
@@ -128,7 +130,9 @@ namespace Google.Api.Generator.Tests
                     if (missing.line != null)
                     {
                         Console.WriteLine(string.Join(Environment.NewLine, actualLines));
-                        throw new XunitException($"Failed to find expected line {missing.lineNumber + 1} in '{Path.GetFileName(file.RelativePath)}': '{missing.line}'");
+                        throw new XunitException($"Failed to find expected line {missing.lineNumber + 1} in '{Path.GetFileName(file.RelativePath)}'\n" +
+                            $"  Expected line: '{missing.line}'\n" +
+                            $"  Actual line:   '{missingActualLine}'");
                     }
                 }
 

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/ResourceNamesClient.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/ResourceNamesClient.cs
@@ -61,7 +61,7 @@ namespace Testing.Resourcenames
         public virtual Response SimpleMethod(SimpleResourceName name, gaxgrpc::CallSettings callSettings = null) =>
             SimpleMethod(new SimpleResource
             {
-                NameAsSimpleResourceName = name,
+                SimpleResourceName = name,
             }, callSettings);
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace Testing.Resourcenames
         public virtual stt::Task<Response> SimpleMethodAsync(SimpleResourceName name, gaxgrpc::CallSettings callSettings = null) =>
             SimpleMethodAsync(new SimpleResource
             {
-                NameAsSimpleResourceName = name,
+                SimpleResourceName = name,
             }, callSettings);
 
         /// <summary>
@@ -138,7 +138,7 @@ namespace Testing.Resourcenames
         public virtual Response SimpleInlineMethod(SimpleInlineResourceName name, gaxgrpc::CallSettings callSettings = null) =>
             SimpleInlineMethod(new SimpleInlineResource
             {
-                NameAsSimpleInlineResourceName = name,
+                SimpleInlineResourceName = name,
             }, callSettings);
 
         /// <summary>
@@ -151,7 +151,7 @@ namespace Testing.Resourcenames
         public virtual stt::Task<Response> SimpleInlineMethodAsync(SimpleInlineResourceName name, gaxgrpc::CallSettings callSettings = null) =>
             SimpleInlineMethodAsync(new SimpleInlineResource
             {
-                NameAsSimpleInlineResourceName = name,
+                SimpleInlineResourceName = name,
             }, callSettings);
 
         /// <summary>

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/ResourceNamesResourceNames.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/ResourceNamesResourceNames.cs
@@ -1,5 +1,6 @@
 ﻿using gax = Google.Api.Gax;
 using sys = System;
+using tr = Testing.Resourcenames;
 
 namespace Testing.Resourcenames
 {
@@ -12,14 +13,14 @@ namespace Testing.Resourcenames
         /// Parses the given <c>SimpleResource</c> resource name in string form into a new
         /// <see cref="SimpleResourceName"/> instance.
         /// </summary>
-        /// <param name="simpleresource">
+        /// <param name="simpleResource">
         /// The <c>SimpleResource</c> resource name in string form. Must not be <c>null</c>.
         /// </param>
         /// <returns>The parsed <see cref="SimpleResourceName"/> if successful.</returns>
-        public static SimpleResourceName Parse(string simpleresource)
+        public static SimpleResourceName Parse(string simpleResource)
         {
-            gax::GaxPreconditions.CheckNotNull(simpleresource, nameof(simpleresource));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(simpleresource);
+            gax::GaxPreconditions.CheckNotNull(simpleResource, nameof(simpleResource));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(simpleResource);
             return new SimpleResourceName(resourceName[0]);
         }
 
@@ -28,20 +29,20 @@ namespace Testing.Resourcenames
         /// instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="simpleresource"/> is
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="simpleResource"/> is
         /// <c>null</c>, as this would usually indicate a programming error rather than a data error.
         /// </remarks>
-        /// <param name="simpleresource">
+        /// <param name="simpleResource">
         /// The <c>SimpleResource</c> resource name in string form. Must not be <c>null</c>.
         /// </param>
         /// <param name="result">
         /// When this method returns, the parsed <see cref="SimpleResourceName"/>, or <c>null</c> if parsing fails.
         /// </param>
         /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string simpleresource, out SimpleResourceName result)
+        public static bool TryParse(string simpleResource, out SimpleResourceName result)
         {
-            gax::GaxPreconditions.CheckNotNull(simpleresource, nameof(simpleresource));
-            if (s_template.TryParseName(simpleresource, out gax::TemplatedResourceName resourceName))
+            gax::GaxPreconditions.CheckNotNull(simpleResource, nameof(simpleResource));
+            if (s_template.TryParseName(simpleResource, out gax::TemplatedResourceName resourceName))
             {
                 result = new SimpleResourceName(resourceName[0]);
                 return true;
@@ -94,14 +95,14 @@ namespace Testing.Resourcenames
         /// Parses the given <c>SimpleInlineResource</c> resource name in string form into a new
         /// <see cref="SimpleInlineResourceName"/> instance.
         /// </summary>
-        /// <param name="simpleinlineresource">
+        /// <param name="simpleInlineResource">
         /// The <c>SimpleInlineResource</c> resource name in string form. Must not be <c>null</c>.
         /// </param>
         /// <returns>The parsed <see cref="SimpleInlineResourceName"/> if successful.</returns>
-        public static SimpleInlineResourceName Parse(string simpleinlineresource)
+        public static SimpleInlineResourceName Parse(string simpleInlineResource)
         {
-            gax::GaxPreconditions.CheckNotNull(simpleinlineresource, nameof(simpleinlineresource));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(simpleinlineresource);
+            gax::GaxPreconditions.CheckNotNull(simpleInlineResource, nameof(simpleInlineResource));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(simpleInlineResource);
             return new SimpleInlineResourceName(resourceName[0], resourceName[1]);
         }
 
@@ -110,10 +111,10 @@ namespace Testing.Resourcenames
         /// <see cref="SimpleInlineResourceName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="simpleinlineresource"/>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="simpleInlineResource"/>
         /// is <c>null</c>, as this would usually indicate a programming error rather than a data error.
         /// </remarks>
-        /// <param name="simpleinlineresource">
+        /// <param name="simpleInlineResource">
         /// The <c>SimpleInlineResource</c> resource name in string form. Must not be <c>null</c>.
         /// </param>
         /// <param name="result">
@@ -121,10 +122,10 @@ namespace Testing.Resourcenames
         /// fails.
         /// </param>
         /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string simpleinlineresource, out SimpleInlineResourceName result)
+        public static bool TryParse(string simpleInlineResource, out SimpleInlineResourceName result)
         {
-            gax::GaxPreconditions.CheckNotNull(simpleinlineresource, nameof(simpleinlineresource));
-            if (s_template.TryParseName(simpleinlineresource, out gax::TemplatedResourceName resourceName))
+            gax::GaxPreconditions.CheckNotNull(simpleInlineResource, nameof(simpleInlineResource));
+            if (s_template.TryParseName(simpleInlineResource, out gax::TemplatedResourceName resourceName))
             {
                 result = new SimpleInlineResourceName(resourceName[0], resourceName[1]);
                 return true;
@@ -179,9 +180,9 @@ namespace Testing.Resourcenames
     public partial class SimpleResource
     {
         /// <summary>
-        /// <see cref="SimpleResourceName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="tr::SimpleResourceName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public SimpleResourceName NameAsSimpleResourceName
+        public SimpleResourceName SimpleResourceName
         {
             get => string.IsNullOrEmpty(Name) ? null : SimpleResourceName.Parse(Name);
             set => Name = value?.ToString() ?? "";
@@ -191,9 +192,9 @@ namespace Testing.Resourcenames
     public partial class SimpleInlineResource
     {
         /// <summary>
-        /// <see cref="SimpleInlineResourceName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="tr::SimpleInlineResourceName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public SimpleInlineResourceName NameAsSimpleInlineResourceName
+        public SimpleInlineResourceName SimpleInlineResourceName
         {
             get => string.IsNullOrEmpty(Name) ? null : SimpleInlineResourceName.Parse(Name);
             set => Name = value?.ToString() ?? "";

--- a/Google.Api.Generator/Generation/ResourceNamesGenerator.cs
+++ b/Google.Api.Generator/Generation/ResourceNamesGenerator.cs
@@ -229,6 +229,7 @@ namespace Google.Api.Generator.Generation
                             else
                             {
                                 var one = res.resDetails.ResourceDefinition.One;
+                                var set = res.resDetails.ResourceDefinition.Set;
                                 if (one != null)
                                 {
                                     object getter;
@@ -245,9 +246,15 @@ namespace Google.Api.Generator.Generation
                                     var resourceProperty = Property(Public, _ctx.Type(one.ResourceNameTyp), res.resDetails.ResourcePropertyName)
                                         .WithGetBody(getter)
                                         .WithSetBody(underlyingProperty.Assign(Value.Call(nameof(object.ToString), conditional: true)().NullCoalesce("")))
-                                        .WithXmlDoc(XmlDoc.Summary(_ctx.Type(one.ResourceNameTyp), "-typed view over the ", underlyingProperty, " resource name property."));
+                                        .WithXmlDoc(XmlDoc.Summary(_ctx.Type(one.ResourceNameTyp, forceFullyQualified: one.ResourceNameTyp.Name == res.resDetails.ResourcePropertyName),
+                                            "-typed view over the ", underlyingProperty, " resource name property."));
                                     // TODO: Sets and One/Set combination.
                                     cls = cls.AddMembers(resourceProperty);
+                                }
+                                if (set != null)
+                                {
+                                    // TODO: Resource-sets.
+                                    throw new NotImplementedException();
                                 }
                             }
                         }

--- a/Google.Api.Generator/Generation/SourceFileContext.cs
+++ b/Google.Api.Generator/Generation/SourceFileContext.cs
@@ -129,7 +129,8 @@ namespace Google.Api.Generator.Generation
 
         public TypeSyntax Type(System.Type type) => Type(Typ.Of(type));
 
-        public TypeSyntax Type(Typ typ)
+        public TypeSyntax Type(Typ typ) => Type(typ, false);
+        public TypeSyntax Type(Typ typ, bool forceFullyQualified)
         {
             if (_importStyle != ImportStyle.FullyAliased)
             {
@@ -157,7 +158,7 @@ namespace Google.Api.Generator.Generation
                 return predefinedType;
             }
             string namespaceAlias;
-            if ($"{Namespace}.".StartsWith($"{typ.Namespace}."))
+            if (!forceFullyQualified && $"{Namespace}.".StartsWith($"{typ.Namespace}."))
             {
                 // Within the current namespace, no import required.
                 namespaceAlias = null;

--- a/Google.Api.Generator/ProtoUtils/ResourceDetails.cs
+++ b/Google.Api.Generator/ProtoUtils/ResourceDetails.cs
@@ -88,8 +88,8 @@ namespace Google.Api.Generator.ProtoUtils
                 // This naming logic is copied directly from the Java generator.
                 // TODO: Make sure it's correct for all combinations - I'm not sure it is!
                 var typName = resourceDefinition.One.IsWildcard ? "Any" : resourceDefinition.One.ResourceNameTyp.Name;
-                var requireIdentifier = !(fieldDesc.IsRepeated && fieldDesc.Name.ToLowerInvariant() == "names") ||
-                    (!fieldDesc.IsRepeated && fieldDesc.Name.ToLowerInvariant() == "name");
+                var requireIdentifier = !((fieldDesc.IsRepeated && fieldDesc.Name.ToLowerInvariant() == "names") ||
+                    (!fieldDesc.IsRepeated && fieldDesc.Name.ToLowerInvariant() == "name"));
                 var requireAs = requireIdentifier || resourceDefinition.One.IsWildcard;
                 var requirePlural = fieldDesc.IsRepeated;
                 var name = requireIdentifier ? UnderlyingPropertyName : "";

--- a/Google.Api.Generator/Utils/SystemExtensions.cs
+++ b/Google.Api.Generator/Utils/SystemExtensions.cs
@@ -20,8 +20,9 @@ namespace Google.Api.Generator.Utils
     internal static class SystemExtensions
     {
         private static string Camelizer(string s, bool firstUpper) =>
-            s.Aggregate((upper: firstUpper, sb: new StringBuilder()), (acc, c) =>
-                c == '_' ? (true, acc.sb) : (false, acc.sb.Append(acc.upper ? char.ToUpperInvariant(c) : char.ToLowerInvariant(c))),
+            s.Aggregate((upper: (bool?)firstUpper, sb: new StringBuilder()), (acc, c) =>
+                c == '_' ? (true, acc.sb) :
+                    ((bool?)null, acc.sb.Append(acc.upper is bool upper ? upper ? char.ToUpperInvariant(c) : char.ToLowerInvariant(c) : c)),
                 acc => acc.sb.ToString());
 
         public static string ToLowerCamelCase(this string s) => Camelizer(s, firstUpper: false);

--- a/Google.Api.Generator/Utils/SystemExtensions.cs
+++ b/Google.Api.Generator/Utils/SystemExtensions.cs
@@ -19,10 +19,12 @@ namespace Google.Api.Generator.Utils
 {
     internal static class SystemExtensions
     {
+        private static char MaybeForceCase(char c, bool? toUpper) =>
+            toUpper is bool upper ? upper ? char.ToUpperInvariant(c) : char.ToLowerInvariant(c) : c;
+
         private static string Camelizer(string s, bool firstUpper) =>
             s.Aggregate((upper: (bool?)firstUpper, sb: new StringBuilder()), (acc, c) =>
-                c == '_' ? (true, acc.sb) :
-                    ((bool?)null, acc.sb.Append(acc.upper is bool upper ? upper ? char.ToUpperInvariant(c) : char.ToLowerInvariant(c) : c)),
+                c == '_' ? (true, acc.sb) : ((bool?)null, acc.sb.Append(MaybeForceCase(c, acc.upper))),
                 acc => acc.sb.ToString());
 
         public static string ToLowerCamelCase(this string s) => Camelizer(s, firstUpper: false);


### PR DESCRIPTION
Fix casing of resource-name class Parse() method parameter

Fix name of reosurce-name property when the underlying property is named 'Name'

Improve test output when proto test fails