### PR TITLE
Fix partial generation

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTests/CommonResource/CommonResourceDef.proto
+++ b/Google.Api.Generator.Tests/ProtoTests/CommonResource/CommonResourceDef.proto
@@ -1,8 +1,9 @@
 ﻿syntax = "proto3";
 
-package testing.commonresource;
+// In different package; so no classes (resource-name or partial) will be generated.
+package testing.commonresource.def;
 
-option csharp_namespace = "Testing.CommonResource";
+option csharp_namespace = "Testing.CommonResource.Def";
 
 import "google/api/resource.proto";
 


### PR DESCRIPTION
Fixes the problem as seen in spanner.
Where a partial class not generated when the class is a resource-message, and the resource-name class is defined elsewhere and configured in the common-resource-config file.