### PR TITLE
Update child_type error if parent doesn't exist

### DIFF
--- a/Google.Api.Generator/ProtoUtils/ResourceDetails.cs
+++ b/Google.Api.Generator/ProtoUtils/ResourceDetails.cs
@@ -269,8 +269,10 @@ namespace Google.Api.Generator.ProtoUtils
                     // Return existing resource; no auto-generated required.
                     return new Field(fieldDesc, parentDef);
                 }
-                // TODO
-                throw new NotImplementedException("Cannot yet auto-generate parent resource-names.");
+                // It is invalid to ask for a parent that is not already defined.
+                // This may change in the future, to allow auto-generating parent resource-names, but this is not currently allowed.
+                throw new InvalidOperationException(
+                    "Cannot refer to the child-type of a resource if the child pattern is not already defined in a resource.");
             }
             throw new InvalidOperationException("type or child_type must be set.");
 


### PR DESCRIPTION
After discussions with Luke, we'll require the parent pattern to be explicitly defined within an existing resource. No autogeneration of parent resource-names will be supported.

This decision can be revisited if necessary.