### PR TITLE
Support all defaults, including resource-names, in snippets

### DIFF
--- a/Google.Api.Generator.Tests/Google.Api.Generator.Tests.csproj
+++ b/Google.Api.Generator.Tests/Google.Api.Generator.Tests.csproj
@@ -109,6 +109,15 @@
     <Compile Update="ProtoTests\ServerStreaming\ServerStreamingResourceNames.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Compile>
+    <Compile Update="ProtoTests\Snippets\SnippetsClient.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Compile>
+    <Compile Update="ProtoTests\Snippets\SnippetsClientSnippets.g.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Compile>
+    <Compile Update="ProtoTests\Snippets\SnippetsResourceNames.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Compile>
     <Compile Update="WhitespaceFormatterTest.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Compile>
@@ -137,6 +146,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="ProtoTests\ServerStreaming\ServerStreaming.proto">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="ProtoTests\Snippets\Snippets.proto">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/Google.Api.Generator.Tests/ProtoTest.cs
+++ b/Google.Api.Generator.Tests/ProtoTest.cs
@@ -202,5 +202,8 @@ namespace Google.Api.Generator.Tests
 
         [Fact]
         public void ServerStreaming0() => ProtoTestSingle("ServerStreaming");
+
+        [Fact]
+        public void Snippets() => ProtoTestSingle("Snippets");
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Basic/BasicClient.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic/BasicClient.cs
@@ -89,11 +89,7 @@ namespace Testing.Basic
         /// <item><description>scope2</description></item>
         /// </list>
         /// </remarks>
-        public static scg::IReadOnlyList<string> DefaultScopes { get; } = new sco::ReadOnlyCollection<string>(new string[]
-        {
-            "scope1",
-            "scope2",
-        });
+        public static scg::IReadOnlyList<string> DefaultScopes { get; } = new sco::ReadOnlyCollection<string>(new string[] { "scope1", "scope2", });
 
         private static readonly gaxgrpc::ChannelPool s_channelPool = new gaxgrpc::ChannelPool(DefaultScopes);
 

--- a/Google.Api.Generator.Tests/ProtoTests/Basic/BasicClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic/BasicClientSnippets.g.cs
@@ -12,9 +12,7 @@ namespace Testing.Basic
             // Create client
             BasicClient basicClient = BasicClient.Create();
             // Initialize request argument(s)
-            Request request = new Request
-            {
-            };
+            Request request = new Request { };
             // Make the request
             Response response = basicClient.IdempotentMethod(request);
             // End snippet
@@ -28,9 +26,7 @@ namespace Testing.Basic
             // Create client
             BasicClient basicClient = await BasicClient.CreateAsync();
             // Initialize request argument(s)
-            Request request = new Request
-            {
-            };
+            Request request = new Request { };
             // Make the request
             Response response = await basicClient.IdempotentMethodAsync(request);
             // End snippet
@@ -43,9 +39,7 @@ namespace Testing.Basic
             // Create client
             BasicClient basicClient = BasicClient.Create();
             // Initialize request argument(s)
-            Request request = new Request
-            {
-            };
+            Request request = new Request { };
             // Make the request
             Response response = basicClient.NonIdempotentMethod(request);
             // End snippet
@@ -59,9 +53,7 @@ namespace Testing.Basic
             // Create client
             BasicClient basicClient = await BasicClient.CreateAsync();
             // Initialize request argument(s)
-            Request request = new Request
-            {
-            };
+            Request request = new Request { };
             // Make the request
             Response response = await basicClient.NonIdempotentMethodAsync(request);
             // End snippet

--- a/Google.Api.Generator.Tests/ProtoTests/Lro/LroClient.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Lro/LroClient.cs
@@ -19,10 +19,7 @@ namespace Testing.Lro
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The RPC response.</returns>
         public virtual lro::Operation<LroResponse, LroMetadata> SignatureMethod(string name, gaxgrpc::CallSettings callSettings = null) =>
-            SignatureMethod(new Request
-            {
-                Name = name ?? "",
-            }, callSettings);
+            SignatureMethod(new Request { Name = name ?? "", }, callSettings);
 
         /// <summary>
         /// Test an LRO RPC with a method signature.
@@ -32,10 +29,7 @@ namespace Testing.Lro
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A Task containing the RPC response.</returns>
         public virtual stt::Task<lro::Operation<LroResponse, LroMetadata>> SignatureMethodAsync(string name, gaxgrpc::CallSettings callSettings = null) =>
-            SignatureMethodAsync(new Request
-            {
-                Name = name ?? "",
-            }, callSettings);
+            SignatureMethodAsync(new Request { Name = name ?? "", }, callSettings);
 
         /// <summary>
         /// Test an LRO RPC with a method signature.
@@ -60,10 +54,7 @@ namespace Testing.Lro
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The RPC response.</returns>
         public virtual lro::Operation<LroResponse, LroMetadata> ResourcedMethod(string name, gaxgrpc::CallSettings callSettings = null) =>
-            ResourcedMethod(new ResourceRequest
-            {
-                Name = name ?? "",
-            }, callSettings);
+            ResourcedMethod(new ResourceRequest { Name = name ?? "", }, callSettings);
 
         /// <summary>
         /// Test an LRO RPC with a method signature that contains resource-names.
@@ -73,10 +64,7 @@ namespace Testing.Lro
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A Task containing the RPC response.</returns>
         public virtual stt::Task<lro::Operation<LroResponse, LroMetadata>> ResourcedMethodAsync(string name, gaxgrpc::CallSettings callSettings = null) =>
-            ResourcedMethodAsync(new ResourceRequest
-            {
-                Name = name ?? "",
-            }, callSettings);
+            ResourcedMethodAsync(new ResourceRequest { Name = name ?? "", }, callSettings);
 
         /// <summary>
         /// Test an LRO RPC with a method signature that contains resource-names.
@@ -96,10 +84,7 @@ namespace Testing.Lro
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The RPC response.</returns>
         public virtual lro::Operation<LroResponse, LroMetadata> ResourcedMethod(ResourceName name, gaxgrpc::CallSettings callSettings = null) =>
-            ResourcedMethod(new ResourceRequest
-            {
-                ResourceName = name,
-            }, callSettings);
+            ResourcedMethod(new ResourceRequest { ResourceName = name, }, callSettings);
 
         /// <summary>
         /// Test an LRO RPC with a method signature that contains resource-names.
@@ -109,10 +94,7 @@ namespace Testing.Lro
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A Task containing the RPC response.</returns>
         public virtual stt::Task<lro::Operation<LroResponse, LroMetadata>> ResourcedMethodAsync(ResourceName name, gaxgrpc::CallSettings callSettings = null) =>
-            ResourcedMethodAsync(new ResourceRequest
-            {
-                ResourceName = name,
-            }, callSettings);
+            ResourcedMethodAsync(new ResourceRequest { ResourceName = name, }, callSettings);
 
         /// <summary>
         /// Test an LRO RPC with a method signature that contains resource-names.

--- a/Google.Api.Generator.Tests/ProtoTests/MethodSignatures/MethodSignaturesClient.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/MethodSignatures/MethodSignaturesClient.cs
@@ -23,10 +23,7 @@ namespace Testing.Methodsignatures
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The RPC response.</returns>
         public virtual Response SimpleMethod(int aNumber, gaxgrpc::CallSettings callSettings = null) =>
-            SimpleMethod(new SimpleRequest
-            {
-                ANumber = aNumber,
-            }, callSettings);
+            SimpleMethod(new SimpleRequest { ANumber = aNumber, }, callSettings);
 
         /// <summary>
         /// </summary>
@@ -36,10 +33,7 @@ namespace Testing.Methodsignatures
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A Task containing the RPC response.</returns>
         public virtual stt::Task<Response> SimpleMethodAsync(int aNumber, gaxgrpc::CallSettings callSettings = null) =>
-            SimpleMethodAsync(new SimpleRequest
-            {
-                ANumber = aNumber,
-            }, callSettings);
+            SimpleMethodAsync(new SimpleRequest { ANumber = aNumber, }, callSettings);
 
         /// <summary>
         /// </summary>

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/PaginatedClient.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/PaginatedClient.cs
@@ -88,10 +88,7 @@ namespace Testing.Paginated
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A pageable sequence of <see cref="ResourceName"/> resources.</returns>
         public virtual gax::PagedEnumerable<ResourceResponse, ResourceName> ResourcedMethod(string name, gaxgrpc::CallSettings callSettings = null) =>
-            ResourcedMethod(new ResourceRequest
-            {
-                Name = name ?? "",
-            }, callSettings);
+            ResourcedMethod(new ResourceRequest { Name = name ?? "", }, callSettings);
 
         /// <summary>
         /// Test a paginated RPC with a method signature that contains resource-names
@@ -102,10 +99,7 @@ namespace Testing.Paginated
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A pageable asynchronous sequence of <see cref="ResourceName"/> resources.</returns>
         public virtual gax::PagedAsyncEnumerable<ResourceResponse, ResourceName> ResourcedMethodAsync(string name, gaxgrpc::CallSettings callSettings = null) =>
-            ResourcedMethodAsync(new ResourceRequest
-            {
-                Name = name ?? "",
-            }, callSettings);
+            ResourcedMethodAsync(new ResourceRequest { Name = name ?? "", }, callSettings);
 
         /// <summary>
         /// Test a paginated RPC with a method signature that contains resource-names
@@ -116,10 +110,7 @@ namespace Testing.Paginated
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A pageable sequence of <see cref="ResourceName"/> resources.</returns>
         public virtual gax::PagedEnumerable<ResourceResponse, ResourceName> ResourcedMethod(ResourceName name, gaxgrpc::CallSettings callSettings = null) =>
-            ResourcedMethod(new ResourceRequest
-            {
-                ResourceName = name,
-            }, callSettings);
+            ResourcedMethod(new ResourceRequest { ResourceName = name, }, callSettings);
 
         /// <summary>
         /// Test a paginated RPC with a method signature that contains resource-names
@@ -130,10 +121,7 @@ namespace Testing.Paginated
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A pageable asynchronous sequence of <see cref="ResourceName"/> resources.</returns>
         public virtual gax::PagedAsyncEnumerable<ResourceResponse, ResourceName> ResourcedMethodAsync(ResourceName name, gaxgrpc::CallSettings callSettings = null) =>
-            ResourcedMethodAsync(new ResourceRequest
-            {
-                ResourceName = name,
-            }, callSettings);
+            ResourcedMethodAsync(new ResourceRequest { ResourceName = name, }, callSettings);
         // TEST_END
     }
 

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/ResourceNamesClient.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/ResourceNamesClient.cs
@@ -23,10 +23,7 @@ namespace Testing.Resourcenames
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The RPC response.</returns>
         public virtual Response SimpleMethod(string name, gaxgrpc::CallSettings callSettings = null) =>
-            SimpleMethod(new SimpleResource
-            {
-                Name = name ?? "",
-            }, callSettings);
+            SimpleMethod(new SimpleResource { Name = name ?? "", }, callSettings);
 
         /// <summary>
         /// Test top-level resource definition.
@@ -36,10 +33,7 @@ namespace Testing.Resourcenames
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A Task containing the RPC response.</returns>
         public virtual stt::Task<Response> SimpleMethodAsync(string name, gaxgrpc::CallSettings callSettings = null) =>
-            SimpleMethodAsync(new SimpleResource
-            {
-                Name = name ?? "",
-            }, callSettings);
+            SimpleMethodAsync(new SimpleResource { Name = name ?? "", }, callSettings);
 
         /// <summary>
         /// Test top-level resource definition.
@@ -100,10 +94,7 @@ namespace Testing.Resourcenames
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The RPC response.</returns>
         public virtual Response SimpleInlineMethod(string name, gaxgrpc::CallSettings callSettings = null) =>
-            SimpleInlineMethod(new SimpleInlineResource
-            {
-                Name = name ?? "",
-            }, callSettings);
+            SimpleInlineMethod(new SimpleInlineResource { Name = name ?? "", }, callSettings);
 
         /// <summary>
         /// Test resource definition inlined in the proto message.
@@ -113,10 +104,7 @@ namespace Testing.Resourcenames
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A Task containing the RPC response.</returns>
         public virtual stt::Task<Response> SimpleInlineMethodAsync(string name, gaxgrpc::CallSettings callSettings = null) =>
-            SimpleInlineMethodAsync(new SimpleInlineResource
-            {
-                Name = name ?? "",
-            }, callSettings);
+            SimpleInlineMethodAsync(new SimpleInlineResource { Name = name ?? "", }, callSettings);
 
         /// <summary>
         /// Test resource definition inlined in the proto message.

--- a/Google.Api.Generator.Tests/ProtoTests/ServerStreaming/ServerStreamingClient.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ServerStreaming/ServerStreamingClient.cs
@@ -16,10 +16,7 @@ namespace Testing.Serverstreaming
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The server stream.</returns>
         public virtual SignatureMethodStream SignatureMethod(string name, gaxgrpc::CallSettings callSettings = null) =>
-            SignatureMethod(new Request
-            {
-                Name = name ?? "",
-            }, callSettings);
+            SignatureMethod(new Request { Name = name ?? "", }, callSettings);
         // TEST_END
 
         public abstract class ResourcedMethodStream : gaxgrpc::ServerStreamingBase<Response> { }
@@ -34,10 +31,7 @@ namespace Testing.Serverstreaming
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The server stream.</returns>
         public virtual ResourcedMethodStream ResourcedMethod(string name, gaxgrpc::CallSettings callSettings = null) =>
-            ResourcedMethod(new ResourceRequest
-            {
-                Name = name ?? "",
-            }, callSettings);
+            ResourcedMethod(new ResourceRequest { Name = name ?? "", }, callSettings);
 
         /// <summary>
         /// Test a server-streaming RPC with a method signature and resource-name.
@@ -47,10 +41,7 @@ namespace Testing.Serverstreaming
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The server stream.</returns>
         public virtual ResourcedMethodStream ResourcedMethod(ResourceName name, gaxgrpc::CallSettings callSettings = null) =>
-            ResourcedMethod(new ResourceRequest
-            {
-                ResourceName = name,
-            }, callSettings);
+            ResourcedMethod(new ResourceRequest { ResourceName = name, }, callSettings);
         // TEST_END
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Snippets.proto
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Snippets.proto
@@ -1,0 +1,62 @@
+﻿syntax = "proto3";
+
+package testing.snippets;
+
+import "google/api/annotations.proto";
+
+service Snippets {
+  option (google.api.default_host) = "snippets.example.com";
+
+  rpc MethodDefaultValues(DefaultValuesRequest) returns(Response);
+}
+
+option (google.api.resource_definition) = {
+  name: "AResource",
+  path: "items/{item_id}/parts/{part_id}"
+};
+
+option (google.api.resource_definition) = {
+  name: "WildcardResource",
+  path: "*"
+};
+
+message DefaultValuesRequest {
+  // TODO: Enums, Messages
+  double single_double = 1;
+  float single_float = 2;
+  int32 single_int32 = 3;
+  int64 single_int64 = 4;
+  uint32 single_uint32 = 5;
+  uint64 single_uint64 = 6;
+  sint32 single_sint32 = 7;
+  sint64 single_sint64 = 8;
+  fixed32 single_fixed32 = 9;
+  fixed64 single_fixed64 = 10;
+  sfixed32 single_sfixed32 = 11;
+  sfixed64 single_sfixed64 = 12;
+  bool single_bool = 13;
+  string single_string = 14;
+  bytes single_bytes = 15;
+  repeated double repeated_double = 21;
+  repeated float repeated_float = 22;
+  repeated int32 repeated_int32 = 23;
+  repeated int64 repeated_int64 = 24;
+  repeated uint32 repeated_uint32 = 25;
+  repeated uint64 repeated_uint64 = 26;
+  repeated sint32 repeated_sint32 = 27;
+  repeated sint64 repeated_sint64 = 28;
+  repeated fixed32 repeated_fixed32 = 29;
+  repeated fixed64 repeated_fixed64 = 30;
+  repeated sfixed32 repeated_sfixed32 = 31;
+  repeated sfixed64 repeated_sfixed64 = 32;
+  repeated bool repeated_bool = 33;
+  repeated string repeated_string = 34;
+  repeated bytes repeated_bytes = 35;
+  string single_resource_name = 40 [(google.api.resource_reference) = "AResource"];
+  repeated string repeated_resource_name = 41 [(google.api.resource_reference) = "AResource"];
+  string single_wildcard_resource = 42 [(google.api.resource_reference) = "WildcardResource"];
+  repeated string repeated_wildcard_resource = 43 [(google.api.resource_reference) = "WildcardResource"];
+}
+
+message Response {
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/SnippetsClient.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/SnippetsClient.cs
@@ -1,0 +1,1 @@
+﻿// TEST_DISABLE

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/SnippetsClientFakes.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/SnippetsClientFakes.cs
@@ -1,0 +1,82 @@
+﻿// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Protobuf;
+using Google.Protobuf.Collections;
+using System;
+using System.Threading.Tasks;
+
+namespace Testing.Snippets
+{
+    public class SnippetsClient
+    {
+        public static SnippetsClient Create() => throw new NotImplementedException();
+        public static Task<SnippetsClient> CreateAsync() => throw new NotImplementedException();
+
+        public Response MethodDefaultValues(DefaultValuesRequest request) => throw new NotImplementedException();
+        public Task<Response> MethodDefaultValuesAsync(DefaultValuesRequest request) => throw new NotImplementedException();
+    }
+
+    public class AResourceName : IResourceName
+    {
+        public AResourceName(string itemId, string partId) => throw new NotImplementedException();
+        public ResourceNameKind Kind => throw new NotImplementedException();
+    }
+
+    public class DefaultValuesRequest : ProtoMsgFake<DefaultValuesRequest>
+    {
+        public double SingleDouble { get; set; }
+        public float SingleFloat { get; set; }
+        public int SingleInt32 { get; set; }
+        public long SingleInt64 { get; set; }
+        public uint SingleUint32 { get; set; }
+        public ulong SingleUint64 { get; set; }
+        public int SingleSint32 { get; set; }
+        public long SingleSint64 { get; set; }
+        public uint SingleFixed32 { get; set; }
+        public ulong SingleFixed64 { get; set; }
+        public int SingleSfixed32 { get; set; }
+        public long SingleSfixed64 { get; set; }
+        public bool SingleBool { get; set; }
+        public string SingleString { get; set; }
+        public ByteString SingleBytes { get; set; }
+        public RepeatedField<double> RepeatedDouble { get; }
+        public RepeatedField<float> RepeatedFloat { get; }
+        public RepeatedField<int> RepeatedInt32 { get; }
+        public RepeatedField<long> RepeatedInt64 { get; }
+        public RepeatedField<uint> RepeatedUint32 { get; }
+        public RepeatedField<ulong> RepeatedUint64 { get; }
+        public RepeatedField<int> RepeatedSint32 { get; }
+        public RepeatedField<long> RepeatedSint64 { get; }
+        public RepeatedField<uint> RepeatedFixed32 { get; }
+        public RepeatedField<ulong> RepeatedFixed64 { get; }
+        public RepeatedField<int> RepeatedSfixed32 { get; }
+        public RepeatedField<long> RepeatedSfixed64 { get; }
+        public RepeatedField<bool> RepeatedBool { get; }
+        public RepeatedField<string> RepeatedString { get; }
+        public RepeatedField<ByteString> RepeatedBytes { get; }
+        public string SingleResourceName { get; set; }
+        public RepeatedField<string> RepeatedResourceName { get; }
+        public string SingleWildcardResource { get; set; }
+        public RepeatedField<string> RepeatedWildcardResource { get; }
+
+        public AResourceName SingleResourceNameAsAResourceName { get; set; }
+        public ResourceNameList<AResourceName> RepeatedResourceNameAsAResourceNames { get; }
+        public IResourceName SingleWildcardResourceAsResourceName { get; set; }
+        public ResourceNameList<IResourceName> RepeatedWildcardResourceAsResourceNames { get; }
+    }
+
+    public class Response : ProtoMsgFake<Response> { }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/SnippetsClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/SnippetsClientSnippets.g.cs
@@ -1,0 +1,66 @@
+﻿using Google.Api.Gax;
+using Google.Protobuf;
+
+namespace Testing.Snippets
+{
+    /// <summary>Generated snippets.</summary>
+    public sealed class GeneratedSnippetsSnippets
+    {
+        // TEST_START
+        /// <summary>Snippet for MethodDefaultValues</summary>
+        public void MethodDefaultValues_RequestObject()
+        {
+            // Snippet: MethodDefaultValues(DefaultValuesRequest, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            DefaultValuesRequest request = new DefaultValuesRequest
+            {
+                SingleDouble = 0,
+                SingleFloat = 0F,
+                SingleInt32 = 0,
+                SingleInt64 = 0L,
+                SingleUint32 = 0U,
+                SingleUint64 = 0UL,
+                SingleSint32 = 0,
+                SingleSint64 = 0L,
+                SingleFixed32 = 0U,
+                SingleFixed64 = 0UL,
+                SingleSfixed32 = 0,
+                SingleSfixed64 = 0L,
+                SingleBool = false,
+                SingleString = "",
+                SingleBytes = ByteString.Empty,
+                RepeatedDouble = { 0, },
+                RepeatedFloat = { 0F, },
+                RepeatedInt32 = { 0, },
+                RepeatedInt64 = { 0L, },
+                RepeatedUint32 = { 0U, },
+                RepeatedUint64 = { 0UL, },
+                RepeatedSint32 = { 0, },
+                RepeatedSint64 = { 0L, },
+                RepeatedFixed32 = { 0U, },
+                RepeatedFixed64 = { 0UL, },
+                RepeatedSfixed32 = { 0, },
+                RepeatedSfixed64 = { 0L, },
+                RepeatedBool = { false, },
+                RepeatedString = { "", },
+                RepeatedBytes = { ByteString.Empty, },
+                SingleResourceNameAsAResourceName = new AResourceName("[ITEM_ID]", "[PART_ID]"),
+                RepeatedResourceNameAsAResourceNames =
+                {
+                    new AResourceName("[ITEM_ID]", "[PART_ID]"),
+                },
+                SingleWildcardResourceAsResourceName = new UnknownResourceName("a/wildcard/resource"),
+                RepeatedWildcardResourceAsResourceNames =
+                {
+                    new UnknownResourceName("a/wildcard/resource"),
+                },
+            };
+            // Make the request
+            Response response = snippetsClient.MethodDefaultValues(request);
+            // End snippet
+        }
+        // TEST_END
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/SnippetsResourceNames.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/SnippetsResourceNames.cs
@@ -1,0 +1,1 @@
+﻿// TEST_DISABLE

--- a/Google.Api.Generator.Tests/WhitespaceFormatterTest.cs
+++ b/Google.Api.Generator.Tests/WhitespaceFormatterTest.cs
@@ -113,12 +113,7 @@ namespace Google.Api.Generator.Tests
                 {
                     S = "Another_string",
                 },
-                List =
-                {
-                    1,
-                    2,
-                    3,
-                },
+                List = { 1, 2, 3, },
             };
 
             public void M1()
@@ -139,10 +134,7 @@ namespace Google.Api.Generator.Tests
             public string[] GetStringArrayWithSize() => new string[0];
 
             // Test `new` array without size, with initializer.
-            public string[] GetStringArrayWithInitializer() => new string[]
-            {
-                "one",
-            };
+            public string[] GetStringArrayWithInitializer() => new string[] { "one", };
 
             // Test expression containing `await`.
             // Test `if` and `else` statement.
@@ -181,10 +173,7 @@ namespace Google.Api.Generator.Tests
 
             // Test wrapping of long expression-bodied method, with correct multi-line indent.
             public object MethodWithLongNameSoTheExpressionBodyWillWrapToTheNextLine(string aParameter, string anotherParameter, string aThirdParameter) =>
-                new List<int>
-                {
-                    18,
-                };
+                new List<int> { 18, };
 
             // Test conditional operator.
             public int Conditional(bool b) => b ? 1 : 2;

--- a/Google.Api.Generator/Formatting/WhitespaceFormatter.cs
+++ b/Google.Api.Generator/Formatting/WhitespaceFormatter.cs
@@ -325,14 +325,26 @@ namespace Google.Api.Generator.Formatting
 
         public override SyntaxNode VisitInitializerExpression(InitializerExpressionSyntax node)
         {
-            using (WithIndent())
+            // Do not call base; the contained expressions are visited in this method.
+            if (node.Span.Length < 20)
             {
+                // Crude <20 to only make short initializer expressions stay on a single line.
                 node = node.WithExpressions(SeparatedList(
-                    node.Expressions.Select(e => Visit(e).WithLeadingTrivia(_indentTrivia)),
-                    node.Expressions.Select(_ => Token(SyntaxKind.CommaToken).WithTrailingCrLf())));
+                    node.Expressions.Select(e => Visit(e)),
+                    node.Expressions.Select(_ => Token(SyntaxKind.CommaToken).WithTrailingSpace())));
+                node = node.WithOpenBraceToken(node.OpenBraceToken.WithLeadingSpace().WithTrailingSpace());
             }
-            node = node.WithOpenBraceToken(node.OpenBraceToken.WithLeadingTrivia(CarriageReturnLineFeed, _indentTrivia).WithTrailingCrLf());
-            node = node.WithCloseBraceToken(node.CloseBraceToken.WithLeadingTrivia(_indentTrivia));
+            else
+            {
+                using (WithIndent())
+                {
+                    node = node.WithExpressions(SeparatedList(
+                        node.Expressions.Select(e => Visit(e).WithLeadingTrivia(_indentTrivia)),
+                        node.Expressions.Select(_ => Token(SyntaxKind.CommaToken).WithTrailingCrLf())));
+                }
+                node = node.WithOpenBraceToken(node.OpenBraceToken.WithLeadingTrivia(CarriageReturnLineFeed, _indentTrivia).WithTrailingCrLf());
+                node = node.WithCloseBraceToken(node.CloseBraceToken.WithLeadingTrivia(_indentTrivia));
+            }
             return node;
         }
 

--- a/Google.Api.Generator/RoslynUtils/RoslynConverters.cs
+++ b/Google.Api.Generator/RoslynUtils/RoslynConverters.cs
@@ -54,6 +54,14 @@ namespace Google.Api.Generator.RoslynUtils
                     return new[] { LiteralExpression(value ? SyntaxKind.TrueLiteralExpression : SyntaxKind.FalseLiteralExpression) };
                 case double value:
                     return new[] { LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(value)) };
+                case float value:
+                    return new[] { LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(value)) };
+                case long value:
+                    return new[] { LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(value)) };
+                case uint value:
+                    return new[] { LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(value)) };
+                case ulong value:
+                    return new[] { LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(value)) };
                 default:
                     throw new NotSupportedException($"Cannot handle ToExpressions({o.GetType()})");
             }


### PR DESCRIPTION
Two commits. The first one is the affects of a small code-formatter change.
The support for defaults in snippets is in the seconds commit.