### PR TITLE
Fix using directive location in snippets

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTests/Basic/BasicClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic/BasicClientSnippets.g.cs
@@ -1,7 +1,7 @@
-﻿using System.Threading.Tasks;
-
-namespace Testing.Basic
+﻿namespace Testing.Basic
 {
+    using System.Threading.Tasks;
+
     /// <summary>Generated snippets.</summary>
     public sealed class GeneratedBasicSnippets
     {

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/SnippetsClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/SnippetsClientSnippets.g.cs
@@ -1,12 +1,12 @@
-﻿using Google.Api.Gax;
-using Google.Protobuf;
-
-namespace Testing.Snippets
+﻿namespace Testing.Snippets
 {
+    using Google.Api.Gax;
+    using Google.Protobuf;
+    using System.Threading.Tasks;
+
     /// <summary>Generated snippets.</summary>
     public sealed class GeneratedSnippetsSnippets
     {
-        // TEST_START
         /// <summary>Snippet for MethodDefaultValues</summary>
         public void MethodDefaultValues_RequestObject()
         {
@@ -61,6 +61,61 @@ namespace Testing.Snippets
             Response response = snippetsClient.MethodDefaultValues(request);
             // End snippet
         }
-        // TEST_END
+
+        /// <summary>Snippet for MethodDefaultValuesAsync</summary>
+        public async Task MethodDefaultValuesAsync_RequestObject()
+        {
+            // Snippet: MethodDefaultValuesAsync(DefaultValuesRequest, CallSettings)
+            // Additional: MethodDefaultValuesAsync(DefaultValuesRequest, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            DefaultValuesRequest request = new DefaultValuesRequest
+            {
+                SingleDouble = 0,
+                SingleFloat = 0F,
+                SingleInt32 = 0,
+                SingleInt64 = 0L,
+                SingleUint32 = 0U,
+                SingleUint64 = 0UL,
+                SingleSint32 = 0,
+                SingleSint64 = 0L,
+                SingleFixed32 = 0U,
+                SingleFixed64 = 0UL,
+                SingleSfixed32 = 0,
+                SingleSfixed64 = 0L,
+                SingleBool = false,
+                SingleString = "",
+                SingleBytes = ByteString.Empty,
+                RepeatedDouble = { 0, },
+                RepeatedFloat = { 0F, },
+                RepeatedInt32 = { 0, },
+                RepeatedInt64 = { 0L, },
+                RepeatedUint32 = { 0U, },
+                RepeatedUint64 = { 0UL, },
+                RepeatedSint32 = { 0, },
+                RepeatedSint64 = { 0L, },
+                RepeatedFixed32 = { 0U, },
+                RepeatedFixed64 = { 0UL, },
+                RepeatedSfixed32 = { 0, },
+                RepeatedSfixed64 = { 0L, },
+                RepeatedBool = { false, },
+                RepeatedString = { "", },
+                RepeatedBytes = { ByteString.Empty, },
+                SingleResourceNameAsAResourceName = new AResourceName("[ITEM_ID]", "[PART_ID]"),
+                RepeatedResourceNameAsAResourceNames =
+                {
+                    new AResourceName("[ITEM_ID]", "[PART_ID]"),
+                },
+                SingleWildcardResourceAsResourceName = new UnknownResourceName("a/wildcard/resource"),
+                RepeatedWildcardResourceAsResourceNames =
+                {
+                    new UnknownResourceName("a/wildcard/resource"),
+                },
+            };
+            // Make the request
+            Response response = await snippetsClient.MethodDefaultValuesAsync(request);
+            // End snippet
+        }
     }
 }

--- a/Google.Api.Generator/Formatting/WhitespaceFormatter.cs
+++ b/Google.Api.Generator/Formatting/WhitespaceFormatter.cs
@@ -82,6 +82,10 @@ namespace Google.Api.Generator.Formatting
             using (WithIndent())
             {
                 node = (NamespaceDeclarationSyntax)base.VisitNamespaceDeclaration(node);
+                if (node.Usings.Any())
+                {
+                    node = node.WithUsings(List(node.Usings.SkipLast(1).Append(node.Usings.Last().WithTrailingTrivia(CarriageReturnLineFeed, CarriageReturnLineFeed))));
+                }
             }
             node = node.WithLeadingTrivia(_indentTrivia);
             node = node.WithNamespaceKeyword(node.NamespaceKeyword.WithTrailingSpace());

--- a/Google.Api.Generator/Generation/SourceFileContext.cs
+++ b/Google.Api.Generator/Generation/SourceFileContext.cs
@@ -136,7 +136,7 @@ namespace Google.Api.Generator.Generation
             public override CompilationUnitSyntax CreateCompilationUnit(NamespaceDeclarationSyntax ns)
             {
                 var usings = _imports.OrderBy(x => x).Select(x => UsingDirective(IdentifierName(x)));
-                return CompilationUnit().AddUsings(usings.ToArray()).AddMembers(ns);
+                return CompilationUnit().AddMembers(ns.AddUsings(usings.ToArray()));
             }
         }
 


### PR DESCRIPTION
Using statements in snippets need to be within the namespace, not at the top-level of the file.

Test the entire snippet test output file, rather thatn just a portion of it.