### PR TITLE
Minor fix to protoc invokation in docker

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -17,6 +17,6 @@
 # THIS SCRIPT IS MEANT ONLY TO BE USED IN THE GAPIC-GENERATOR-CSHARP DOCKER IMAGE
 
 protoc --proto_path=/protos/ --proto_path=/in/ \
-  --plugin=protoc-gen-csharpgapic=/usr/src/gapic-generator-csharp/Google.Api.Generator/bin/Release/netcoreapp2.2/linux-x64/publish/Google.Api.Generator \
-  --csharpgapic_out=/out/ \
+  --plugin=protoc-gen-csharp_gapic=/usr/src/gapic-generator-csharp/Google.Api.Generator/bin/Release/netcoreapp2.2/linux-x64/publish/Google.Api.Generator \
+  --csharp_gapic_out=/out/ \
   $(find /in/ -name '*.proto')


### PR DESCRIPTION
To conform to naming convention specificed in https://aip.dev/client-libraries/4210