### PR TITLE
Fix unfortunate float->double conversion

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTests/GrpcServiceConfig/GrpcServiceConfig.json
+++ b/Google.Api.Generator.Tests/ProtoTests/GrpcServiceConfig/GrpcServiceConfig.json
@@ -10,7 +10,7 @@
       "retry_policy": {
         "initial_backoff": "0.5s",
         "max_backoff": "5s",
-        "backoff_multiplier": 2.0,
+        "backoff_multiplier": 1.3,
         "retryable_status_codes": [ "DEADLINE_EXCEEDED", "RESOURCE_EXHAUSTED" ]
       }
     },

--- a/Google.Api.Generator.Tests/ProtoTests/GrpcServiceConfig/Testing.GrpcServiceConfig/GrpcServiceConfigClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/GrpcServiceConfig/Testing.GrpcServiceConfig/GrpcServiceConfigClient.g.cs
@@ -32,7 +32,7 @@ namespace Testing.GrpcServiceConfig
         /// <remarks>
         /// <list type="bullet">
         /// <item><description>Initial retry delay: 500 milliseconds.</description></item>
-        /// <item><description>Retry delay multiplier: 2</description></item>
+        /// <item><description>Retry delay multiplier: 1.3</description></item>
         /// <item><description>Retry maximum delay: 5000 milliseconds.</description></item>
         /// <item><description>Initial timeout: 20000 milliseconds.</description></item>
         /// <item><description>Timeout multiplier: 1</description></item>
@@ -40,7 +40,7 @@ namespace Testing.GrpcServiceConfig
         /// <item><description>Total timeout: 20 seconds.</description></item>
         /// </list>
         /// </remarks>
-        public gaxgrpc::CallSettings ServiceLevelRetryMethodSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(retryBackoff: new gaxgrpc::BackoffSettings(delay: sys::TimeSpan.FromMilliseconds(500), maxDelay: sys::TimeSpan.FromMilliseconds(5000), delayMultiplier: 2), timeoutBackoff: new gaxgrpc::BackoffSettings(delay: sys::TimeSpan.FromMilliseconds(20000), maxDelay: sys::TimeSpan.FromMilliseconds(20000), delayMultiplier: 1), totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(20000)), retryFilter: gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.ResourceExhausted))));
+        public gaxgrpc::CallSettings ServiceLevelRetryMethodSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(gaxgrpc::CallTiming.FromRetry(new gaxgrpc::RetrySettings(retryBackoff: new gaxgrpc::BackoffSettings(delay: sys::TimeSpan.FromMilliseconds(500), maxDelay: sys::TimeSpan.FromMilliseconds(5000), delayMultiplier: 1.3), timeoutBackoff: new gaxgrpc::BackoffSettings(delay: sys::TimeSpan.FromMilliseconds(20000), maxDelay: sys::TimeSpan.FromMilliseconds(20000), delayMultiplier: 1), totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(20000)), retryFilter: gaxgrpc::RetrySettings.FilterForStatusCodes(grpccore::StatusCode.DeadlineExceeded, grpccore::StatusCode.ResourceExhausted))));
 
         /// <summary>
         /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to

--- a/Google.Api.Generator/Generation/MethodDetails.cs
+++ b/Google.Api.Generator/Generation/MethodDetails.cs
@@ -309,7 +309,8 @@ namespace Google.Api.Generator.Generation
             }
             var rp = config.RetryPolicy;
             // `retry` is the delay duration between calls.
-            var retry = new BackoffSettings(rp.InitialBackoff.ToTimeSpan(), rp.MaxBackoff.ToTimeSpan(), rp.BackoffMultiplier);
+            // float -> double conversion via string to avoid unpleasent results from unrepresentable floats (e.g. 1.3 -> 1.2999999523162842)
+            var retry = new BackoffSettings(rp.InitialBackoff.ToTimeSpan(), rp.MaxBackoff.ToTimeSpan(), double.Parse(rp.BackoffMultiplier.ToString()));
             // `timeout` is the timeout duration of a single RPC.
             var timeout = new BackoffSettings(config.Timeout.ToTimeSpan(), config.Timeout.ToTimeSpan(), 1.0); 
             var totalExpiration = Expiration.FromTimeout(config.Timeout.ToTimeSpan());


### PR DESCRIPTION
This used to produce very ugly output for unrepresentable numbers - e.g. 1.3 would be output as 1.2999999523162842