### PR TITLE
Resource-name redesign for vNext

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTests/ChildResource/Testing.ChildResource/ChildResourceResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ChildResource/Testing.ChildResource/ChildResourceResourceNames.g.cs
@@ -22,67 +22,178 @@ namespace Testing.ChildResource
     /// <summary>Resource name for the <c>Project</c> resource.</summary>
     public sealed partial class ProjectName : gax::IResourceName, sys::IEquatable<ProjectName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}");
-
-        /// <summary>
-        /// Parses the given <c>Project</c> resource name in string form into a new <see cref="ProjectName"/> instance.
-        /// </summary>
-        /// <param name="projectName">The <c>Project</c> resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="ProjectName"/> if successful.</returns>
-        public static ProjectName Parse(string projectName)
+        /// <summary>The possible contents of <see cref="ProjectName"/>.</summary>
+        public enum ResourceType
         {
-            gax::GaxPreconditions.CheckNotNull(projectName, nameof(projectName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(projectName);
-            return new ProjectName(resourceName[0]);
+            /// <summary>A resource of an unknown type.</summary>
+            Unknown = 0,
+
+            /// <summary>A resource of type 'project'.</summary>
+            Project = 1
         }
 
+        private static gax::PathTemplate s_project = new gax::PathTemplate("projects/{project}");
+
+        /// <summary>Creates a <see cref="ProjectName"/> containing an unknown resource name.</summary>
+        /// <param name="unknownResourceName">The unknown resource name. Must not be <c>null</c>.</param>
+        /// <returns>
+        /// A new instance of <see cref="ProjectName"/> containing the provided <paramref name="unknownResourceName"/>.
+        /// </returns>
+        public static ProjectName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new ProjectName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+
+        /// <summary>Creates a <see cref="ProjectName"/> with the pattern <c>projects/{project}</c>.</summary>
+        /// <param name="projectId">The <c>Project</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>A new instance of <see cref="ProjectName"/> constructed from the provided ids.</returns>
+        public static ProjectName CreateProject(string projectId) =>
+            new ProjectName(ResourceType.Project, projectId: gax::GaxPreconditions.CheckNotNullOrEmpty(projectId, nameof(projectId)));
+
         /// <summary>
-        /// Tries to parse the given session resource name in string form into a new <see cref="ProjectName"/> instance.
+        /// Formats the IDs into the string representation of this <see cref="ProjectName"/> with pattern
+        /// <c>projects/{project}</c>.
+        /// </summary>
+        /// <param name="projectId">The <c>Project</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="ProjectName"/> with pattern <c>projects/{project}</c>.
+        /// </returns>
+        public static string Format(string projectId) => FormatProject(projectId);
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="ProjectName"/> with pattern
+        /// <c>projects/{project}</c>.
+        /// </summary>
+        /// <param name="projectId">The <c>Project</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="ProjectName"/> with pattern <c>projects/{project}</c>.
+        /// </returns>
+        public static string FormatProject(string projectId) =>
+            s_project.Expand(gax::GaxPreconditions.CheckNotNullOrEmpty(projectId, nameof(projectId)));
+
+        /// <summary>Parses the given resource name string into a new <see cref="ProjectName"/> instance.</summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>projects/{project}</c></description></item></list>
+        /// </remarks>
+        /// <param name="projectName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="ProjectName"/> if successful.</returns>
+        public static ProjectName Parse(string projectName) => Parse(projectName, false);
+
+        /// <summary>
+        /// Parses the given resource name string into a new <see cref="ProjectName"/> instance; optionally allowing an
+        /// unknown resource name to be successfully parsed
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectName"/> is
-        /// <c>null</c>, as this would usually indicate a programming error rather than a data error.
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>projects/{project}</c></description></item></list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
         /// </remarks>
-        /// <param name="projectName">The <c>Project</c> resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">
-        /// When this method returns, the parsed <see cref="ProjectName"/>, or <c>null</c> if parsing fails.
+        /// <param name="projectName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
         /// </param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string projectName, out ProjectName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(projectName, nameof(projectName));
-            if (s_template.TryParseName(projectName, out gax::TemplatedResourceName resourceName))
-            {
-                result = new ProjectName(resourceName[0]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>Formats the IDs into the string representation of the <see cref="ProjectName"/>.</summary>
-        /// <param name="projectId">The <c>Project</c> ID. Must not be <c>null</c>.</param>
-        /// <returns>The string representation of the <see cref="ProjectName"/>.</returns>
-        public static string Format(string projectId) =>
-            s_template.Expand(gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId)));
+        /// <returns>The parsed <see cref="ProjectName"/> if successful.</returns>
+        public static ProjectName Parse(string projectName, bool allowUnknown) =>
+            TryParse(projectName, allowUnknown, out ProjectName result) ? result : throw new sys::ArgumentException("The given resource-name matches no pattern.");
 
         /// <summary>
-        /// Constructs a new instance of the <see cref="ProjectName"/> resource name class from its component parts.
+        /// Tries to parse the given resource name string into a new <see cref="ProjectName"/> instance.
         /// </summary>
-        /// <param name="projectId">The <c>Project</c> ID. Must not be <c>null</c>.</param>
-        public ProjectName(string projectId) => ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>projects/{project}</c></description></item></list>
+        /// </remarks>
+        /// <param name="projectName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="ProjectName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string projectName, out ProjectName result) => TryParse(projectName, false, out result);
 
-        /// <summary>The <c>Project</c> ID. Never <c>null</c>.</summary>
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="ProjectName"/> instance; optionally
+        /// allowing an unknown resource name to be successfully parsed.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>projects/{project}</c></description></item></list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="projectName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
+        /// </param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="ProjectName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string projectName, bool allowUnknown, out ProjectName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(projectName, nameof(projectName));
+            gax::TemplatedResourceName resourceName;
+            if (s_project.TryParseName(projectName, out resourceName))
+            {
+                result = CreateProject(resourceName[0]);
+                return true;
+            }
+            if (allowUnknown)
+            {
+                if (gax::UnknownResourceName.TryParse(projectName, out gax::UnknownResourceName unknownResourceName))
+                {
+                    result = CreateUnknown(unknownResourceName);
+                    return true;
+                }
+            }
+            result = null;
+            return false;
+        }
+
+        private ProjectName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string projectId = null)
+        {
+            Type = type;
+            UnknownResource = unknownResourceName;
+            ProjectId = projectId;
+        }
+
+        /// <summary>
+        /// Constructs a new instance of a <see cref="ProjectName"/> class from the component parts of pattern
+        /// <c>projects/{project}</c>
+        /// </summary>
+        /// <param name="projectId">The <c>Project</c> ID. Must not be <c>null</c> or empty.</param>
+        public ProjectName(string projectId) : this(ResourceType.Project, projectId: gax::GaxPreconditions.CheckNotNullOrEmpty(projectId, nameof(projectId)))
+        {
+        }
+
+        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
+        public ResourceType Type { get; }
+
+        /// <summary>
+        /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
+        /// unknown resource name.
+        /// </summary>
+        public gax::UnknownResourceName UnknownResource { get; }
+
+        /// <summary>
+        /// The <c>Project</c> ID. Will not be <c>null</c>, unless this instance contains an unknown resource name.
+        /// </summary>
         public string ProjectId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
 
         /// <inheritdoc/>
-        public override string ToString() => s_template.Expand(ProjectId);
+        public override string ToString()
+        {
+            switch (Type)
+            {
+                case ResourceType.Unknown: return UnknownResource.ToString();
+                case ResourceType.Project: return s_project.Expand(ProjectId);
+                default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
+            }
+        }
 
         /// <inheritdoc/>
         public override int GetHashCode() => ToString().GetHashCode();
@@ -103,82 +214,194 @@ namespace Testing.ChildResource
     /// <summary>Resource name for the <c>ProjectUser</c> resource.</summary>
     public sealed partial class ProjectUserName : gax::IResourceName, sys::IEquatable<ProjectUserName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/users/{user}");
-
-        /// <summary>
-        /// Parses the given <c>ProjectUser</c> resource name in string form into a new <see cref="ProjectUserName"/>
-        /// instance.
-        /// </summary>
-        /// <param name="projectUserName">
-        /// The <c>ProjectUser</c> resource name in string form. Must not be <c>null</c>.
-        /// </param>
-        /// <returns>The parsed <see cref="ProjectUserName"/> if successful.</returns>
-        public static ProjectUserName Parse(string projectUserName)
+        /// <summary>The possible contents of <see cref="ProjectUserName"/>.</summary>
+        public enum ResourceType
         {
-            gax::GaxPreconditions.CheckNotNull(projectUserName, nameof(projectUserName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(projectUserName);
-            return new ProjectUserName(resourceName[0], resourceName[1]);
+            /// <summary>A resource of an unknown type.</summary>
+            Unknown = 0,
+
+            /// <summary>A resource of type 'project'.</summary>
+            ProjectUser = 1
         }
 
+        private static gax::PathTemplate s_projectUser = new gax::PathTemplate("projects/{project}/users/{user}");
+
+        /// <summary>Creates a <see cref="ProjectUserName"/> containing an unknown resource name.</summary>
+        /// <param name="unknownResourceName">The unknown resource name. Must not be <c>null</c>.</param>
+        /// <returns>
+        /// A new instance of <see cref="ProjectUserName"/> containing the provided
+        /// <paramref name="unknownResourceName"/>.
+        /// </returns>
+        public static ProjectUserName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new ProjectUserName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+
         /// <summary>
-        /// Tries to parse the given session resource name in string form into a new <see cref="ProjectUserName"/>
-        /// instance.
+        /// Creates a <see cref="ProjectUserName"/> with the pattern <c>projects/{project}/users/{user}</c>.
+        /// </summary>
+        /// <param name="projectId">The <c>Project</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="userId">The <c>User</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>A new instance of <see cref="ProjectUserName"/> constructed from the provided ids.</returns>
+        public static ProjectUserName CreateProjectUser(string projectId, string userId) =>
+            new ProjectUserName(ResourceType.ProjectUser, projectId: gax::GaxPreconditions.CheckNotNullOrEmpty(projectId, nameof(projectId)), userId: gax::GaxPreconditions.CheckNotNullOrEmpty(userId, nameof(userId)));
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="ProjectUserName"/> with pattern
+        /// <c>projects/{project}/users/{user}</c>.
+        /// </summary>
+        /// <param name="projectId">The <c>Project</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="userId">The <c>User</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="ProjectUserName"/> with pattern
+        /// <c>projects/{project}/users/{user}</c>.
+        /// </returns>
+        public static string Format(string projectId, string userId) => FormatProjectUser(projectId, userId);
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="ProjectUserName"/> with pattern
+        /// <c>projects/{project}/users/{user}</c>.
+        /// </summary>
+        /// <param name="projectId">The <c>Project</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="userId">The <c>User</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="ProjectUserName"/> with pattern
+        /// <c>projects/{project}/users/{user}</c>.
+        /// </returns>
+        public static string FormatProjectUser(string projectId, string userId) =>
+            s_projectUser.Expand(gax::GaxPreconditions.CheckNotNullOrEmpty(projectId, nameof(projectId)), gax::GaxPreconditions.CheckNotNullOrEmpty(userId, nameof(userId)));
+
+        /// <summary>Parses the given resource name string into a new <see cref="ProjectUserName"/> instance.</summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>projects/{project}/users/{user}</c></description></item></list>
+        /// </remarks>
+        /// <param name="projectUserName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="ProjectUserName"/> if successful.</returns>
+        public static ProjectUserName Parse(string projectUserName) => Parse(projectUserName, false);
+
+        /// <summary>
+        /// Parses the given resource name string into a new <see cref="ProjectUserName"/> instance; optionally allowing
+        /// an unknown resource name to be successfully parsed
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectUserName"/> is
-        /// <c>null</c>, as this would usually indicate a programming error rather than a data error.
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>projects/{project}/users/{user}</c></description></item></list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
         /// </remarks>
-        /// <param name="projectUserName">
-        /// The <c>ProjectUser</c> resource name in string form. Must not be <c>null</c>.
+        /// <param name="projectUserName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
         /// </param>
-        /// <param name="result">
-        /// When this method returns, the parsed <see cref="ProjectUserName"/>, or <c>null</c> if parsing fails.
-        /// </param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string projectUserName, out ProjectUserName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(projectUserName, nameof(projectUserName));
-            if (s_template.TryParseName(projectUserName, out gax::TemplatedResourceName resourceName))
-            {
-                result = new ProjectUserName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>Formats the IDs into the string representation of the <see cref="ProjectUserName"/>.</summary>
-        /// <param name="projectId">The <c>Project</c> ID. Must not be <c>null</c>.</param>
-        /// <param name="userId">The <c>User</c> ID. Must not be <c>null</c>.</param>
-        /// <returns>The string representation of the <see cref="ProjectUserName"/>.</returns>
-        public static string Format(string projectId, string userId) =>
-            s_template.Expand(gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId)), gax::GaxPreconditions.CheckNotNull(userId, nameof(userId)));
+        /// <returns>The parsed <see cref="ProjectUserName"/> if successful.</returns>
+        public static ProjectUserName Parse(string projectUserName, bool allowUnknown) =>
+            TryParse(projectUserName, allowUnknown, out ProjectUserName result) ? result : throw new sys::ArgumentException("The given resource-name matches no pattern.");
 
         /// <summary>
-        /// Constructs a new instance of the <see cref="ProjectUserName"/> resource name class from its component parts.
+        /// Tries to parse the given resource name string into a new <see cref="ProjectUserName"/> instance.
         /// </summary>
-        /// <param name="projectId">The <c>Project</c> ID. Must not be <c>null</c>.</param>
-        /// <param name="userId">The <c>User</c> ID. Must not be <c>null</c>.</param>
-        public ProjectUserName(string projectId, string userId)
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>projects/{project}/users/{user}</c></description></item></list>
+        /// </remarks>
+        /// <param name="projectUserName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="ProjectUserName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string projectUserName, out ProjectUserName result) =>
+            TryParse(projectUserName, false, out result);
+
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="ProjectUserName"/> instance; optionally
+        /// allowing an unknown resource name to be successfully parsed.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>projects/{project}/users/{user}</c></description></item></list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="projectUserName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
+        /// </param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="ProjectUserName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string projectUserName, bool allowUnknown, out ProjectUserName result)
         {
-            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            UserId = gax::GaxPreconditions.CheckNotNull(userId, nameof(userId));
+            gax::GaxPreconditions.CheckNotNull(projectUserName, nameof(projectUserName));
+            gax::TemplatedResourceName resourceName;
+            if (s_projectUser.TryParseName(projectUserName, out resourceName))
+            {
+                result = CreateProjectUser(resourceName[0], resourceName[1]);
+                return true;
+            }
+            if (allowUnknown)
+            {
+                if (gax::UnknownResourceName.TryParse(projectUserName, out gax::UnknownResourceName unknownResourceName))
+                {
+                    result = CreateUnknown(unknownResourceName);
+                    return true;
+                }
+            }
+            result = null;
+            return false;
         }
 
-        /// <summary>The <c>Project</c> ID. Never <c>null</c>.</summary>
+        private ProjectUserName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string projectId = null, string userId = null)
+        {
+            Type = type;
+            UnknownResource = unknownResourceName;
+            ProjectId = projectId;
+            UserId = userId;
+        }
+
+        /// <summary>
+        /// Constructs a new instance of a <see cref="ProjectUserName"/> class from the component parts of pattern
+        /// <c>projects/{project}/users/{user}</c>
+        /// </summary>
+        /// <param name="projectId">The <c>Project</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="userId">The <c>User</c> ID. Must not be <c>null</c> or empty.</param>
+        public ProjectUserName(string projectId, string userId) : this(ResourceType.ProjectUser, projectId: gax::GaxPreconditions.CheckNotNullOrEmpty(projectId, nameof(projectId)), userId: gax::GaxPreconditions.CheckNotNullOrEmpty(userId, nameof(userId)))
+        {
+        }
+
+        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
+        public ResourceType Type { get; }
+
+        /// <summary>
+        /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
+        /// unknown resource name.
+        /// </summary>
+        public gax::UnknownResourceName UnknownResource { get; }
+
+        /// <summary>
+        /// The <c>Project</c> ID. Will not be <c>null</c>, unless this instance contains an unknown resource name.
+        /// </summary>
         public string ProjectId { get; }
 
-        /// <summary>The <c>User</c> ID. Never <c>null</c>.</summary>
+        /// <summary>
+        /// The <c>User</c> ID. Will not be <c>null</c>, unless this instance contains an unknown resource name.
+        /// </summary>
         public string UserId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
 
         /// <inheritdoc/>
-        public override string ToString() => s_template.Expand(ProjectId, UserId);
+        public override string ToString()
+        {
+            switch (Type)
+            {
+                case ResourceType.Unknown: return UnknownResource.ToString();
+                case ResourceType.ProjectUser: return s_projectUser.Expand(ProjectId, UserId);
+                default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
+            }
+        }
 
         /// <inheritdoc/>
         public override int GetHashCode() => ToString().GetHashCode();
@@ -196,287 +419,186 @@ namespace Testing.ChildResource
         public static bool operator !=(ProjectUserName a, ProjectUserName b) => !(a == b);
     }
 
-    /// <summary>Resource name for the <c>RootAItem</c> resource.</summary>
-    public sealed partial class RootAItemName : gax::IResourceName, sys::IEquatable<RootAItemName>
+    /// <summary>Resource name for the <c>MultiRootItem</c> resource.</summary>
+    public sealed partial class MultiRootItemName : gax::IResourceName, sys::IEquatable<MultiRootItemName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("root_a/{root_a}/items/{item}");
-
-        /// <summary>
-        /// Parses the given <c>RootAItem</c> resource name in string form into a new <see cref="RootAItemName"/>
-        /// instance.
-        /// </summary>
-        /// <param name="rootAItemName">
-        /// The <c>RootAItem</c> resource name in string form. Must not be <c>null</c>.
-        /// </param>
-        /// <returns>The parsed <see cref="RootAItemName"/> if successful.</returns>
-        public static RootAItemName Parse(string rootAItemName)
-        {
-            gax::GaxPreconditions.CheckNotNull(rootAItemName, nameof(rootAItemName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(rootAItemName);
-            return new RootAItemName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given session resource name in string form into a new <see cref="RootAItemName"/>
-        /// instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="rootAItemName"/> is
-        /// <c>null</c>, as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="rootAItemName">
-        /// The <c>RootAItem</c> resource name in string form. Must not be <c>null</c>.
-        /// </param>
-        /// <param name="result">
-        /// When this method returns, the parsed <see cref="RootAItemName"/>, or <c>null</c> if parsing fails.
-        /// </param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string rootAItemName, out RootAItemName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(rootAItemName, nameof(rootAItemName));
-            if (s_template.TryParseName(rootAItemName, out gax::TemplatedResourceName resourceName))
-            {
-                result = new RootAItemName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>Formats the IDs into the string representation of the <see cref="RootAItemName"/>.</summary>
-        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c>.</param>
-        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c>.</param>
-        /// <returns>The string representation of the <see cref="RootAItemName"/>.</returns>
-        public static string Format(string rootAId, string itemId) =>
-            s_template.Expand(gax::GaxPreconditions.CheckNotNull(rootAId, nameof(rootAId)), gax::GaxPreconditions.CheckNotNull(itemId, nameof(itemId)));
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="RootAItemName"/> resource name class from its component parts.
-        /// </summary>
-        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c>.</param>
-        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c>.</param>
-        public RootAItemName(string rootAId, string itemId)
-        {
-            RootAId = gax::GaxPreconditions.CheckNotNull(rootAId, nameof(rootAId));
-            ItemId = gax::GaxPreconditions.CheckNotNull(itemId, nameof(itemId));
-        }
-
-        /// <summary>The <c>RootA</c> ID. Never <c>null</c>.</summary>
-        public string RootAId { get; }
-
-        /// <summary>The <c>Item</c> ID. Never <c>null</c>.</summary>
-        public string ItemId { get; }
-
-        /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc/>
-        public override string ToString() => s_template.Expand(RootAId, ItemId);
-
-        /// <inheritdoc/>
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as RootAItemName);
-
-        /// <inheritdoc/>
-        public bool Equals(RootAItemName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc/>
-        public static bool operator ==(RootAItemName a, RootAItemName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc/>
-        public static bool operator !=(RootAItemName a, RootAItemName b) => !(a == b);
-    }
-
-    /// <summary>Resource name for the <c>RootBItem</c> resource.</summary>
-    public sealed partial class RootBItemName : gax::IResourceName, sys::IEquatable<RootBItemName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("root_b/{root_b}/items/{item}");
-
-        /// <summary>
-        /// Parses the given <c>RootBItem</c> resource name in string form into a new <see cref="RootBItemName"/>
-        /// instance.
-        /// </summary>
-        /// <param name="rootBItemName">
-        /// The <c>RootBItem</c> resource name in string form. Must not be <c>null</c>.
-        /// </param>
-        /// <returns>The parsed <see cref="RootBItemName"/> if successful.</returns>
-        public static RootBItemName Parse(string rootBItemName)
-        {
-            gax::GaxPreconditions.CheckNotNull(rootBItemName, nameof(rootBItemName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(rootBItemName);
-            return new RootBItemName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given session resource name in string form into a new <see cref="RootBItemName"/>
-        /// instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="rootBItemName"/> is
-        /// <c>null</c>, as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="rootBItemName">
-        /// The <c>RootBItem</c> resource name in string form. Must not be <c>null</c>.
-        /// </param>
-        /// <param name="result">
-        /// When this method returns, the parsed <see cref="RootBItemName"/>, or <c>null</c> if parsing fails.
-        /// </param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string rootBItemName, out RootBItemName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(rootBItemName, nameof(rootBItemName));
-            if (s_template.TryParseName(rootBItemName, out gax::TemplatedResourceName resourceName))
-            {
-                result = new RootBItemName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>Formats the IDs into the string representation of the <see cref="RootBItemName"/>.</summary>
-        /// <param name="rootBId">The <c>RootB</c> ID. Must not be <c>null</c>.</param>
-        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c>.</param>
-        /// <returns>The string representation of the <see cref="RootBItemName"/>.</returns>
-        public static string Format(string rootBId, string itemId) =>
-            s_template.Expand(gax::GaxPreconditions.CheckNotNull(rootBId, nameof(rootBId)), gax::GaxPreconditions.CheckNotNull(itemId, nameof(itemId)));
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="RootBItemName"/> resource name class from its component parts.
-        /// </summary>
-        /// <param name="rootBId">The <c>RootB</c> ID. Must not be <c>null</c>.</param>
-        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c>.</param>
-        public RootBItemName(string rootBId, string itemId)
-        {
-            RootBId = gax::GaxPreconditions.CheckNotNull(rootBId, nameof(rootBId));
-            ItemId = gax::GaxPreconditions.CheckNotNull(itemId, nameof(itemId));
-        }
-
-        /// <summary>The <c>RootB</c> ID. Never <c>null</c>.</summary>
-        public string RootBId { get; }
-
-        /// <summary>The <c>Item</c> ID. Never <c>null</c>.</summary>
-        public string ItemId { get; }
-
-        /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc/>
-        public override string ToString() => s_template.Expand(RootBId, ItemId);
-
-        /// <inheritdoc/>
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as RootBItemName);
-
-        /// <inheritdoc/>
-        public bool Equals(RootBItemName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc/>
-        public static bool operator ==(RootBItemName a, RootBItemName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc/>
-        public static bool operator !=(RootBItemName a, RootBItemName b) => !(a == b);
-    }
-
-    /// <summary>Resource name which will contain one of a choice of resource names.</summary>
-    /// <remarks>
-    /// This resource name will contain one of the following:
-    /// <list type="bullet">
-    /// <item><description>RootAItemName: A resource of type 'root_a'.</description></item>
-    /// <item><description>RootBItemName: A resource of type 'root_b'.</description></item>
-    /// </list>
-    /// </remarks>
-    public sealed partial class MultiRootItemNameOneOf : gax::IResourceName, sys::IEquatable<MultiRootItemNameOneOf>
-    {
-        /// <summary>The possible contents of <see cref="MultiRootItemNameOneOf"/>.</summary>
-        public enum OneofType
+        /// <summary>The possible contents of <see cref="MultiRootItemName"/>.</summary>
+        public enum ResourceType
         {
             /// <summary>A resource of an unknown type.</summary>
             Unknown = 0,
 
-            /// <summary>A resource of type 'root_a'</summary>
-            RootAItemName = 1,
+            /// <summary>A resource of type 'root_a'.</summary>
+            RootAItem = 1,
 
-            /// <summary>A resource of type 'root_b'</summary>
-            RootBItemName = 2
+            /// <summary>A resource of type 'root_b'.</summary>
+            RootBItem = 2
         }
 
+        private static gax::PathTemplate s_rootAItem = new gax::PathTemplate("root_a/{root_a}/items/{item}");
+
+        private static gax::PathTemplate s_rootBItem = new gax::PathTemplate("root_b/{root_b}/items/{item}");
+
+        /// <summary>Creates a <see cref="MultiRootItemName"/> containing an unknown resource name.</summary>
+        /// <param name="unknownResourceName">The unknown resource name. Must not be <c>null</c>.</param>
+        /// <returns>
+        /// A new instance of <see cref="MultiRootItemName"/> containing the provided
+        /// <paramref name="unknownResourceName"/>.
+        /// </returns>
+        public static MultiRootItemName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new MultiRootItemName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+
         /// <summary>
-        /// Parses the given <c>MultiRootItem</c> resource name in string form into a new
-        /// <see cref="MultiRootItemNameOneOf"/> instance.
+        /// Creates a <see cref="MultiRootItemName"/> with the pattern <c>root_a/{root_a}/items/{item}</c>.
+        /// </summary>
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>A new instance of <see cref="MultiRootItemName"/> constructed from the provided ids.</returns>
+        public static MultiRootItemName CreateRootAItem(string rootAId, string itemId) =>
+            new MultiRootItemName(ResourceType.RootAItem, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+
+        /// <summary>
+        /// Creates a <see cref="MultiRootItemName"/> with the pattern <c>root_b/{root_b}/items/{item}</c>.
+        /// </summary>
+        /// <param name="rootBId">The <c>RootB</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>A new instance of <see cref="MultiRootItemName"/> constructed from the provided ids.</returns>
+        public static MultiRootItemName CreateRootBItem(string rootBId, string itemId) =>
+            new MultiRootItemName(ResourceType.RootBItem, rootBId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootBId, nameof(rootBId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="MultiRootItemName"/> with pattern
+        /// <c>root_a/{root_a}/items/{item}</c>.
+        /// </summary>
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="MultiRootItemName"/> with pattern
+        /// <c>root_a/{root_a}/items/{item}</c>.
+        /// </returns>
+        public static string Format(string rootAId, string itemId) => FormatRootAItem(rootAId, itemId);
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="MultiRootItemName"/> with pattern
+        /// <c>root_a/{root_a}/items/{item}</c>.
+        /// </summary>
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="MultiRootItemName"/> with pattern
+        /// <c>root_a/{root_a}/items/{item}</c>.
+        /// </returns>
+        public static string FormatRootAItem(string rootAId, string itemId) =>
+            s_rootAItem.Expand(gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="MultiRootItemName"/> with pattern
+        /// <c>root_b/{root_b}/items/{item}</c>.
+        /// </summary>
+        /// <param name="rootBId">The <c>RootB</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="MultiRootItemName"/> with pattern
+        /// <c>root_b/{root_b}/items/{item}</c>.
+        /// </returns>
+        public static string FormatRootBItem(string rootBId, string itemId) =>
+            s_rootBItem.Expand(gax::GaxPreconditions.CheckNotNullOrEmpty(rootBId, nameof(rootBId)), gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+
+        /// <summary>
+        /// Parses the given resource name string into a new <see cref="MultiRootItemName"/> instance.
         /// </summary>
         /// <remarks>
-        /// To parse successfully the resource name must be one of the following:
+        /// To parse successfully, the resource name must be formatted as one of the following:
         /// <list type="bullet">
-        /// <item><description>RootAItemName: A resource of type 'root_a'.</description></item>
-        /// <item><description>RootBItemName: A resource of type 'root_b'.</description></item>
+        /// <item><description><c>root_a/{root_a}/items/{item}</c></description></item>
+        /// <item><description><c>root_b/{root_b}/items/{item}</c></description></item>
         /// </list>
-        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>
         /// </remarks>
-        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="multiRootItemName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="MultiRootItemName"/> if successful.</returns>
+        public static MultiRootItemName Parse(string multiRootItemName) => Parse(multiRootItemName, false);
+
+        /// <summary>
+        /// Parses the given resource name string into a new <see cref="MultiRootItemName"/> instance; optionally
+        /// allowing an unknown resource name to be successfully parsed
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet">
+        /// <item><description><c>root_a/{root_a}/items/{item}</c></description></item>
+        /// <item><description><c>root_b/{root_b}/items/{item}</c></description></item>
+        /// </list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="multiRootItemName">The resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="allowUnknown">
-        /// If <c>true</c>, will successfully parse an unknown resource name into an
-        /// <see cref="gax::UnknownResourceName"/>; otherwise will throw an<see cref="sys::ArgumentException"/> if an
-        /// unknown resource name is given.
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
         /// </param>
-        /// <returns>The parsed <see cref="MultiRootItemNameOneOf"/> if successful.</returns>
-        public static MultiRootItemNameOneOf Parse(string name, bool allowUnknown)
-        {
-            if (TryParse(name, allowUnknown, out MultiRootItemNameOneOf result))
-            {
-                return result;
-            }
-            throw new sys::ArgumentException("Invalid name", nameof(name));
-        }
+        /// <returns>The parsed <see cref="MultiRootItemName"/> if successful.</returns>
+        public static MultiRootItemName Parse(string multiRootItemName, bool allowUnknown) =>
+            TryParse(multiRootItemName, allowUnknown, out MultiRootItemName result) ? result : throw new sys::ArgumentException("The given resource-name matches no pattern.");
 
         /// <summary>
-        /// Tries to parse a resource name in string form into a new <see cref="MultiRootItemNameOneOf"/> instance.
+        /// Tries to parse the given resource name string into a new <see cref="MultiRootItemName"/> instance.
         /// </summary>
         /// <remarks>
-        /// To parse successfully the resource name must be one of the following:
+        /// To parse successfully, the resource name must be formatted as one of the following:
         /// <list type="bullet">
-        /// <item><description>RootAItemName: A resource of type 'root_a'.</description></item>
-        /// <item><description>RootBItemName: A resource of type 'root_b'.</description></item>
+        /// <item><description><c>root_a/{root_a}/items/{item}</c></description></item>
+        /// <item><description><c>root_b/{root_b}/items/{item}</c></description></item>
         /// </list>
-        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>
         /// </remarks>
-        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="multiRootItemName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="MultiRootItemName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string multiRootItemName, out MultiRootItemName result) =>
+            TryParse(multiRootItemName, false, out result);
+
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="MultiRootItemName"/> instance;
+        /// optionally allowing an unknown resource name to be successfully parsed.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet">
+        /// <item><description><c>root_a/{root_a}/items/{item}</c></description></item>
+        /// <item><description><c>root_b/{root_b}/items/{item}</c></description></item>
+        /// </list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="multiRootItemName">The resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="allowUnknown">
-        /// If <c>true</c>, will successfully parse an unknown resource name into an
-        /// <see cref="gax::UnknownResourceName"/>.
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
         /// </param>
         /// <param name="result">
-        /// When this method returns, the parsed <see cref="MultiRootItemNameOneOf"/>, or <c>null</c> if parsing fails.
+        /// When this method returns, the parsed <see cref="MultiRootItemName"/>, or <c>null</c> if parsing failed.
         /// </param>
-        /// <returns><c>true</c> if the name was parsed succssfully; othrewise <c>false</c></returns>
-        public static bool TryParse(string name, bool allowUnknown, out MultiRootItemNameOneOf result)
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string multiRootItemName, bool allowUnknown, out MultiRootItemName result)
         {
-            gax::GaxPreconditions.CheckNotNull(name, nameof(name));
-            if (RootAItemName.TryParse(name, out RootAItemName rootAItemName))
+            gax::GaxPreconditions.CheckNotNull(multiRootItemName, nameof(multiRootItemName));
+            gax::TemplatedResourceName resourceName;
+            if (s_rootAItem.TryParseName(multiRootItemName, out resourceName))
             {
-                result = new MultiRootItemNameOneOf(OneofType.RootAItemName, rootAItemName);
+                result = CreateRootAItem(resourceName[0], resourceName[1]);
                 return true;
             }
-            if (RootBItemName.TryParse(name, out RootBItemName rootBItemName))
+            if (s_rootBItem.TryParseName(multiRootItemName, out resourceName))
             {
-                result = new MultiRootItemNameOneOf(OneofType.RootBItemName, rootBItemName);
+                result = CreateRootBItem(resourceName[0], resourceName[1]);
                 return true;
             }
             if (allowUnknown)
             {
-                if (gax::UnknownResourceName.TryParse(name, out gax::UnknownResourceName unknownResourceName))
+                if (gax::UnknownResourceName.TryParse(multiRootItemName, out gax::UnknownResourceName unknownResourceName))
                 {
-                    result = new MultiRootItemNameOneOf(OneofType.Unknown, unknownResourceName);
+                    result = CreateUnknown(unknownResourceName);
                     return true;
                 }
             }
@@ -484,352 +606,244 @@ namespace Testing.ChildResource
             return false;
         }
 
-        /// <summary>
-        /// Constructs a new instance of <see cref="MultiRootItemNameOneOf"/> from the provided
-        /// <see cref="RootAItemName"/>.
-        /// </summary>
-        /// <param name="rootAItemName">
-        /// The <see cref="RootAItemName"/> to be contained within the returned <see cref="MultiRootItemNameOneOf"/>.
-        /// Must not be <c>null</c>
-        /// </param>
-        /// <returns>A new <see cref="MultiRootItemNameOneOf"/>, containing <paramref name="rootAItemName"/>.</returns>
-        public static MultiRootItemNameOneOf From(RootAItemName rootAItemName) =>
-            new MultiRootItemNameOneOf(OneofType.RootAItemName, rootAItemName);
-
-        /// <summary>
-        /// Constructs a new instance of <see cref="MultiRootItemNameOneOf"/> from the provided
-        /// <see cref="RootBItemName"/>.
-        /// </summary>
-        /// <param name="rootBItemName">
-        /// The <see cref="RootBItemName"/> to be contained within the returned <see cref="MultiRootItemNameOneOf"/>.
-        /// Must not be <c>null</c>
-        /// </param>
-        /// <returns>A new <see cref="MultiRootItemNameOneOf"/>, containing <paramref name="rootBItemName"/>.</returns>
-        public static MultiRootItemNameOneOf From(RootBItemName rootBItemName) =>
-            new MultiRootItemNameOneOf(OneofType.RootBItemName, rootBItemName);
-
-        private static bool IsValid(OneofType type, gax::IResourceName name)
+        private MultiRootItemName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null, string rootAId = null, string rootBId = null)
         {
-            switch (type)
-            {
-                case OneofType.Unknown: return true;
-                case OneofType.RootAItemName: return name is RootAItemName;
-                case OneofType.RootBItemName: return name is RootBItemName;
-                default: return false;
-            }
-        }
-
-        public MultiRootItemNameOneOf(OneofType type, gax::IResourceName name)
-        {
-            Type = gax::GaxPreconditions.CheckEnumValue<OneofType>(type, nameof(type));
-            Name = gax::GaxPreconditions.CheckNotNull(name, nameof(name));
-            if (!IsValid(type, name))
-            {
-                throw new sys::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
-            }
-        }
-
-        /// <summary>The <see cref="OneofType"/> of the Name contained in this instance.</summary>
-        public OneofType Type { get; }
-
-        /// <summary>The <see cref="gax::IResourceName"/> contained in this instance.</summary>
-        public gax::IResourceName Name { get; }
-
-        private T CheckAndReturn<T>(OneofType type)
-        {
-            if (Type != type)
-            {
-                throw new sys::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
-            }
-            return (T)Name;
-        }
-
-        /// <summary>Get the contained <see cref="gax::IResourceName"/> as <see cref="RootAItemName"/>.</summary>
-        /// <remarks>
-        /// An <see cref="sys::InvalidOperationException"/> will be thrown is this does not contain an instance of
-        /// <see cref="RootAItemName"/>.
-        /// </remarks>
-        public RootAItemName RootAItemName => CheckAndReturn<RootAItemName>(OneofType.RootAItemName);
-
-        /// <summary>Get the contained <see cref="gax::IResourceName"/> as <see cref="RootBItemName"/>.</summary>
-        /// <remarks>
-        /// An <see cref="sys::InvalidOperationException"/> will be thrown is this does not contain an instance of
-        /// <see cref="RootBItemName"/>.
-        /// </remarks>
-        public RootBItemName RootBItemName => CheckAndReturn<RootBItemName>(OneofType.RootBItemName);
-
-        /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Oneof;
-
-        /// <inheritdoc/>
-        public override string ToString() => this.Name.ToString();
-
-        /// <inheritdoc/>
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as MultiRootItemNameOneOf);
-
-        /// <inheritdoc/>
-        public bool Equals(MultiRootItemNameOneOf other) => ToString() == other?.ToString();
-
-        /// <inheritdoc/>
-        public static bool operator ==(MultiRootItemNameOneOf a, MultiRootItemNameOneOf b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc/>
-        public static bool operator !=(MultiRootItemNameOneOf a, MultiRootItemNameOneOf b) => !(a == b);
-    }
-
-    /// <summary>Resource name for the <c>RootA</c> resource.</summary>
-    public sealed partial class RootAName : gax::IResourceName, sys::IEquatable<RootAName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("root_a/{root_a}");
-
-        /// <summary>
-        /// Parses the given <c>RootA</c> resource name in string form into a new <see cref="RootAName"/> instance.
-        /// </summary>
-        /// <param name="rootAName">The <c>RootA</c> resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="RootAName"/> if successful.</returns>
-        public static RootAName Parse(string rootAName)
-        {
-            gax::GaxPreconditions.CheckNotNull(rootAName, nameof(rootAName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(rootAName);
-            return new RootAName(resourceName[0]);
+            Type = type;
+            UnknownResource = unknownResourceName;
+            ItemId = itemId;
+            RootAId = rootAId;
+            RootBId = rootBId;
         }
 
         /// <summary>
-        /// Tries to parse the given session resource name in string form into a new <see cref="RootAName"/> instance.
+        /// Constructs a new instance of a <see cref="MultiRootItemName"/> class from the component parts of pattern
+        /// <c>root_a/{root_a}/items/{item}</c>
         /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="rootAName"/> is <c>null</c>
-        /// , as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="rootAName">The <c>RootA</c> resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">
-        /// When this method returns, the parsed <see cref="RootAName"/>, or <c>null</c> if parsing fails.
-        /// </param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string rootAName, out RootAName result)
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        public MultiRootItemName(string rootAId, string itemId) : this(ResourceType.RootAItem, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
         {
-            gax::GaxPreconditions.CheckNotNull(rootAName, nameof(rootAName));
-            if (s_template.TryParseName(rootAName, out gax::TemplatedResourceName resourceName))
-            {
-                result = new RootAName(resourceName[0]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
         }
 
-        /// <summary>Formats the IDs into the string representation of the <see cref="RootAName"/>.</summary>
-        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c>.</param>
-        /// <returns>The string representation of the <see cref="RootAName"/>.</returns>
-        public static string Format(string rootAId) =>
-            s_template.Expand(gax::GaxPreconditions.CheckNotNull(rootAId, nameof(rootAId)));
+        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
+        public ResourceType Type { get; }
 
         /// <summary>
-        /// Constructs a new instance of the <see cref="RootAName"/> resource name class from its component parts.
+        /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
+        /// unknown resource name.
         /// </summary>
-        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c>.</param>
-        public RootAName(string rootAId) => RootAId = gax::GaxPreconditions.CheckNotNull(rootAId, nameof(rootAId));
+        public gax::UnknownResourceName UnknownResource { get; }
 
-        /// <summary>The <c>RootA</c> ID. Never <c>null</c>.</summary>
+        /// <summary>
+        /// The <c>Item</c> ID. May be <c>null</c>, depending on which resource name is contained by this instance.
+        /// </summary>
+        public string ItemId { get; }
+
+        /// <summary>
+        /// The <c>RootA</c> ID. May be <c>null</c>, depending on which resource name is contained by this instance.
+        /// </summary>
         public string RootAId { get; }
 
-        /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc/>
-        public override string ToString() => s_template.Expand(RootAId);
-
-        /// <inheritdoc/>
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as RootAName);
-
-        /// <inheritdoc/>
-        public bool Equals(RootAName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc/>
-        public static bool operator ==(RootAName a, RootAName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc/>
-        public static bool operator !=(RootAName a, RootAName b) => !(a == b);
-    }
-
-    /// <summary>Resource name for the <c>RootB</c> resource.</summary>
-    public sealed partial class RootBName : gax::IResourceName, sys::IEquatable<RootBName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("root_b/{root_b}");
-
         /// <summary>
-        /// Parses the given <c>RootB</c> resource name in string form into a new <see cref="RootBName"/> instance.
+        /// The <c>RootB</c> ID. May be <c>null</c>, depending on which resource name is contained by this instance.
         /// </summary>
-        /// <param name="rootBName">The <c>RootB</c> resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="RootBName"/> if successful.</returns>
-        public static RootBName Parse(string rootBName)
-        {
-            gax::GaxPreconditions.CheckNotNull(rootBName, nameof(rootBName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(rootBName);
-            return new RootBName(resourceName[0]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given session resource name in string form into a new <see cref="RootBName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="rootBName"/> is <c>null</c>
-        /// , as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="rootBName">The <c>RootB</c> resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">
-        /// When this method returns, the parsed <see cref="RootBName"/>, or <c>null</c> if parsing fails.
-        /// </param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string rootBName, out RootBName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(rootBName, nameof(rootBName));
-            if (s_template.TryParseName(rootBName, out gax::TemplatedResourceName resourceName))
-            {
-                result = new RootBName(resourceName[0]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>Formats the IDs into the string representation of the <see cref="RootBName"/>.</summary>
-        /// <param name="rootBId">The <c>RootB</c> ID. Must not be <c>null</c>.</param>
-        /// <returns>The string representation of the <see cref="RootBName"/>.</returns>
-        public static string Format(string rootBId) =>
-            s_template.Expand(gax::GaxPreconditions.CheckNotNull(rootBId, nameof(rootBId)));
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="RootBName"/> resource name class from its component parts.
-        /// </summary>
-        /// <param name="rootBId">The <c>RootB</c> ID. Must not be <c>null</c>.</param>
-        public RootBName(string rootBId) => RootBId = gax::GaxPreconditions.CheckNotNull(rootBId, nameof(rootBId));
-
-        /// <summary>The <c>RootB</c> ID. Never <c>null</c>.</summary>
         public string RootBId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Oneof;
 
         /// <inheritdoc/>
-        public override string ToString() => s_template.Expand(RootBId);
+        public override string ToString()
+        {
+            switch (Type)
+            {
+                case ResourceType.Unknown: return UnknownResource.ToString();
+                case ResourceType.RootAItem: return s_rootAItem.Expand(RootAId, ItemId);
+                case ResourceType.RootBItem: return s_rootBItem.Expand(RootBId, ItemId);
+                default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
+            }
+        }
 
         /// <inheritdoc/>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as RootBName);
+        public override bool Equals(object obj) => Equals(obj as MultiRootItemName);
 
         /// <inheritdoc/>
-        public bool Equals(RootBName other) => ToString() == other?.ToString();
+        public bool Equals(MultiRootItemName other) => ToString() == other?.ToString();
 
         /// <inheritdoc/>
-        public static bool operator ==(RootBName a, RootBName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+        public static bool operator ==(MultiRootItemName a, MultiRootItemName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
 
         /// <inheritdoc/>
-        public static bool operator !=(RootBName a, RootBName b) => !(a == b);
+        public static bool operator !=(MultiRootItemName a, MultiRootItemName b) => !(a == b);
     }
 
-    /// <summary>Resource name which will contain one of a choice of resource names.</summary>
-    /// <remarks>
-    /// This resource name will contain one of the following:
-    /// <list type="bullet">
-    /// <item><description>RootAName: A resource of type 'root_a'.</description></item>
-    /// <item><description>RootBName: A resource of type 'root_b'.</description></item>
-    /// </list>
-    /// </remarks>
-    public sealed partial class RootsNameOneOf : gax::IResourceName, sys::IEquatable<RootsNameOneOf>
+    /// <summary>Resource name for the <c>Roots</c> resource.</summary>
+    public sealed partial class RootsName : gax::IResourceName, sys::IEquatable<RootsName>
     {
-        /// <summary>The possible contents of <see cref="RootsNameOneOf"/>.</summary>
-        public enum OneofType
+        /// <summary>The possible contents of <see cref="RootsName"/>.</summary>
+        public enum ResourceType
         {
             /// <summary>A resource of an unknown type.</summary>
             Unknown = 0,
 
-            /// <summary>A resource of type 'root_a'</summary>
-            RootAName = 1,
+            /// <summary>A resource of type 'root_a'.</summary>
+            RootA = 1,
 
-            /// <summary>A resource of type 'root_b'</summary>
-            RootBName = 2
+            /// <summary>A resource of type 'root_b'.</summary>
+            RootB = 2
         }
 
+        private static gax::PathTemplate s_rootA = new gax::PathTemplate("root_a/{root_a}");
+
+        private static gax::PathTemplate s_rootB = new gax::PathTemplate("root_b/{root_b}");
+
+        /// <summary>Creates a <see cref="RootsName"/> containing an unknown resource name.</summary>
+        /// <param name="unknownResourceName">The unknown resource name. Must not be <c>null</c>.</param>
+        /// <returns>
+        /// A new instance of <see cref="RootsName"/> containing the provided <paramref name="unknownResourceName"/>.
+        /// </returns>
+        public static RootsName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new RootsName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+
+        /// <summary>Creates a <see cref="RootsName"/> with the pattern <c>root_a/{root_a}</c>.</summary>
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>A new instance of <see cref="RootsName"/> constructed from the provided ids.</returns>
+        public static RootsName CreateRootA(string rootAId) =>
+            new RootsName(ResourceType.RootA, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)));
+
+        /// <summary>Creates a <see cref="RootsName"/> with the pattern <c>root_b/{root_b}</c>.</summary>
+        /// <param name="rootBId">The <c>RootB</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>A new instance of <see cref="RootsName"/> constructed from the provided ids.</returns>
+        public static RootsName CreateRootB(string rootBId) =>
+            new RootsName(ResourceType.RootB, rootBId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootBId, nameof(rootBId)));
+
         /// <summary>
-        /// Parses the given <c>Roots</c> resource name in string form into a new <see cref="RootsNameOneOf"/> instance.
+        /// Formats the IDs into the string representation of this <see cref="RootsName"/> with pattern
+        /// <c>root_a/{root_a}</c>.
+        /// </summary>
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="RootsName"/> with pattern <c>root_a/{root_a}</c>.
+        /// </returns>
+        public static string Format(string rootAId) => FormatRootA(rootAId);
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="RootsName"/> with pattern
+        /// <c>root_a/{root_a}</c>.
+        /// </summary>
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="RootsName"/> with pattern <c>root_a/{root_a}</c>.
+        /// </returns>
+        public static string FormatRootA(string rootAId) =>
+            s_rootA.Expand(gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)));
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="RootsName"/> with pattern
+        /// <c>root_b/{root_b}</c>.
+        /// </summary>
+        /// <param name="rootBId">The <c>RootB</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="RootsName"/> with pattern <c>root_b/{root_b}</c>.
+        /// </returns>
+        public static string FormatRootB(string rootBId) =>
+            s_rootB.Expand(gax::GaxPreconditions.CheckNotNullOrEmpty(rootBId, nameof(rootBId)));
+
+        /// <summary>Parses the given resource name string into a new <see cref="RootsName"/> instance.</summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet">
+        /// <item><description><c>root_a/{root_a}</c></description></item>
+        /// <item><description><c>root_b/{root_b}</c></description></item>
+        /// </list>
+        /// </remarks>
+        /// <param name="rootsName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="RootsName"/> if successful.</returns>
+        public static RootsName Parse(string rootsName) => Parse(rootsName, false);
+
+        /// <summary>
+        /// Parses the given resource name string into a new <see cref="RootsName"/> instance; optionally allowing an
+        /// unknown resource name to be successfully parsed
         /// </summary>
         /// <remarks>
-        /// To parse successfully the resource name must be one of the following:
+        /// To parse successfully, the resource name must be formatted as one of the following:
         /// <list type="bullet">
-        /// <item><description>RootAName: A resource of type 'root_a'.</description></item>
-        /// <item><description>RootBName: A resource of type 'root_b'.</description></item>
+        /// <item><description><c>root_a/{root_a}</c></description></item>
+        /// <item><description><c>root_b/{root_b}</c></description></item>
         /// </list>
-        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
         /// </remarks>
-        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="rootsName">The resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="allowUnknown">
-        /// If <c>true</c>, will successfully parse an unknown resource name into an
-        /// <see cref="gax::UnknownResourceName"/>; otherwise will throw an<see cref="sys::ArgumentException"/> if an
-        /// unknown resource name is given.
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
         /// </param>
-        /// <returns>The parsed <see cref="RootsNameOneOf"/> if successful.</returns>
-        public static RootsNameOneOf Parse(string name, bool allowUnknown)
-        {
-            if (TryParse(name, allowUnknown, out RootsNameOneOf result))
-            {
-                return result;
-            }
-            throw new sys::ArgumentException("Invalid name", nameof(name));
-        }
+        /// <returns>The parsed <see cref="RootsName"/> if successful.</returns>
+        public static RootsName Parse(string rootsName, bool allowUnknown) =>
+            TryParse(rootsName, allowUnknown, out RootsName result) ? result : throw new sys::ArgumentException("The given resource-name matches no pattern.");
 
         /// <summary>
-        /// Tries to parse a resource name in string form into a new <see cref="RootsNameOneOf"/> instance.
+        /// Tries to parse the given resource name string into a new <see cref="RootsName"/> instance.
         /// </summary>
         /// <remarks>
-        /// To parse successfully the resource name must be one of the following:
+        /// To parse successfully, the resource name must be formatted as one of the following:
         /// <list type="bullet">
-        /// <item><description>RootAName: A resource of type 'root_a'.</description></item>
-        /// <item><description>RootBName: A resource of type 'root_b'.</description></item>
+        /// <item><description><c>root_a/{root_a}</c></description></item>
+        /// <item><description><c>root_b/{root_b}</c></description></item>
         /// </list>
-        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>
         /// </remarks>
-        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="rootsName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="RootsName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string rootsName, out RootsName result) => TryParse(rootsName, false, out result);
+
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="RootsName"/> instance; optionally
+        /// allowing an unknown resource name to be successfully parsed.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet">
+        /// <item><description><c>root_a/{root_a}</c></description></item>
+        /// <item><description><c>root_b/{root_b}</c></description></item>
+        /// </list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="rootsName">The resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="allowUnknown">
-        /// If <c>true</c>, will successfully parse an unknown resource name into an
-        /// <see cref="gax::UnknownResourceName"/>.
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
         /// </param>
         /// <param name="result">
-        /// When this method returns, the parsed <see cref="RootsNameOneOf"/>, or <c>null</c> if parsing fails.
+        /// When this method returns, the parsed <see cref="RootsName"/>, or <c>null</c> if parsing failed.
         /// </param>
-        /// <returns><c>true</c> if the name was parsed succssfully; othrewise <c>false</c></returns>
-        public static bool TryParse(string name, bool allowUnknown, out RootsNameOneOf result)
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string rootsName, bool allowUnknown, out RootsName result)
         {
-            gax::GaxPreconditions.CheckNotNull(name, nameof(name));
-            if (RootAName.TryParse(name, out RootAName rootAName))
+            gax::GaxPreconditions.CheckNotNull(rootsName, nameof(rootsName));
+            gax::TemplatedResourceName resourceName;
+            if (s_rootA.TryParseName(rootsName, out resourceName))
             {
-                result = new RootsNameOneOf(OneofType.RootAName, rootAName);
+                result = CreateRootA(resourceName[0]);
                 return true;
             }
-            if (RootBName.TryParse(name, out RootBName rootBName))
+            if (s_rootB.TryParseName(rootsName, out resourceName))
             {
-                result = new RootsNameOneOf(OneofType.RootBName, rootBName);
+                result = CreateRootB(resourceName[0]);
                 return true;
             }
             if (allowUnknown)
             {
-                if (gax::UnknownResourceName.TryParse(name, out gax::UnknownResourceName unknownResourceName))
+                if (gax::UnknownResourceName.TryParse(rootsName, out gax::UnknownResourceName unknownResourceName))
                 {
-                    result = new RootsNameOneOf(OneofType.Unknown, unknownResourceName);
+                    result = CreateUnknown(unknownResourceName);
                     return true;
                 }
             }
@@ -837,106 +851,81 @@ namespace Testing.ChildResource
             return false;
         }
 
-        /// <summary>
-        /// Constructs a new instance of <see cref="RootsNameOneOf"/> from the provided <see cref="RootAName"/>.
-        /// </summary>
-        /// <param name="rootAName">
-        /// The <see cref="RootAName"/> to be contained within the returned <see cref="RootsNameOneOf"/>. Must not be
-        /// <c>null</c>
-        /// </param>
-        /// <returns>A new <see cref="RootsNameOneOf"/>, containing <paramref name="rootAName"/>.</returns>
-        public static RootsNameOneOf From(RootAName rootAName) => new RootsNameOneOf(OneofType.RootAName, rootAName);
+        private RootsName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string rootAId = null, string rootBId = null)
+        {
+            Type = type;
+            UnknownResource = unknownResourceName;
+            RootAId = rootAId;
+            RootBId = rootBId;
+        }
 
         /// <summary>
-        /// Constructs a new instance of <see cref="RootsNameOneOf"/> from the provided <see cref="RootBName"/>.
+        /// Constructs a new instance of a <see cref="RootsName"/> class from the component parts of pattern
+        /// <c>root_a/{root_a}</c>
         /// </summary>
-        /// <param name="rootBName">
-        /// The <see cref="RootBName"/> to be contained within the returned <see cref="RootsNameOneOf"/>. Must not be
-        /// <c>null</c>
-        /// </param>
-        /// <returns>A new <see cref="RootsNameOneOf"/>, containing <paramref name="rootBName"/>.</returns>
-        public static RootsNameOneOf From(RootBName rootBName) => new RootsNameOneOf(OneofType.RootBName, rootBName);
-
-        private static bool IsValid(OneofType type, gax::IResourceName name)
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        public RootsName(string rootAId) : this(ResourceType.RootA, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)))
         {
-            switch (type)
-            {
-                case OneofType.Unknown: return true;
-                case OneofType.RootAName: return name is RootAName;
-                case OneofType.RootBName: return name is RootBName;
-                default: return false;
-            }
         }
 
-        public RootsNameOneOf(OneofType type, gax::IResourceName name)
-        {
-            Type = gax::GaxPreconditions.CheckEnumValue<OneofType>(type, nameof(type));
-            Name = gax::GaxPreconditions.CheckNotNull(name, nameof(name));
-            if (!IsValid(type, name))
-            {
-                throw new sys::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
-            }
-        }
+        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
+        public ResourceType Type { get; }
 
-        /// <summary>The <see cref="OneofType"/> of the Name contained in this instance.</summary>
-        public OneofType Type { get; }
+        /// <summary>
+        /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
+        /// unknown resource name.
+        /// </summary>
+        public gax::UnknownResourceName UnknownResource { get; }
 
-        /// <summary>The <see cref="gax::IResourceName"/> contained in this instance.</summary>
-        public gax::IResourceName Name { get; }
+        /// <summary>
+        /// The <c>RootA</c> ID. May be <c>null</c>, depending on which resource name is contained by this instance.
+        /// </summary>
+        public string RootAId { get; }
 
-        private T CheckAndReturn<T>(OneofType type)
-        {
-            if (Type != type)
-            {
-                throw new sys::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
-            }
-            return (T)Name;
-        }
-
-        /// <summary>Get the contained <see cref="gax::IResourceName"/> as <see cref="RootAName"/>.</summary>
-        /// <remarks>
-        /// An <see cref="sys::InvalidOperationException"/> will be thrown is this does not contain an instance of
-        /// <see cref="RootAName"/>.
-        /// </remarks>
-        public RootAName RootAName => CheckAndReturn<RootAName>(OneofType.RootAName);
-
-        /// <summary>Get the contained <see cref="gax::IResourceName"/> as <see cref="RootBName"/>.</summary>
-        /// <remarks>
-        /// An <see cref="sys::InvalidOperationException"/> will be thrown is this does not contain an instance of
-        /// <see cref="RootBName"/>.
-        /// </remarks>
-        public RootBName RootBName => CheckAndReturn<RootBName>(OneofType.RootBName);
+        /// <summary>
+        /// The <c>RootB</c> ID. May be <c>null</c>, depending on which resource name is contained by this instance.
+        /// </summary>
+        public string RootBId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Oneof;
+        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Oneof;
 
         /// <inheritdoc/>
-        public override string ToString() => this.Name.ToString();
+        public override string ToString()
+        {
+            switch (Type)
+            {
+                case ResourceType.Unknown: return UnknownResource.ToString();
+                case ResourceType.RootA: return s_rootA.Expand(RootAId);
+                case ResourceType.RootB: return s_rootB.Expand(RootBId);
+                default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
+            }
+        }
 
         /// <inheritdoc/>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as RootsNameOneOf);
+        public override bool Equals(object obj) => Equals(obj as RootsName);
 
         /// <inheritdoc/>
-        public bool Equals(RootsNameOneOf other) => ToString() == other?.ToString();
+        public bool Equals(RootsName other) => ToString() == other?.ToString();
 
         /// <inheritdoc/>
-        public static bool operator ==(RootsNameOneOf a, RootsNameOneOf b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+        public static bool operator ==(RootsName a, RootsName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
 
         /// <inheritdoc/>
-        public static bool operator !=(RootsNameOneOf a, RootsNameOneOf b) => !(a == b);
+        public static bool operator !=(RootsName a, RootsName b) => !(a == b);
     }
 
     public partial class ProjectRef
     {
         /// <summary>
-        /// <see cref="ProjectName"/>-typed view over the <see cref="ProjectUserParent"/> resource name property.
+        /// <see cref="ProjectUserName"/>-typed view over the <see cref="ProjectUserParent"/> resource name property.
         /// </summary>
-        public ProjectName ProjectUserParentAsProjectName
+        public ProjectUserName ProjectUserParentAsProjectUserName
         {
-            get => string.IsNullOrEmpty(ProjectUserParent) ? null : ProjectName.Parse(ProjectUserParent);
+            get => string.IsNullOrEmpty(ProjectUserParent) ? null : ProjectUserName.Parse(ProjectUserParent);
             set => ProjectUserParent = value?.ToString() ?? "";
         }
     }
@@ -944,11 +933,11 @@ namespace Testing.ChildResource
     public partial class MultiRootRef
     {
         /// <summary>
-        /// <see cref="RootsNameOneOf"/>-typed view over the <see cref="MultiRootParent"/> resource name property.
+        /// <see cref="MultiRootItemName"/>-typed view over the <see cref="MultiRootParent"/> resource name property.
         /// </summary>
-        public RootsNameOneOf MultiRootParentAsRootsNameOneOf
+        public MultiRootItemName MultiRootParentAsMultiRootItemName
         {
-            get => string.IsNullOrEmpty(MultiRootParent) ? null : RootsNameOneOf.Parse(MultiRootParent, true);
+            get => string.IsNullOrEmpty(MultiRootParent) ? null : MultiRootItemName.Parse(MultiRootParent);
             set => MultiRootParent = value?.ToString() ?? "";
         }
     }

--- a/Google.Api.Generator.Tests/ProtoTests/ChildResource/Testing.ChildResource/ChildResourceResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ChildResource/Testing.ChildResource/ChildResourceResourceNames.g.cs
@@ -23,12 +23,12 @@ namespace Testing.ChildResource
     public sealed partial class ProjectName : gax::IResourceName, sys::IEquatable<ProjectName>
     {
         /// <summary>The possible contents of <see cref="ProjectName"/>.</summary>
-        public enum ResourceType
+        public enum ResourceNameType
         {
             /// <summary>A resource of an unknown type.</summary>
             Unknown = 0,
 
-            /// <summary>A resource of type 'project'.</summary>
+            /// <summary>A resource name with pattern <c>projects/{project}</c>.</summary>
             Project = 1
         }
 
@@ -39,14 +39,14 @@ namespace Testing.ChildResource
         /// <returns>
         /// A new instance of <see cref="ProjectName"/> containing the provided <paramref name="unknownResourceName"/>.
         /// </returns>
-        public static ProjectName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
-            new ProjectName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+        public static ProjectName FromUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new ProjectName(ResourceNameType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
 
         /// <summary>Creates a <see cref="ProjectName"/> with the pattern <c>projects/{project}</c>.</summary>
         /// <param name="projectId">The <c>Project</c> ID. Must not be <c>null</c> or empty.</param>
         /// <returns>A new instance of <see cref="ProjectName"/> constructed from the provided ids.</returns>
-        public static ProjectName CreateProject(string projectId) =>
-            new ProjectName(ResourceType.Project, projectId: gax::GaxPreconditions.CheckNotNullOrEmpty(projectId, nameof(projectId)));
+        public static ProjectName FromProject(string projectId) =>
+            new ProjectName(ResourceNameType.Project, projectId: gax::GaxPreconditions.CheckNotNullOrEmpty(projectId, nameof(projectId)));
 
         /// <summary>
         /// Formats the IDs into the string representation of this <see cref="ProjectName"/> with pattern
@@ -136,14 +136,14 @@ namespace Testing.ChildResource
             gax::TemplatedResourceName resourceName;
             if (s_project.TryParseName(projectName, out resourceName))
             {
-                result = CreateProject(resourceName[0]);
+                result = FromProject(resourceName[0]);
                 return true;
             }
             if (allowUnknown)
             {
                 if (gax::UnknownResourceName.TryParse(projectName, out gax::UnknownResourceName unknownResourceName))
                 {
-                    result = CreateUnknown(unknownResourceName);
+                    result = FromUnknown(unknownResourceName);
                     return true;
                 }
             }
@@ -151,7 +151,7 @@ namespace Testing.ChildResource
             return false;
         }
 
-        private ProjectName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string projectId = null)
+        private ProjectName(ResourceNameType type, gax::UnknownResourceName unknownResourceName = null, string projectId = null)
         {
             Type = type;
             UnknownResource = unknownResourceName;
@@ -163,12 +163,12 @@ namespace Testing.ChildResource
         /// <c>projects/{project}</c>
         /// </summary>
         /// <param name="projectId">The <c>Project</c> ID. Must not be <c>null</c> or empty.</param>
-        public ProjectName(string projectId) : this(ResourceType.Project, projectId: gax::GaxPreconditions.CheckNotNullOrEmpty(projectId, nameof(projectId)))
+        public ProjectName(string projectId) : this(ResourceNameType.Project, projectId: gax::GaxPreconditions.CheckNotNullOrEmpty(projectId, nameof(projectId)))
         {
         }
 
-        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
-        public ResourceType Type { get; }
+        /// <summary>The <see cref="ResourceNameType"/> of the contained resource name.</summary>
+        public ResourceNameType Type { get; }
 
         /// <summary>
         /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
@@ -182,15 +182,15 @@ namespace Testing.ChildResource
         public string ProjectId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
+        public gax::ResourceNameKind Kind => Type == ResourceNameType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
 
         /// <inheritdoc/>
         public override string ToString()
         {
             switch (Type)
             {
-                case ResourceType.Unknown: return UnknownResource.ToString();
-                case ResourceType.Project: return s_project.Expand(ProjectId);
+                case ResourceNameType.Unknown: return UnknownResource.ToString();
+                case ResourceNameType.Project: return s_project.Expand(ProjectId);
                 default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
             }
         }
@@ -215,12 +215,12 @@ namespace Testing.ChildResource
     public sealed partial class ProjectUserName : gax::IResourceName, sys::IEquatable<ProjectUserName>
     {
         /// <summary>The possible contents of <see cref="ProjectUserName"/>.</summary>
-        public enum ResourceType
+        public enum ResourceNameType
         {
             /// <summary>A resource of an unknown type.</summary>
             Unknown = 0,
 
-            /// <summary>A resource of type 'project'.</summary>
+            /// <summary>A resource name with pattern <c>projects/{project}/users/{user}</c>.</summary>
             ProjectUser = 1
         }
 
@@ -232,8 +232,8 @@ namespace Testing.ChildResource
         /// A new instance of <see cref="ProjectUserName"/> containing the provided
         /// <paramref name="unknownResourceName"/>.
         /// </returns>
-        public static ProjectUserName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
-            new ProjectUserName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+        public static ProjectUserName FromUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new ProjectUserName(ResourceNameType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
 
         /// <summary>
         /// Creates a <see cref="ProjectUserName"/> with the pattern <c>projects/{project}/users/{user}</c>.
@@ -241,8 +241,8 @@ namespace Testing.ChildResource
         /// <param name="projectId">The <c>Project</c> ID. Must not be <c>null</c> or empty.</param>
         /// <param name="userId">The <c>User</c> ID. Must not be <c>null</c> or empty.</param>
         /// <returns>A new instance of <see cref="ProjectUserName"/> constructed from the provided ids.</returns>
-        public static ProjectUserName CreateProjectUser(string projectId, string userId) =>
-            new ProjectUserName(ResourceType.ProjectUser, projectId: gax::GaxPreconditions.CheckNotNullOrEmpty(projectId, nameof(projectId)), userId: gax::GaxPreconditions.CheckNotNullOrEmpty(userId, nameof(userId)));
+        public static ProjectUserName FromProjectUser(string projectId, string userId) =>
+            new ProjectUserName(ResourceNameType.ProjectUser, projectId: gax::GaxPreconditions.CheckNotNullOrEmpty(projectId, nameof(projectId)), userId: gax::GaxPreconditions.CheckNotNullOrEmpty(userId, nameof(userId)));
 
         /// <summary>
         /// Formats the IDs into the string representation of this <see cref="ProjectUserName"/> with pattern
@@ -337,14 +337,14 @@ namespace Testing.ChildResource
             gax::TemplatedResourceName resourceName;
             if (s_projectUser.TryParseName(projectUserName, out resourceName))
             {
-                result = CreateProjectUser(resourceName[0], resourceName[1]);
+                result = FromProjectUser(resourceName[0], resourceName[1]);
                 return true;
             }
             if (allowUnknown)
             {
                 if (gax::UnknownResourceName.TryParse(projectUserName, out gax::UnknownResourceName unknownResourceName))
                 {
-                    result = CreateUnknown(unknownResourceName);
+                    result = FromUnknown(unknownResourceName);
                     return true;
                 }
             }
@@ -352,7 +352,7 @@ namespace Testing.ChildResource
             return false;
         }
 
-        private ProjectUserName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string projectId = null, string userId = null)
+        private ProjectUserName(ResourceNameType type, gax::UnknownResourceName unknownResourceName = null, string projectId = null, string userId = null)
         {
             Type = type;
             UnknownResource = unknownResourceName;
@@ -366,12 +366,12 @@ namespace Testing.ChildResource
         /// </summary>
         /// <param name="projectId">The <c>Project</c> ID. Must not be <c>null</c> or empty.</param>
         /// <param name="userId">The <c>User</c> ID. Must not be <c>null</c> or empty.</param>
-        public ProjectUserName(string projectId, string userId) : this(ResourceType.ProjectUser, projectId: gax::GaxPreconditions.CheckNotNullOrEmpty(projectId, nameof(projectId)), userId: gax::GaxPreconditions.CheckNotNullOrEmpty(userId, nameof(userId)))
+        public ProjectUserName(string projectId, string userId) : this(ResourceNameType.ProjectUser, projectId: gax::GaxPreconditions.CheckNotNullOrEmpty(projectId, nameof(projectId)), userId: gax::GaxPreconditions.CheckNotNullOrEmpty(userId, nameof(userId)))
         {
         }
 
-        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
-        public ResourceType Type { get; }
+        /// <summary>The <see cref="ResourceNameType"/> of the contained resource name.</summary>
+        public ResourceNameType Type { get; }
 
         /// <summary>
         /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
@@ -390,15 +390,15 @@ namespace Testing.ChildResource
         public string UserId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
+        public gax::ResourceNameKind Kind => Type == ResourceNameType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
 
         /// <inheritdoc/>
         public override string ToString()
         {
             switch (Type)
             {
-                case ResourceType.Unknown: return UnknownResource.ToString();
-                case ResourceType.ProjectUser: return s_projectUser.Expand(ProjectId, UserId);
+                case ResourceNameType.Unknown: return UnknownResource.ToString();
+                case ResourceNameType.ProjectUser: return s_projectUser.Expand(ProjectId, UserId);
                 default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
             }
         }
@@ -423,15 +423,15 @@ namespace Testing.ChildResource
     public sealed partial class MultiRootItemName : gax::IResourceName, sys::IEquatable<MultiRootItemName>
     {
         /// <summary>The possible contents of <see cref="MultiRootItemName"/>.</summary>
-        public enum ResourceType
+        public enum ResourceNameType
         {
             /// <summary>A resource of an unknown type.</summary>
             Unknown = 0,
 
-            /// <summary>A resource of type 'root_a'.</summary>
+            /// <summary>A resource name with pattern <c>root_a/{root_a}/items/{item}</c>.</summary>
             RootAItem = 1,
 
-            /// <summary>A resource of type 'root_b'.</summary>
+            /// <summary>A resource name with pattern <c>root_b/{root_b}/items/{item}</c>.</summary>
             RootBItem = 2
         }
 
@@ -445,8 +445,8 @@ namespace Testing.ChildResource
         /// A new instance of <see cref="MultiRootItemName"/> containing the provided
         /// <paramref name="unknownResourceName"/>.
         /// </returns>
-        public static MultiRootItemName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
-            new MultiRootItemName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+        public static MultiRootItemName FromUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new MultiRootItemName(ResourceNameType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
 
         /// <summary>
         /// Creates a <see cref="MultiRootItemName"/> with the pattern <c>root_a/{root_a}/items/{item}</c>.
@@ -454,8 +454,8 @@ namespace Testing.ChildResource
         /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
         /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
         /// <returns>A new instance of <see cref="MultiRootItemName"/> constructed from the provided ids.</returns>
-        public static MultiRootItemName CreateRootAItem(string rootAId, string itemId) =>
-            new MultiRootItemName(ResourceType.RootAItem, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+        public static MultiRootItemName FromRootAItem(string rootAId, string itemId) =>
+            new MultiRootItemName(ResourceNameType.RootAItem, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
 
         /// <summary>
         /// Creates a <see cref="MultiRootItemName"/> with the pattern <c>root_b/{root_b}/items/{item}</c>.
@@ -463,8 +463,8 @@ namespace Testing.ChildResource
         /// <param name="rootBId">The <c>RootB</c> ID. Must not be <c>null</c> or empty.</param>
         /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
         /// <returns>A new instance of <see cref="MultiRootItemName"/> constructed from the provided ids.</returns>
-        public static MultiRootItemName CreateRootBItem(string rootBId, string itemId) =>
-            new MultiRootItemName(ResourceType.RootBItem, rootBId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootBId, nameof(rootBId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+        public static MultiRootItemName FromRootBItem(string rootBId, string itemId) =>
+            new MultiRootItemName(ResourceNameType.RootBItem, rootBId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootBId, nameof(rootBId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
 
         /// <summary>
         /// Formats the IDs into the string representation of this <see cref="MultiRootItemName"/> with pattern
@@ -586,19 +586,19 @@ namespace Testing.ChildResource
             gax::TemplatedResourceName resourceName;
             if (s_rootAItem.TryParseName(multiRootItemName, out resourceName))
             {
-                result = CreateRootAItem(resourceName[0], resourceName[1]);
+                result = FromRootAItem(resourceName[0], resourceName[1]);
                 return true;
             }
             if (s_rootBItem.TryParseName(multiRootItemName, out resourceName))
             {
-                result = CreateRootBItem(resourceName[0], resourceName[1]);
+                result = FromRootBItem(resourceName[0], resourceName[1]);
                 return true;
             }
             if (allowUnknown)
             {
                 if (gax::UnknownResourceName.TryParse(multiRootItemName, out gax::UnknownResourceName unknownResourceName))
                 {
-                    result = CreateUnknown(unknownResourceName);
+                    result = FromUnknown(unknownResourceName);
                     return true;
                 }
             }
@@ -606,7 +606,7 @@ namespace Testing.ChildResource
             return false;
         }
 
-        private MultiRootItemName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null, string rootAId = null, string rootBId = null)
+        private MultiRootItemName(ResourceNameType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null, string rootAId = null, string rootBId = null)
         {
             Type = type;
             UnknownResource = unknownResourceName;
@@ -621,12 +621,12 @@ namespace Testing.ChildResource
         /// </summary>
         /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
         /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
-        public MultiRootItemName(string rootAId, string itemId) : this(ResourceType.RootAItem, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
+        public MultiRootItemName(string rootAId, string itemId) : this(ResourceNameType.RootAItem, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
         {
         }
 
-        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
-        public ResourceType Type { get; }
+        /// <summary>The <see cref="ResourceNameType"/> of the contained resource name.</summary>
+        public ResourceNameType Type { get; }
 
         /// <summary>
         /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
@@ -650,16 +650,16 @@ namespace Testing.ChildResource
         public string RootBId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Oneof;
+        public gax::ResourceNameKind Kind => Type == ResourceNameType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Oneof;
 
         /// <inheritdoc/>
         public override string ToString()
         {
             switch (Type)
             {
-                case ResourceType.Unknown: return UnknownResource.ToString();
-                case ResourceType.RootAItem: return s_rootAItem.Expand(RootAId, ItemId);
-                case ResourceType.RootBItem: return s_rootBItem.Expand(RootBId, ItemId);
+                case ResourceNameType.Unknown: return UnknownResource.ToString();
+                case ResourceNameType.RootAItem: return s_rootAItem.Expand(RootAId, ItemId);
+                case ResourceNameType.RootBItem: return s_rootBItem.Expand(RootBId, ItemId);
                 default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
             }
         }
@@ -684,15 +684,15 @@ namespace Testing.ChildResource
     public sealed partial class RootsName : gax::IResourceName, sys::IEquatable<RootsName>
     {
         /// <summary>The possible contents of <see cref="RootsName"/>.</summary>
-        public enum ResourceType
+        public enum ResourceNameType
         {
             /// <summary>A resource of an unknown type.</summary>
             Unknown = 0,
 
-            /// <summary>A resource of type 'root_a'.</summary>
+            /// <summary>A resource name with pattern <c>root_a/{root_a}</c>.</summary>
             RootA = 1,
 
-            /// <summary>A resource of type 'root_b'.</summary>
+            /// <summary>A resource name with pattern <c>root_b/{root_b}</c>.</summary>
             RootB = 2
         }
 
@@ -705,20 +705,20 @@ namespace Testing.ChildResource
         /// <returns>
         /// A new instance of <see cref="RootsName"/> containing the provided <paramref name="unknownResourceName"/>.
         /// </returns>
-        public static RootsName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
-            new RootsName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+        public static RootsName FromUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new RootsName(ResourceNameType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
 
         /// <summary>Creates a <see cref="RootsName"/> with the pattern <c>root_a/{root_a}</c>.</summary>
         /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
         /// <returns>A new instance of <see cref="RootsName"/> constructed from the provided ids.</returns>
-        public static RootsName CreateRootA(string rootAId) =>
-            new RootsName(ResourceType.RootA, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)));
+        public static RootsName FromRootA(string rootAId) =>
+            new RootsName(ResourceNameType.RootA, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)));
 
         /// <summary>Creates a <see cref="RootsName"/> with the pattern <c>root_b/{root_b}</c>.</summary>
         /// <param name="rootBId">The <c>RootB</c> ID. Must not be <c>null</c> or empty.</param>
         /// <returns>A new instance of <see cref="RootsName"/> constructed from the provided ids.</returns>
-        public static RootsName CreateRootB(string rootBId) =>
-            new RootsName(ResourceType.RootB, rootBId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootBId, nameof(rootBId)));
+        public static RootsName FromRootB(string rootBId) =>
+            new RootsName(ResourceNameType.RootB, rootBId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootBId, nameof(rootBId)));
 
         /// <summary>
         /// Formats the IDs into the string representation of this <see cref="RootsName"/> with pattern
@@ -831,19 +831,19 @@ namespace Testing.ChildResource
             gax::TemplatedResourceName resourceName;
             if (s_rootA.TryParseName(rootsName, out resourceName))
             {
-                result = CreateRootA(resourceName[0]);
+                result = FromRootA(resourceName[0]);
                 return true;
             }
             if (s_rootB.TryParseName(rootsName, out resourceName))
             {
-                result = CreateRootB(resourceName[0]);
+                result = FromRootB(resourceName[0]);
                 return true;
             }
             if (allowUnknown)
             {
                 if (gax::UnknownResourceName.TryParse(rootsName, out gax::UnknownResourceName unknownResourceName))
                 {
-                    result = CreateUnknown(unknownResourceName);
+                    result = FromUnknown(unknownResourceName);
                     return true;
                 }
             }
@@ -851,7 +851,7 @@ namespace Testing.ChildResource
             return false;
         }
 
-        private RootsName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string rootAId = null, string rootBId = null)
+        private RootsName(ResourceNameType type, gax::UnknownResourceName unknownResourceName = null, string rootAId = null, string rootBId = null)
         {
             Type = type;
             UnknownResource = unknownResourceName;
@@ -864,12 +864,12 @@ namespace Testing.ChildResource
         /// <c>root_a/{root_a}</c>
         /// </summary>
         /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
-        public RootsName(string rootAId) : this(ResourceType.RootA, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)))
+        public RootsName(string rootAId) : this(ResourceNameType.RootA, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)))
         {
         }
 
-        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
-        public ResourceType Type { get; }
+        /// <summary>The <see cref="ResourceNameType"/> of the contained resource name.</summary>
+        public ResourceNameType Type { get; }
 
         /// <summary>
         /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
@@ -888,16 +888,16 @@ namespace Testing.ChildResource
         public string RootBId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Oneof;
+        public gax::ResourceNameKind Kind => Type == ResourceNameType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Oneof;
 
         /// <inheritdoc/>
         public override string ToString()
         {
             switch (Type)
             {
-                case ResourceType.Unknown: return UnknownResource.ToString();
-                case ResourceType.RootA: return s_rootA.Expand(RootAId);
-                case ResourceType.RootB: return s_rootB.Expand(RootBId);
+                case ResourceNameType.Unknown: return UnknownResource.ToString();
+                case ResourceNameType.RootA: return s_rootA.Expand(RootAId);
+                case ResourceNameType.RootB: return s_rootB.Expand(RootBId);
                 default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
             }
         }

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.Snippets/KeywordsClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.Snippets/KeywordsClientSnippets.g.cs
@@ -30,7 +30,7 @@ namespace Testing.Keywords.Snippets
             // Initialize request argument(s)
             Request request = new Request
             {
-                EventAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
+                EventAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
                 Switch = 0,
                 Void = Enum.Void,
             };
@@ -49,7 +49,7 @@ namespace Testing.Keywords.Snippets
             // Initialize request argument(s)
             Request request = new Request
             {
-                EventAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
+                EventAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
                 Switch = 0,
                 Void = Enum.Void,
             };
@@ -96,7 +96,7 @@ namespace Testing.Keywords.Snippets
             // Create client
             KeywordsClient keywordsClient = KeywordsClient.Create();
             // Initialize request argument(s)
-            ResourceName @event = ResourceName.CreateItem("[ITEM_ID]");
+            ResourceName @event = ResourceName.FromItem("[ITEM_ID]");
             int @switch = 0;
             Enum @void = Enum.Void;
             // Make the request
@@ -112,7 +112,7 @@ namespace Testing.Keywords.Snippets
             // Create client
             KeywordsClient keywordsClient = await KeywordsClient.CreateAsync();
             // Initialize request argument(s)
-            ResourceName @event = ResourceName.CreateItem("[ITEM_ID]");
+            ResourceName @event = ResourceName.FromItem("[ITEM_ID]");
             int @switch = 0;
             Enum @void = Enum.Void;
             // Make the request
@@ -129,7 +129,7 @@ namespace Testing.Keywords.Snippets
             // Initialize request argument(s)
             Resource request = new Resource
             {
-                WhileAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
+                WhileAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
                 Enum = Enum.Void,
             };
             // Make the request
@@ -147,7 +147,7 @@ namespace Testing.Keywords.Snippets
             // Initialize request argument(s)
             Resource request = new Resource
             {
-                WhileAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
+                WhileAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
                 Enum = Enum.Void,
             };
             // Make the request
@@ -191,7 +191,7 @@ namespace Testing.Keywords.Snippets
             // Create client
             KeywordsClient keywordsClient = KeywordsClient.Create();
             // Initialize request argument(s)
-            ResourceName @while = ResourceName.CreateItem("[ITEM_ID]");
+            ResourceName @while = ResourceName.FromItem("[ITEM_ID]");
             Enum @enum = Enum.Void;
             // Make the request
             Response response = keywordsClient.Method2(@while, @enum);
@@ -206,7 +206,7 @@ namespace Testing.Keywords.Snippets
             // Create client
             KeywordsClient keywordsClient = await KeywordsClient.CreateAsync();
             // Initialize request argument(s)
-            ResourceName @while = ResourceName.CreateItem("[ITEM_ID]");
+            ResourceName @while = ResourceName.FromItem("[ITEM_ID]");
             Enum @enum = Enum.Void;
             // Make the request
             Response response = await keywordsClient.Method2Async(@while, @enum);

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.Snippets/KeywordsClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.Snippets/KeywordsClientSnippets.g.cs
@@ -30,7 +30,7 @@ namespace Testing.Keywords.Snippets
             // Initialize request argument(s)
             Request request = new Request
             {
-                EventAsResourceName = new ResourceName("[ITEM_ID]"),
+                EventAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
                 Switch = 0,
                 Void = Enum.Void,
             };
@@ -49,7 +49,7 @@ namespace Testing.Keywords.Snippets
             // Initialize request argument(s)
             Request request = new Request
             {
-                EventAsResourceName = new ResourceName("[ITEM_ID]"),
+                EventAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
                 Switch = 0,
                 Void = Enum.Void,
             };
@@ -96,7 +96,7 @@ namespace Testing.Keywords.Snippets
             // Create client
             KeywordsClient keywordsClient = KeywordsClient.Create();
             // Initialize request argument(s)
-            ResourceName @event = new ResourceName("[ITEM_ID]");
+            ResourceName @event = ResourceName.CreateItem("[ITEM_ID]");
             int @switch = 0;
             Enum @void = Enum.Void;
             // Make the request
@@ -112,7 +112,7 @@ namespace Testing.Keywords.Snippets
             // Create client
             KeywordsClient keywordsClient = await KeywordsClient.CreateAsync();
             // Initialize request argument(s)
-            ResourceName @event = new ResourceName("[ITEM_ID]");
+            ResourceName @event = ResourceName.CreateItem("[ITEM_ID]");
             int @switch = 0;
             Enum @void = Enum.Void;
             // Make the request
@@ -129,7 +129,7 @@ namespace Testing.Keywords.Snippets
             // Initialize request argument(s)
             Resource request = new Resource
             {
-                WhileAsResourceName = new ResourceName("[ITEM_ID]"),
+                WhileAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
                 Enum = Enum.Void,
             };
             // Make the request
@@ -147,7 +147,7 @@ namespace Testing.Keywords.Snippets
             // Initialize request argument(s)
             Resource request = new Resource
             {
-                WhileAsResourceName = new ResourceName("[ITEM_ID]"),
+                WhileAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
                 Enum = Enum.Void,
             };
             // Make the request
@@ -191,7 +191,7 @@ namespace Testing.Keywords.Snippets
             // Create client
             KeywordsClient keywordsClient = KeywordsClient.Create();
             // Initialize request argument(s)
-            ResourceName @while = new ResourceName("[ITEM_ID]");
+            ResourceName @while = ResourceName.CreateItem("[ITEM_ID]");
             Enum @enum = Enum.Void;
             // Make the request
             Response response = keywordsClient.Method2(@while, @enum);
@@ -206,7 +206,7 @@ namespace Testing.Keywords.Snippets
             // Create client
             KeywordsClient keywordsClient = await KeywordsClient.CreateAsync();
             // Initialize request argument(s)
-            ResourceName @while = new ResourceName("[ITEM_ID]");
+            ResourceName @while = ResourceName.CreateItem("[ITEM_ID]");
             Enum @enum = Enum.Void;
             // Make the request
             Response response = await keywordsClient.Method2Async(@while, @enum);

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.Tests/KeywordsClientTest.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.Tests/KeywordsClientTest.g.cs
@@ -32,7 +32,7 @@ namespace Testing.Keywords.Tests
             moq::Mock<Keywords.KeywordsClient> mockGrpcClient = new moq::Mock<Keywords.KeywordsClient>(moq::MockBehavior.Strict);
             Request request = new Request
             {
-                EventAsResourceName = new ResourceName("[ITEM_ID]"),
+                EventAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
                 Switch = -1514770765,
                 Void = Enum.Foreach,
             };
@@ -50,7 +50,7 @@ namespace Testing.Keywords.Tests
             moq::Mock<Keywords.KeywordsClient> mockGrpcClient = new moq::Mock<Keywords.KeywordsClient>(moq::MockBehavior.Strict);
             Request request = new Request
             {
-                EventAsResourceName = new ResourceName("[ITEM_ID]"),
+                EventAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
                 Switch = -1514770765,
                 Void = Enum.Foreach,
             };
@@ -70,7 +70,7 @@ namespace Testing.Keywords.Tests
             moq::Mock<Keywords.KeywordsClient> mockGrpcClient = new moq::Mock<Keywords.KeywordsClient>(moq::MockBehavior.Strict);
             Request request = new Request
             {
-                EventAsResourceName = new ResourceName("[ITEM_ID]"),
+                EventAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
                 Switch = -1514770765,
                 Void = Enum.Foreach,
             };
@@ -88,7 +88,7 @@ namespace Testing.Keywords.Tests
             moq::Mock<Keywords.KeywordsClient> mockGrpcClient = new moq::Mock<Keywords.KeywordsClient>(moq::MockBehavior.Strict);
             Request request = new Request
             {
-                EventAsResourceName = new ResourceName("[ITEM_ID]"),
+                EventAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
                 Switch = -1514770765,
                 Void = Enum.Foreach,
             };
@@ -108,7 +108,7 @@ namespace Testing.Keywords.Tests
             moq::Mock<Keywords.KeywordsClient> mockGrpcClient = new moq::Mock<Keywords.KeywordsClient>(moq::MockBehavior.Strict);
             Request request = new Request
             {
-                EventAsResourceName = new ResourceName("[ITEM_ID]"),
+                EventAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
                 Switch = -1514770765,
                 Void = Enum.Foreach,
             };
@@ -126,7 +126,7 @@ namespace Testing.Keywords.Tests
             moq::Mock<Keywords.KeywordsClient> mockGrpcClient = new moq::Mock<Keywords.KeywordsClient>(moq::MockBehavior.Strict);
             Request request = new Request
             {
-                EventAsResourceName = new ResourceName("[ITEM_ID]"),
+                EventAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
                 Switch = -1514770765,
                 Void = Enum.Foreach,
             };
@@ -146,7 +146,7 @@ namespace Testing.Keywords.Tests
             moq::Mock<Keywords.KeywordsClient> mockGrpcClient = new moq::Mock<Keywords.KeywordsClient>(moq::MockBehavior.Strict);
             Resource request = new Resource
             {
-                WhileAsResourceName = new ResourceName("[ITEM_ID]"),
+                WhileAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
                 Enum = Enum.For,
             };
             Response expectedResponse = new Response { };
@@ -163,7 +163,7 @@ namespace Testing.Keywords.Tests
             moq::Mock<Keywords.KeywordsClient> mockGrpcClient = new moq::Mock<Keywords.KeywordsClient>(moq::MockBehavior.Strict);
             Resource request = new Resource
             {
-                WhileAsResourceName = new ResourceName("[ITEM_ID]"),
+                WhileAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
                 Enum = Enum.For,
             };
             Response expectedResponse = new Response { };
@@ -182,7 +182,7 @@ namespace Testing.Keywords.Tests
             moq::Mock<Keywords.KeywordsClient> mockGrpcClient = new moq::Mock<Keywords.KeywordsClient>(moq::MockBehavior.Strict);
             Resource request = new Resource
             {
-                WhileAsResourceName = new ResourceName("[ITEM_ID]"),
+                WhileAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
                 Enum = Enum.For,
             };
             Response expectedResponse = new Response { };
@@ -199,7 +199,7 @@ namespace Testing.Keywords.Tests
             moq::Mock<Keywords.KeywordsClient> mockGrpcClient = new moq::Mock<Keywords.KeywordsClient>(moq::MockBehavior.Strict);
             Resource request = new Resource
             {
-                WhileAsResourceName = new ResourceName("[ITEM_ID]"),
+                WhileAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
                 Enum = Enum.For,
             };
             Response expectedResponse = new Response { };
@@ -218,7 +218,7 @@ namespace Testing.Keywords.Tests
             moq::Mock<Keywords.KeywordsClient> mockGrpcClient = new moq::Mock<Keywords.KeywordsClient>(moq::MockBehavior.Strict);
             Resource request = new Resource
             {
-                WhileAsResourceName = new ResourceName("[ITEM_ID]"),
+                WhileAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
                 Enum = Enum.For,
             };
             Response expectedResponse = new Response { };
@@ -235,7 +235,7 @@ namespace Testing.Keywords.Tests
             moq::Mock<Keywords.KeywordsClient> mockGrpcClient = new moq::Mock<Keywords.KeywordsClient>(moq::MockBehavior.Strict);
             Resource request = new Resource
             {
-                WhileAsResourceName = new ResourceName("[ITEM_ID]"),
+                WhileAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
                 Enum = Enum.For,
             };
             Response expectedResponse = new Response { };

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.Tests/KeywordsClientTest.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.Tests/KeywordsClientTest.g.cs
@@ -32,7 +32,7 @@ namespace Testing.Keywords.Tests
             moq::Mock<Keywords.KeywordsClient> mockGrpcClient = new moq::Mock<Keywords.KeywordsClient>(moq::MockBehavior.Strict);
             Request request = new Request
             {
-                EventAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
+                EventAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
                 Switch = -1514770765,
                 Void = Enum.Foreach,
             };
@@ -50,7 +50,7 @@ namespace Testing.Keywords.Tests
             moq::Mock<Keywords.KeywordsClient> mockGrpcClient = new moq::Mock<Keywords.KeywordsClient>(moq::MockBehavior.Strict);
             Request request = new Request
             {
-                EventAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
+                EventAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
                 Switch = -1514770765,
                 Void = Enum.Foreach,
             };
@@ -70,7 +70,7 @@ namespace Testing.Keywords.Tests
             moq::Mock<Keywords.KeywordsClient> mockGrpcClient = new moq::Mock<Keywords.KeywordsClient>(moq::MockBehavior.Strict);
             Request request = new Request
             {
-                EventAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
+                EventAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
                 Switch = -1514770765,
                 Void = Enum.Foreach,
             };
@@ -88,7 +88,7 @@ namespace Testing.Keywords.Tests
             moq::Mock<Keywords.KeywordsClient> mockGrpcClient = new moq::Mock<Keywords.KeywordsClient>(moq::MockBehavior.Strict);
             Request request = new Request
             {
-                EventAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
+                EventAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
                 Switch = -1514770765,
                 Void = Enum.Foreach,
             };
@@ -108,7 +108,7 @@ namespace Testing.Keywords.Tests
             moq::Mock<Keywords.KeywordsClient> mockGrpcClient = new moq::Mock<Keywords.KeywordsClient>(moq::MockBehavior.Strict);
             Request request = new Request
             {
-                EventAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
+                EventAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
                 Switch = -1514770765,
                 Void = Enum.Foreach,
             };
@@ -126,7 +126,7 @@ namespace Testing.Keywords.Tests
             moq::Mock<Keywords.KeywordsClient> mockGrpcClient = new moq::Mock<Keywords.KeywordsClient>(moq::MockBehavior.Strict);
             Request request = new Request
             {
-                EventAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
+                EventAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
                 Switch = -1514770765,
                 Void = Enum.Foreach,
             };
@@ -146,7 +146,7 @@ namespace Testing.Keywords.Tests
             moq::Mock<Keywords.KeywordsClient> mockGrpcClient = new moq::Mock<Keywords.KeywordsClient>(moq::MockBehavior.Strict);
             Resource request = new Resource
             {
-                WhileAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
+                WhileAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
                 Enum = Enum.For,
             };
             Response expectedResponse = new Response { };
@@ -163,7 +163,7 @@ namespace Testing.Keywords.Tests
             moq::Mock<Keywords.KeywordsClient> mockGrpcClient = new moq::Mock<Keywords.KeywordsClient>(moq::MockBehavior.Strict);
             Resource request = new Resource
             {
-                WhileAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
+                WhileAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
                 Enum = Enum.For,
             };
             Response expectedResponse = new Response { };
@@ -182,7 +182,7 @@ namespace Testing.Keywords.Tests
             moq::Mock<Keywords.KeywordsClient> mockGrpcClient = new moq::Mock<Keywords.KeywordsClient>(moq::MockBehavior.Strict);
             Resource request = new Resource
             {
-                WhileAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
+                WhileAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
                 Enum = Enum.For,
             };
             Response expectedResponse = new Response { };
@@ -199,7 +199,7 @@ namespace Testing.Keywords.Tests
             moq::Mock<Keywords.KeywordsClient> mockGrpcClient = new moq::Mock<Keywords.KeywordsClient>(moq::MockBehavior.Strict);
             Resource request = new Resource
             {
-                WhileAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
+                WhileAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
                 Enum = Enum.For,
             };
             Response expectedResponse = new Response { };
@@ -218,7 +218,7 @@ namespace Testing.Keywords.Tests
             moq::Mock<Keywords.KeywordsClient> mockGrpcClient = new moq::Mock<Keywords.KeywordsClient>(moq::MockBehavior.Strict);
             Resource request = new Resource
             {
-                WhileAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
+                WhileAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
                 Enum = Enum.For,
             };
             Response expectedResponse = new Response { };
@@ -235,7 +235,7 @@ namespace Testing.Keywords.Tests
             moq::Mock<Keywords.KeywordsClient> mockGrpcClient = new moq::Mock<Keywords.KeywordsClient>(moq::MockBehavior.Strict);
             Resource request = new Resource
             {
-                WhileAsResourceName = ResourceName.CreateItem("[ITEM_ID]"),
+                WhileAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
                 Enum = Enum.For,
             };
             Response expectedResponse = new Response { };

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords/KeywordsResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords/KeywordsResourceNames.g.cs
@@ -23,12 +23,12 @@ namespace Testing.Keywords
     public sealed partial class ResourceName : gax::IResourceName, sys::IEquatable<ResourceName>
     {
         /// <summary>The possible contents of <see cref="ResourceName"/>.</summary>
-        public enum ResourceType
+        public enum ResourceNameType
         {
             /// <summary>A resource of an unknown type.</summary>
             Unknown = 0,
 
-            /// <summary>A resource of type 'item'.</summary>
+            /// <summary>A resource name with pattern <c>items/{item_id}</c>.</summary>
             Item = 1
         }
 
@@ -39,14 +39,14 @@ namespace Testing.Keywords
         /// <returns>
         /// A new instance of <see cref="ResourceName"/> containing the provided <paramref name="unknownResourceName"/>.
         /// </returns>
-        public static ResourceName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
-            new ResourceName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+        public static ResourceName FromUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new ResourceName(ResourceNameType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
 
         /// <summary>Creates a <see cref="ResourceName"/> with the pattern <c>items/{item_id}</c>.</summary>
         /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
         /// <returns>A new instance of <see cref="ResourceName"/> constructed from the provided ids.</returns>
-        public static ResourceName CreateItem(string itemId) =>
-            new ResourceName(ResourceType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+        public static ResourceName FromItem(string itemId) =>
+            new ResourceName(ResourceNameType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
 
         /// <summary>
         /// Formats the IDs into the string representation of this <see cref="ResourceName"/> with pattern
@@ -136,14 +136,14 @@ namespace Testing.Keywords
             gax::TemplatedResourceName resourceName2;
             if (s_item.TryParseName(resourceName, out resourceName2))
             {
-                result = CreateItem(resourceName2[0]);
+                result = FromItem(resourceName2[0]);
                 return true;
             }
             if (allowUnknown)
             {
                 if (gax::UnknownResourceName.TryParse(resourceName, out gax::UnknownResourceName unknownResourceName))
                 {
-                    result = CreateUnknown(unknownResourceName);
+                    result = FromUnknown(unknownResourceName);
                     return true;
                 }
             }
@@ -151,7 +151,7 @@ namespace Testing.Keywords
             return false;
         }
 
-        private ResourceName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null)
+        private ResourceName(ResourceNameType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null)
         {
             Type = type;
             UnknownResource = unknownResourceName;
@@ -163,12 +163,12 @@ namespace Testing.Keywords
         /// <c>items/{item_id}</c>
         /// </summary>
         /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
-        public ResourceName(string itemId) : this(ResourceType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
+        public ResourceName(string itemId) : this(ResourceNameType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
         {
         }
 
-        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
-        public ResourceType Type { get; }
+        /// <summary>The <see cref="ResourceNameType"/> of the contained resource name.</summary>
+        public ResourceNameType Type { get; }
 
         /// <summary>
         /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
@@ -182,15 +182,15 @@ namespace Testing.Keywords
         public string ItemId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
+        public gax::ResourceNameKind Kind => Type == ResourceNameType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
 
         /// <inheritdoc/>
         public override string ToString()
         {
             switch (Type)
             {
-                case ResourceType.Unknown: return UnknownResource.ToString();
-                case ResourceType.Item: return s_item.Expand(ItemId);
+                case ResourceNameType.Unknown: return UnknownResource.ToString();
+                case ResourceNameType.Item: return s_item.Expand(ItemId);
                 default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
             }
         }

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords/KeywordsResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords/KeywordsResourceNames.g.cs
@@ -22,73 +22,178 @@ namespace Testing.Keywords
     /// <summary>Resource name for the <c>Resource</c> resource.</summary>
     public sealed partial class ResourceName : gax::IResourceName, sys::IEquatable<ResourceName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("items/{item_id}");
-
-        /// <summary>
-        /// Parses the given <c>Resource</c> resource name in string form into a new <see cref="ResourceName"/>
-        /// instance.
-        /// </summary>
-        /// <param name="resourceName">
-        /// The <c>Resource</c> resource name in string form. Must not be <c>null</c>.
-        /// </param>
-        /// <returns>The parsed <see cref="ResourceName"/> if successful.</returns>
-        public static ResourceName Parse(string resourceName)
+        /// <summary>The possible contents of <see cref="ResourceName"/>.</summary>
+        public enum ResourceType
         {
-            gax::GaxPreconditions.CheckNotNull(resourceName, nameof(resourceName));
-            gax::TemplatedResourceName resourceName2 = s_template.ParseName(resourceName);
-            return new ResourceName(resourceName2[0]);
+            /// <summary>A resource of an unknown type.</summary>
+            Unknown = 0,
+
+            /// <summary>A resource of type 'item'.</summary>
+            Item = 1
         }
 
+        private static gax::PathTemplate s_item = new gax::PathTemplate("items/{item_id}");
+
+        /// <summary>Creates a <see cref="ResourceName"/> containing an unknown resource name.</summary>
+        /// <param name="unknownResourceName">The unknown resource name. Must not be <c>null</c>.</param>
+        /// <returns>
+        /// A new instance of <see cref="ResourceName"/> containing the provided <paramref name="unknownResourceName"/>.
+        /// </returns>
+        public static ResourceName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new ResourceName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+
+        /// <summary>Creates a <see cref="ResourceName"/> with the pattern <c>items/{item_id}</c>.</summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>A new instance of <see cref="ResourceName"/> constructed from the provided ids.</returns>
+        public static ResourceName CreateItem(string itemId) =>
+            new ResourceName(ResourceType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+
         /// <summary>
-        /// Tries to parse the given session resource name in string form into a new <see cref="ResourceName"/>
-        /// instance.
+        /// Formats the IDs into the string representation of this <see cref="ResourceName"/> with pattern
+        /// <c>items/{item_id}</c>.
+        /// </summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="ResourceName"/> with pattern <c>items/{item_id}</c>.
+        /// </returns>
+        public static string Format(string itemId) => FormatItem(itemId);
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="ResourceName"/> with pattern
+        /// <c>items/{item_id}</c>.
+        /// </summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="ResourceName"/> with pattern <c>items/{item_id}</c>.
+        /// </returns>
+        public static string FormatItem(string itemId) =>
+            s_item.Expand(gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+
+        /// <summary>Parses the given resource name string into a new <see cref="ResourceName"/> instance.</summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}</c></description></item></list>
+        /// </remarks>
+        /// <param name="resourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="ResourceName"/> if successful.</returns>
+        public static ResourceName Parse(string resourceName) => Parse(resourceName, false);
+
+        /// <summary>
+        /// Parses the given resource name string into a new <see cref="ResourceName"/> instance; optionally allowing an
+        /// unknown resource name to be successfully parsed
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="resourceName"/> is
-        /// <c>null</c>, as this would usually indicate a programming error rather than a data error.
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}</c></description></item></list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
         /// </remarks>
-        /// <param name="resourceName">
-        /// The <c>Resource</c> resource name in string form. Must not be <c>null</c>.
+        /// <param name="resourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
         /// </param>
-        /// <param name="result">
-        /// When this method returns, the parsed <see cref="ResourceName"/>, or <c>null</c> if parsing fails.
-        /// </param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string resourceName, out ResourceName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(resourceName, nameof(resourceName));
-            if (s_template.TryParseName(resourceName, out gax::TemplatedResourceName resourceName2))
-            {
-                result = new ResourceName(resourceName2[0]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>Formats the IDs into the string representation of the <see cref="ResourceName"/>.</summary>
-        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c>.</param>
-        /// <returns>The string representation of the <see cref="ResourceName"/>.</returns>
-        public static string Format(string itemId) =>
-            s_template.Expand(gax::GaxPreconditions.CheckNotNull(itemId, nameof(itemId)));
+        /// <returns>The parsed <see cref="ResourceName"/> if successful.</returns>
+        public static ResourceName Parse(string resourceName, bool allowUnknown) =>
+            TryParse(resourceName, allowUnknown, out ResourceName result) ? result : throw new sys::ArgumentException("The given resource-name matches no pattern.");
 
         /// <summary>
-        /// Constructs a new instance of the <see cref="ResourceName"/> resource name class from its component parts.
+        /// Tries to parse the given resource name string into a new <see cref="ResourceName"/> instance.
         /// </summary>
-        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c>.</param>
-        public ResourceName(string itemId) => ItemId = gax::GaxPreconditions.CheckNotNull(itemId, nameof(itemId));
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}</c></description></item></list>
+        /// </remarks>
+        /// <param name="resourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="ResourceName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string resourceName, out ResourceName result) => TryParse(resourceName, false, out result);
 
-        /// <summary>The <c>Item</c> ID. Never <c>null</c>.</summary>
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="ResourceName"/> instance; optionally
+        /// allowing an unknown resource name to be successfully parsed.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}</c></description></item></list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="resourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
+        /// </param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="ResourceName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string resourceName, bool allowUnknown, out ResourceName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(resourceName, nameof(resourceName));
+            gax::TemplatedResourceName resourceName2;
+            if (s_item.TryParseName(resourceName, out resourceName2))
+            {
+                result = CreateItem(resourceName2[0]);
+                return true;
+            }
+            if (allowUnknown)
+            {
+                if (gax::UnknownResourceName.TryParse(resourceName, out gax::UnknownResourceName unknownResourceName))
+                {
+                    result = CreateUnknown(unknownResourceName);
+                    return true;
+                }
+            }
+            result = null;
+            return false;
+        }
+
+        private ResourceName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null)
+        {
+            Type = type;
+            UnknownResource = unknownResourceName;
+            ItemId = itemId;
+        }
+
+        /// <summary>
+        /// Constructs a new instance of a <see cref="ResourceName"/> class from the component parts of pattern
+        /// <c>items/{item_id}</c>
+        /// </summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        public ResourceName(string itemId) : this(ResourceType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
+        {
+        }
+
+        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
+        public ResourceType Type { get; }
+
+        /// <summary>
+        /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
+        /// unknown resource name.
+        /// </summary>
+        public gax::UnknownResourceName UnknownResource { get; }
+
+        /// <summary>
+        /// The <c>Item</c> ID. Will not be <c>null</c>, unless this instance contains an unknown resource name.
+        /// </summary>
         public string ItemId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
 
         /// <inheritdoc/>
-        public override string ToString() => s_template.Expand(ItemId);
+        public override string ToString()
+        {
+            switch (Type)
+            {
+                case ResourceType.Unknown: return UnknownResource.ToString();
+                case ResourceType.Item: return s_item.Expand(ItemId);
+                default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
+            }
+        }
 
         /// <inheritdoc/>
         public override int GetHashCode() => ToString().GetHashCode();

--- a/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro/LroResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro/LroResourceNames.g.cs
@@ -23,73 +23,178 @@ namespace Testing.Lro
     /// <summary>Resource name for the <c>Resource</c> resource.</summary>
     public sealed partial class ResourceName : gax::IResourceName, sys::IEquatable<ResourceName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("items/{item_id}");
-
-        /// <summary>
-        /// Parses the given <c>Resource</c> resource name in string form into a new <see cref="ResourceName"/>
-        /// instance.
-        /// </summary>
-        /// <param name="resourceName">
-        /// The <c>Resource</c> resource name in string form. Must not be <c>null</c>.
-        /// </param>
-        /// <returns>The parsed <see cref="ResourceName"/> if successful.</returns>
-        public static ResourceName Parse(string resourceName)
+        /// <summary>The possible contents of <see cref="ResourceName"/>.</summary>
+        public enum ResourceType
         {
-            gax::GaxPreconditions.CheckNotNull(resourceName, nameof(resourceName));
-            gax::TemplatedResourceName resourceName2 = s_template.ParseName(resourceName);
-            return new ResourceName(resourceName2[0]);
+            /// <summary>A resource of an unknown type.</summary>
+            Unknown = 0,
+
+            /// <summary>A resource of type 'item'.</summary>
+            Item = 1
         }
 
+        private static gax::PathTemplate s_item = new gax::PathTemplate("items/{item_id}");
+
+        /// <summary>Creates a <see cref="ResourceName"/> containing an unknown resource name.</summary>
+        /// <param name="unknownResourceName">The unknown resource name. Must not be <c>null</c>.</param>
+        /// <returns>
+        /// A new instance of <see cref="ResourceName"/> containing the provided <paramref name="unknownResourceName"/>.
+        /// </returns>
+        public static ResourceName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new ResourceName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+
+        /// <summary>Creates a <see cref="ResourceName"/> with the pattern <c>items/{item_id}</c>.</summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>A new instance of <see cref="ResourceName"/> constructed from the provided ids.</returns>
+        public static ResourceName CreateItem(string itemId) =>
+            new ResourceName(ResourceType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+
         /// <summary>
-        /// Tries to parse the given session resource name in string form into a new <see cref="ResourceName"/>
-        /// instance.
+        /// Formats the IDs into the string representation of this <see cref="ResourceName"/> with pattern
+        /// <c>items/{item_id}</c>.
+        /// </summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="ResourceName"/> with pattern <c>items/{item_id}</c>.
+        /// </returns>
+        public static string Format(string itemId) => FormatItem(itemId);
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="ResourceName"/> with pattern
+        /// <c>items/{item_id}</c>.
+        /// </summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="ResourceName"/> with pattern <c>items/{item_id}</c>.
+        /// </returns>
+        public static string FormatItem(string itemId) =>
+            s_item.Expand(gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+
+        /// <summary>Parses the given resource name string into a new <see cref="ResourceName"/> instance.</summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}</c></description></item></list>
+        /// </remarks>
+        /// <param name="resourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="ResourceName"/> if successful.</returns>
+        public static ResourceName Parse(string resourceName) => Parse(resourceName, false);
+
+        /// <summary>
+        /// Parses the given resource name string into a new <see cref="ResourceName"/> instance; optionally allowing an
+        /// unknown resource name to be successfully parsed
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="resourceName"/> is
-        /// <c>null</c>, as this would usually indicate a programming error rather than a data error.
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}</c></description></item></list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
         /// </remarks>
-        /// <param name="resourceName">
-        /// The <c>Resource</c> resource name in string form. Must not be <c>null</c>.
+        /// <param name="resourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
         /// </param>
-        /// <param name="result">
-        /// When this method returns, the parsed <see cref="ResourceName"/>, or <c>null</c> if parsing fails.
-        /// </param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string resourceName, out ResourceName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(resourceName, nameof(resourceName));
-            if (s_template.TryParseName(resourceName, out gax::TemplatedResourceName resourceName2))
-            {
-                result = new ResourceName(resourceName2[0]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>Formats the IDs into the string representation of the <see cref="ResourceName"/>.</summary>
-        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c>.</param>
-        /// <returns>The string representation of the <see cref="ResourceName"/>.</returns>
-        public static string Format(string itemId) =>
-            s_template.Expand(gax::GaxPreconditions.CheckNotNull(itemId, nameof(itemId)));
+        /// <returns>The parsed <see cref="ResourceName"/> if successful.</returns>
+        public static ResourceName Parse(string resourceName, bool allowUnknown) =>
+            TryParse(resourceName, allowUnknown, out ResourceName result) ? result : throw new sys::ArgumentException("The given resource-name matches no pattern.");
 
         /// <summary>
-        /// Constructs a new instance of the <see cref="ResourceName"/> resource name class from its component parts.
+        /// Tries to parse the given resource name string into a new <see cref="ResourceName"/> instance.
         /// </summary>
-        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c>.</param>
-        public ResourceName(string itemId) => ItemId = gax::GaxPreconditions.CheckNotNull(itemId, nameof(itemId));
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}</c></description></item></list>
+        /// </remarks>
+        /// <param name="resourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="ResourceName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string resourceName, out ResourceName result) => TryParse(resourceName, false, out result);
 
-        /// <summary>The <c>Item</c> ID. Never <c>null</c>.</summary>
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="ResourceName"/> instance; optionally
+        /// allowing an unknown resource name to be successfully parsed.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}</c></description></item></list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="resourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
+        /// </param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="ResourceName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string resourceName, bool allowUnknown, out ResourceName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(resourceName, nameof(resourceName));
+            gax::TemplatedResourceName resourceName2;
+            if (s_item.TryParseName(resourceName, out resourceName2))
+            {
+                result = CreateItem(resourceName2[0]);
+                return true;
+            }
+            if (allowUnknown)
+            {
+                if (gax::UnknownResourceName.TryParse(resourceName, out gax::UnknownResourceName unknownResourceName))
+                {
+                    result = CreateUnknown(unknownResourceName);
+                    return true;
+                }
+            }
+            result = null;
+            return false;
+        }
+
+        private ResourceName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null)
+        {
+            Type = type;
+            UnknownResource = unknownResourceName;
+            ItemId = itemId;
+        }
+
+        /// <summary>
+        /// Constructs a new instance of a <see cref="ResourceName"/> class from the component parts of pattern
+        /// <c>items/{item_id}</c>
+        /// </summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        public ResourceName(string itemId) : this(ResourceType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
+        {
+        }
+
+        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
+        public ResourceType Type { get; }
+
+        /// <summary>
+        /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
+        /// unknown resource name.
+        /// </summary>
+        public gax::UnknownResourceName UnknownResource { get; }
+
+        /// <summary>
+        /// The <c>Item</c> ID. Will not be <c>null</c>, unless this instance contains an unknown resource name.
+        /// </summary>
         public string ItemId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
 
         /// <inheritdoc/>
-        public override string ToString() => s_template.Expand(ItemId);
+        public override string ToString()
+        {
+            switch (Type)
+            {
+                case ResourceType.Unknown: return UnknownResource.ToString();
+                case ResourceType.Item: return s_item.Expand(ItemId);
+                default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
+            }
+        }
 
         /// <inheritdoc/>
         public override int GetHashCode() => ToString().GetHashCode();

--- a/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro/LroResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro/LroResourceNames.g.cs
@@ -24,12 +24,12 @@ namespace Testing.Lro
     public sealed partial class ResourceName : gax::IResourceName, sys::IEquatable<ResourceName>
     {
         /// <summary>The possible contents of <see cref="ResourceName"/>.</summary>
-        public enum ResourceType
+        public enum ResourceNameType
         {
             /// <summary>A resource of an unknown type.</summary>
             Unknown = 0,
 
-            /// <summary>A resource of type 'item'.</summary>
+            /// <summary>A resource name with pattern <c>items/{item_id}</c>.</summary>
             Item = 1
         }
 
@@ -40,14 +40,14 @@ namespace Testing.Lro
         /// <returns>
         /// A new instance of <see cref="ResourceName"/> containing the provided <paramref name="unknownResourceName"/>.
         /// </returns>
-        public static ResourceName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
-            new ResourceName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+        public static ResourceName FromUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new ResourceName(ResourceNameType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
 
         /// <summary>Creates a <see cref="ResourceName"/> with the pattern <c>items/{item_id}</c>.</summary>
         /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
         /// <returns>A new instance of <see cref="ResourceName"/> constructed from the provided ids.</returns>
-        public static ResourceName CreateItem(string itemId) =>
-            new ResourceName(ResourceType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+        public static ResourceName FromItem(string itemId) =>
+            new ResourceName(ResourceNameType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
 
         /// <summary>
         /// Formats the IDs into the string representation of this <see cref="ResourceName"/> with pattern
@@ -137,14 +137,14 @@ namespace Testing.Lro
             gax::TemplatedResourceName resourceName2;
             if (s_item.TryParseName(resourceName, out resourceName2))
             {
-                result = CreateItem(resourceName2[0]);
+                result = FromItem(resourceName2[0]);
                 return true;
             }
             if (allowUnknown)
             {
                 if (gax::UnknownResourceName.TryParse(resourceName, out gax::UnknownResourceName unknownResourceName))
                 {
-                    result = CreateUnknown(unknownResourceName);
+                    result = FromUnknown(unknownResourceName);
                     return true;
                 }
             }
@@ -152,7 +152,7 @@ namespace Testing.Lro
             return false;
         }
 
-        private ResourceName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null)
+        private ResourceName(ResourceNameType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null)
         {
             Type = type;
             UnknownResource = unknownResourceName;
@@ -164,12 +164,12 @@ namespace Testing.Lro
         /// <c>items/{item_id}</c>
         /// </summary>
         /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
-        public ResourceName(string itemId) : this(ResourceType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
+        public ResourceName(string itemId) : this(ResourceNameType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
         {
         }
 
-        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
-        public ResourceType Type { get; }
+        /// <summary>The <see cref="ResourceNameType"/> of the contained resource name.</summary>
+        public ResourceNameType Type { get; }
 
         /// <summary>
         /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
@@ -183,15 +183,15 @@ namespace Testing.Lro
         public string ItemId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
+        public gax::ResourceNameKind Kind => Type == ResourceNameType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
 
         /// <inheritdoc/>
         public override string ToString()
         {
             switch (Type)
             {
-                case ResourceType.Unknown: return UnknownResource.ToString();
-                case ResourceType.Item: return s_item.Expand(ItemId);
+                case ResourceNameType.Unknown: return UnknownResource.ToString();
+                case ResourceNameType.Item: return s_item.Expand(ItemId);
                 default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
             }
         }

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.Snippets/PaginatedClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.Snippets/PaginatedClientSnippets.g.cs
@@ -399,7 +399,7 @@ namespace Testing.Paginated.Snippets
             // Initialize request argument(s)
             ResourceRequest request = new ResourceRequest
             {
-                ResourceName = ResourceName.CreateItem("[ITEM_ID]"),
+                ResourceName = ResourceName.FromItem("[ITEM_ID]"),
             };
             // Make the request
             PagedEnumerable<ResourceResponse, ResourceName> response = paginatedClient.ResourcedMethod(request);
@@ -447,7 +447,7 @@ namespace Testing.Paginated.Snippets
             // Initialize request argument(s)
             ResourceRequest request = new ResourceRequest
             {
-                ResourceName = ResourceName.CreateItem("[ITEM_ID]"),
+                ResourceName = ResourceName.FromItem("[ITEM_ID]"),
             };
             // Make the request
             PagedAsyncEnumerable<ResourceResponse, ResourceName> response = paginatedClient.ResourcedMethodAsync(request);
@@ -583,7 +583,7 @@ namespace Testing.Paginated.Snippets
             // Create client
             PaginatedClient paginatedClient = PaginatedClient.Create();
             // Initialize request argument(s)
-            ResourceName name = ResourceName.CreateItem("[ITEM_ID]");
+            ResourceName name = ResourceName.FromItem("[ITEM_ID]");
             // Make the request
             PagedEnumerable<ResourceResponse, ResourceName> response = paginatedClient.ResourcedMethod(name);
 
@@ -628,7 +628,7 @@ namespace Testing.Paginated.Snippets
             // Create client
             PaginatedClient paginatedClient = await PaginatedClient.CreateAsync();
             // Initialize request argument(s)
-            ResourceName name = ResourceName.CreateItem("[ITEM_ID]");
+            ResourceName name = ResourceName.FromItem("[ITEM_ID]");
             // Make the request
             PagedAsyncEnumerable<ResourceResponse, ResourceName> response = paginatedClient.ResourcedMethodAsync(name);
 

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.Snippets/PaginatedClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.Snippets/PaginatedClientSnippets.g.cs
@@ -399,7 +399,7 @@ namespace Testing.Paginated.Snippets
             // Initialize request argument(s)
             ResourceRequest request = new ResourceRequest
             {
-                ResourceName = new ResourceName("[ITEM_ID]"),
+                ResourceName = ResourceName.CreateItem("[ITEM_ID]"),
             };
             // Make the request
             PagedEnumerable<ResourceResponse, ResourceName> response = paginatedClient.ResourcedMethod(request);
@@ -447,7 +447,7 @@ namespace Testing.Paginated.Snippets
             // Initialize request argument(s)
             ResourceRequest request = new ResourceRequest
             {
-                ResourceName = new ResourceName("[ITEM_ID]"),
+                ResourceName = ResourceName.CreateItem("[ITEM_ID]"),
             };
             // Make the request
             PagedAsyncEnumerable<ResourceResponse, ResourceName> response = paginatedClient.ResourcedMethodAsync(request);
@@ -583,7 +583,7 @@ namespace Testing.Paginated.Snippets
             // Create client
             PaginatedClient paginatedClient = PaginatedClient.Create();
             // Initialize request argument(s)
-            ResourceName name = new ResourceName("[ITEM_ID]");
+            ResourceName name = ResourceName.CreateItem("[ITEM_ID]");
             // Make the request
             PagedEnumerable<ResourceResponse, ResourceName> response = paginatedClient.ResourcedMethod(name);
 
@@ -628,7 +628,7 @@ namespace Testing.Paginated.Snippets
             // Create client
             PaginatedClient paginatedClient = await PaginatedClient.CreateAsync();
             // Initialize request argument(s)
-            ResourceName name = new ResourceName("[ITEM_ID]");
+            ResourceName name = ResourceName.CreateItem("[ITEM_ID]");
             // Make the request
             PagedAsyncEnumerable<ResourceResponse, ResourceName> response = paginatedClient.ResourcedMethodAsync(name);
 

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated/PaginatedResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated/PaginatedResourceNames.g.cs
@@ -23,73 +23,178 @@ namespace Testing.Paginated
     /// <summary>Resource name for the <c>Resource</c> resource.</summary>
     public sealed partial class ResourceName : gax::IResourceName, sys::IEquatable<ResourceName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("items/{item_id}");
-
-        /// <summary>
-        /// Parses the given <c>Resource</c> resource name in string form into a new <see cref="ResourceName"/>
-        /// instance.
-        /// </summary>
-        /// <param name="resourceName">
-        /// The <c>Resource</c> resource name in string form. Must not be <c>null</c>.
-        /// </param>
-        /// <returns>The parsed <see cref="ResourceName"/> if successful.</returns>
-        public static ResourceName Parse(string resourceName)
+        /// <summary>The possible contents of <see cref="ResourceName"/>.</summary>
+        public enum ResourceType
         {
-            gax::GaxPreconditions.CheckNotNull(resourceName, nameof(resourceName));
-            gax::TemplatedResourceName resourceName2 = s_template.ParseName(resourceName);
-            return new ResourceName(resourceName2[0]);
+            /// <summary>A resource of an unknown type.</summary>
+            Unknown = 0,
+
+            /// <summary>A resource of type 'item'.</summary>
+            Item = 1
         }
 
+        private static gax::PathTemplate s_item = new gax::PathTemplate("items/{item_id}");
+
+        /// <summary>Creates a <see cref="ResourceName"/> containing an unknown resource name.</summary>
+        /// <param name="unknownResourceName">The unknown resource name. Must not be <c>null</c>.</param>
+        /// <returns>
+        /// A new instance of <see cref="ResourceName"/> containing the provided <paramref name="unknownResourceName"/>.
+        /// </returns>
+        public static ResourceName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new ResourceName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+
+        /// <summary>Creates a <see cref="ResourceName"/> with the pattern <c>items/{item_id}</c>.</summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>A new instance of <see cref="ResourceName"/> constructed from the provided ids.</returns>
+        public static ResourceName CreateItem(string itemId) =>
+            new ResourceName(ResourceType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+
         /// <summary>
-        /// Tries to parse the given session resource name in string form into a new <see cref="ResourceName"/>
-        /// instance.
+        /// Formats the IDs into the string representation of this <see cref="ResourceName"/> with pattern
+        /// <c>items/{item_id}</c>.
+        /// </summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="ResourceName"/> with pattern <c>items/{item_id}</c>.
+        /// </returns>
+        public static string Format(string itemId) => FormatItem(itemId);
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="ResourceName"/> with pattern
+        /// <c>items/{item_id}</c>.
+        /// </summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="ResourceName"/> with pattern <c>items/{item_id}</c>.
+        /// </returns>
+        public static string FormatItem(string itemId) =>
+            s_item.Expand(gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+
+        /// <summary>Parses the given resource name string into a new <see cref="ResourceName"/> instance.</summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}</c></description></item></list>
+        /// </remarks>
+        /// <param name="resourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="ResourceName"/> if successful.</returns>
+        public static ResourceName Parse(string resourceName) => Parse(resourceName, false);
+
+        /// <summary>
+        /// Parses the given resource name string into a new <see cref="ResourceName"/> instance; optionally allowing an
+        /// unknown resource name to be successfully parsed
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="resourceName"/> is
-        /// <c>null</c>, as this would usually indicate a programming error rather than a data error.
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}</c></description></item></list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
         /// </remarks>
-        /// <param name="resourceName">
-        /// The <c>Resource</c> resource name in string form. Must not be <c>null</c>.
+        /// <param name="resourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
         /// </param>
-        /// <param name="result">
-        /// When this method returns, the parsed <see cref="ResourceName"/>, or <c>null</c> if parsing fails.
-        /// </param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string resourceName, out ResourceName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(resourceName, nameof(resourceName));
-            if (s_template.TryParseName(resourceName, out gax::TemplatedResourceName resourceName2))
-            {
-                result = new ResourceName(resourceName2[0]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>Formats the IDs into the string representation of the <see cref="ResourceName"/>.</summary>
-        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c>.</param>
-        /// <returns>The string representation of the <see cref="ResourceName"/>.</returns>
-        public static string Format(string itemId) =>
-            s_template.Expand(gax::GaxPreconditions.CheckNotNull(itemId, nameof(itemId)));
+        /// <returns>The parsed <see cref="ResourceName"/> if successful.</returns>
+        public static ResourceName Parse(string resourceName, bool allowUnknown) =>
+            TryParse(resourceName, allowUnknown, out ResourceName result) ? result : throw new sys::ArgumentException("The given resource-name matches no pattern.");
 
         /// <summary>
-        /// Constructs a new instance of the <see cref="ResourceName"/> resource name class from its component parts.
+        /// Tries to parse the given resource name string into a new <see cref="ResourceName"/> instance.
         /// </summary>
-        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c>.</param>
-        public ResourceName(string itemId) => ItemId = gax::GaxPreconditions.CheckNotNull(itemId, nameof(itemId));
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}</c></description></item></list>
+        /// </remarks>
+        /// <param name="resourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="ResourceName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string resourceName, out ResourceName result) => TryParse(resourceName, false, out result);
 
-        /// <summary>The <c>Item</c> ID. Never <c>null</c>.</summary>
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="ResourceName"/> instance; optionally
+        /// allowing an unknown resource name to be successfully parsed.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}</c></description></item></list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="resourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
+        /// </param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="ResourceName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string resourceName, bool allowUnknown, out ResourceName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(resourceName, nameof(resourceName));
+            gax::TemplatedResourceName resourceName2;
+            if (s_item.TryParseName(resourceName, out resourceName2))
+            {
+                result = CreateItem(resourceName2[0]);
+                return true;
+            }
+            if (allowUnknown)
+            {
+                if (gax::UnknownResourceName.TryParse(resourceName, out gax::UnknownResourceName unknownResourceName))
+                {
+                    result = CreateUnknown(unknownResourceName);
+                    return true;
+                }
+            }
+            result = null;
+            return false;
+        }
+
+        private ResourceName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null)
+        {
+            Type = type;
+            UnknownResource = unknownResourceName;
+            ItemId = itemId;
+        }
+
+        /// <summary>
+        /// Constructs a new instance of a <see cref="ResourceName"/> class from the component parts of pattern
+        /// <c>items/{item_id}</c>
+        /// </summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        public ResourceName(string itemId) : this(ResourceType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
+        {
+        }
+
+        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
+        public ResourceType Type { get; }
+
+        /// <summary>
+        /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
+        /// unknown resource name.
+        /// </summary>
+        public gax::UnknownResourceName UnknownResource { get; }
+
+        /// <summary>
+        /// The <c>Item</c> ID. Will not be <c>null</c>, unless this instance contains an unknown resource name.
+        /// </summary>
         public string ItemId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
 
         /// <inheritdoc/>
-        public override string ToString() => s_template.Expand(ItemId);
+        public override string ToString()
+        {
+            switch (Type)
+            {
+                case ResourceType.Unknown: return UnknownResource.ToString();
+                case ResourceType.Item: return s_item.Expand(ItemId);
+                default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
+            }
+        }
 
         /// <inheritdoc/>
         public override int GetHashCode() => ToString().GetHashCode();
@@ -136,6 +241,9 @@ namespace Testing.Paginated
         /// <summary>
         /// <see cref="ResourceName"/>-typed view over the <see cref="Results"/> resource name property.
         /// </summary>
-        public gax::ResourceNameList<ResourceName> ResultsAsResourceNames => new gax::ResourceNameList<ResourceName>(Results, s => ResourceName.Parse(s));
+        public gax::ResourceNameList<ResourceName> ResultsAsResourceNames
+        {
+            get => new gax::ResourceNameList<ResourceName>(Results, s => ResourceName.Parse(s));
+        }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated/PaginatedResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated/PaginatedResourceNames.g.cs
@@ -24,12 +24,12 @@ namespace Testing.Paginated
     public sealed partial class ResourceName : gax::IResourceName, sys::IEquatable<ResourceName>
     {
         /// <summary>The possible contents of <see cref="ResourceName"/>.</summary>
-        public enum ResourceType
+        public enum ResourceNameType
         {
             /// <summary>A resource of an unknown type.</summary>
             Unknown = 0,
 
-            /// <summary>A resource of type 'item'.</summary>
+            /// <summary>A resource name with pattern <c>items/{item_id}</c>.</summary>
             Item = 1
         }
 
@@ -40,14 +40,14 @@ namespace Testing.Paginated
         /// <returns>
         /// A new instance of <see cref="ResourceName"/> containing the provided <paramref name="unknownResourceName"/>.
         /// </returns>
-        public static ResourceName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
-            new ResourceName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+        public static ResourceName FromUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new ResourceName(ResourceNameType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
 
         /// <summary>Creates a <see cref="ResourceName"/> with the pattern <c>items/{item_id}</c>.</summary>
         /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
         /// <returns>A new instance of <see cref="ResourceName"/> constructed from the provided ids.</returns>
-        public static ResourceName CreateItem(string itemId) =>
-            new ResourceName(ResourceType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+        public static ResourceName FromItem(string itemId) =>
+            new ResourceName(ResourceNameType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
 
         /// <summary>
         /// Formats the IDs into the string representation of this <see cref="ResourceName"/> with pattern
@@ -137,14 +137,14 @@ namespace Testing.Paginated
             gax::TemplatedResourceName resourceName2;
             if (s_item.TryParseName(resourceName, out resourceName2))
             {
-                result = CreateItem(resourceName2[0]);
+                result = FromItem(resourceName2[0]);
                 return true;
             }
             if (allowUnknown)
             {
                 if (gax::UnknownResourceName.TryParse(resourceName, out gax::UnknownResourceName unknownResourceName))
                 {
-                    result = CreateUnknown(unknownResourceName);
+                    result = FromUnknown(unknownResourceName);
                     return true;
                 }
             }
@@ -152,7 +152,7 @@ namespace Testing.Paginated
             return false;
         }
 
-        private ResourceName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null)
+        private ResourceName(ResourceNameType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null)
         {
             Type = type;
             UnknownResource = unknownResourceName;
@@ -164,12 +164,12 @@ namespace Testing.Paginated
         /// <c>items/{item_id}</c>
         /// </summary>
         /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
-        public ResourceName(string itemId) : this(ResourceType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
+        public ResourceName(string itemId) : this(ResourceNameType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
         {
         }
 
-        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
-        public ResourceType Type { get; }
+        /// <summary>The <see cref="ResourceNameType"/> of the contained resource name.</summary>
+        public ResourceNameType Type { get; }
 
         /// <summary>
         /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
@@ -183,15 +183,15 @@ namespace Testing.Paginated
         public string ItemId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
+        public gax::ResourceNameKind Kind => Type == ResourceNameType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
 
         /// <inheritdoc/>
         public override string ToString()
         {
             switch (Type)
             {
-                case ResourceType.Unknown: return UnknownResource.ToString();
-                case ResourceType.Item: return s_item.Expand(ItemId);
+                case ResourceNameType.Unknown: return UnknownResource.ToString();
+                case ResourceNameType.Item: return s_item.Expand(ItemId);
                 default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
             }
         }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames/ResourceNamesClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames/ResourceNamesClient.g.cs
@@ -212,10 +212,10 @@ namespace Testing.ResourceNames
         /// </param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The RPC response.</returns>
-        public virtual Response MultiMethod(MultiResourceNameOneOf name, gaxgrpc::CallSettings callSettings = null) =>
+        public virtual Response MultiMethod(MultiResourceName name, gaxgrpc::CallSettings callSettings = null) =>
             MultiMethod(new MultiResource
             {
-                MultiResourceNameOneOf = name,
+                MultiResourceName = name,
             }, callSettings);
 
         /// <summary>
@@ -225,10 +225,10 @@ namespace Testing.ResourceNames
         /// </param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A Task containing the RPC response.</returns>
-        public virtual stt::Task<Response> MultiMethodAsync(MultiResourceNameOneOf name, gaxgrpc::CallSettings callSettings = null) =>
+        public virtual stt::Task<Response> MultiMethodAsync(MultiResourceName name, gaxgrpc::CallSettings callSettings = null) =>
             MultiMethodAsync(new MultiResource
             {
-                MultiResourceNameOneOf = name,
+                MultiResourceName = name,
             }, callSettings);
 
         /// <summary>
@@ -238,7 +238,7 @@ namespace Testing.ResourceNames
         /// </param>
         /// <param name="cancellationToken">A <see cref="st::CancellationToken"/> to use for this RPC.</param>
         /// <returns>A Task containing the RPC response.</returns>
-        public virtual stt::Task<Response> MultiMethodAsync(MultiResourceNameOneOf name, st::CancellationToken cancellationToken) =>
+        public virtual stt::Task<Response> MultiMethodAsync(MultiResourceName name, st::CancellationToken cancellationToken) =>
             MultiMethodAsync(name, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
         // TEST_END
 
@@ -289,10 +289,10 @@ namespace Testing.ResourceNames
         /// </param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The RPC response.</returns>
-        public virtual Response MultiMethodRef(MultiResourceNameOneOf multiResource, gaxgrpc::CallSettings callSettings = null) =>
+        public virtual Response MultiMethodRef(MultiResourceName multiResource, gaxgrpc::CallSettings callSettings = null) =>
             MultiMethodRef(new MultiResourceRef
             {
-                MultiResourceAsMultiResourceNameOneOf = multiResource,
+                MultiResourceAsMultiResourceName = multiResource,
             }, callSettings);
 
         /// <summary>
@@ -302,10 +302,10 @@ namespace Testing.ResourceNames
         /// </param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A Task containing the RPC response.</returns>
-        public virtual stt::Task<Response> MultiMethodRefAsync(MultiResourceNameOneOf multiResource, gaxgrpc::CallSettings callSettings = null) =>
+        public virtual stt::Task<Response> MultiMethodRefAsync(MultiResourceName multiResource, gaxgrpc::CallSettings callSettings = null) =>
             MultiMethodRefAsync(new MultiResourceRef
             {
-                MultiResourceAsMultiResourceNameOneOf = multiResource,
+                MultiResourceAsMultiResourceName = multiResource,
             }, callSettings);
 
         /// <summary>
@@ -315,7 +315,7 @@ namespace Testing.ResourceNames
         /// </param>
         /// <param name="cancellationToken">A <see cref="st::CancellationToken"/> to use for this RPC.</param>
         /// <returns>A Task containing the RPC response.</returns>
-        public virtual stt::Task<Response> MultiMethodRefAsync(MultiResourceNameOneOf multiResource, st::CancellationToken cancellationToken) =>
+        public virtual stt::Task<Response> MultiMethodRefAsync(MultiResourceName multiResource, st::CancellationToken cancellationToken) =>
             MultiMethodRefAsync(multiResource, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
         // TEST_END
 
@@ -388,42 +388,6 @@ namespace Testing.ResourceNames
         /// <returns>A Task containing the RPC response.</returns>
         public virtual stt::Task<Response> OriginallySingleMethodAsync(OriginallySingleResourceName name, st::CancellationToken cancellationToken) =>
             OriginallySingleMethodAsync(name, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
-
-        /// <summary>
-        /// Test original single resource (ORIGINALLY_SINGLE_PATTERN).
-        /// </summary>
-        /// <param name="name">
-        /// </param>
-        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
-        /// <returns>The RPC response.</returns>
-        public virtual Response OriginallySingleMethod(OriginallySingleResourceNameOneOf name, gaxgrpc::CallSettings callSettings = null) =>
-            OriginallySingleMethod(new OriginallySingleResource
-            {
-                OriginallySingleResourceNameOneOf = name,
-            }, callSettings);
-
-        /// <summary>
-        /// Test original single resource (ORIGINALLY_SINGLE_PATTERN).
-        /// </summary>
-        /// <param name="name">
-        /// </param>
-        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
-        /// <returns>A Task containing the RPC response.</returns>
-        public virtual stt::Task<Response> OriginallySingleMethodAsync(OriginallySingleResourceNameOneOf name, gaxgrpc::CallSettings callSettings = null) =>
-            OriginallySingleMethodAsync(new OriginallySingleResource
-            {
-                OriginallySingleResourceNameOneOf = name,
-            }, callSettings);
-
-        /// <summary>
-        /// Test original single resource (ORIGINALLY_SINGLE_PATTERN).
-        /// </summary>
-        /// <param name="name">
-        /// </param>
-        /// <param name="cancellationToken">A <see cref="st::CancellationToken"/> to use for this RPC.</param>
-        /// <returns>A Task containing the RPC response.</returns>
-        public virtual stt::Task<Response> OriginallySingleMethodAsync(OriginallySingleResourceNameOneOf name, st::CancellationToken cancellationToken) =>
-            OriginallySingleMethodAsync(name, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
         // TEST_END
 
         public Response FutureMultiMethod(FutureMultiResource request, gaxgrpc::CallSettings callSettings) => throw new sys::NotImplementedException();
@@ -467,10 +431,10 @@ namespace Testing.ResourceNames
         /// </param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The RPC response.</returns>
-        public virtual Response FutureMultiMethod(FutureMultiResourceNameOneOf name, gaxgrpc::CallSettings callSettings = null) =>
+        public virtual Response FutureMultiMethod(FutureMultiResourceName name, gaxgrpc::CallSettings callSettings = null) =>
             FutureMultiMethod(new FutureMultiResource
             {
-                FutureMultiResourceNameOneOf = name,
+                FutureMultiResourceName = name,
             }, callSettings);
 
         /// <summary>
@@ -480,10 +444,10 @@ namespace Testing.ResourceNames
         /// </param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A Task containing the RPC response.</returns>
-        public virtual stt::Task<Response> FutureMultiMethodAsync(FutureMultiResourceNameOneOf name, gaxgrpc::CallSettings callSettings = null) =>
+        public virtual stt::Task<Response> FutureMultiMethodAsync(FutureMultiResourceName name, gaxgrpc::CallSettings callSettings = null) =>
             FutureMultiMethodAsync(new FutureMultiResource
             {
-                FutureMultiResourceNameOneOf = name,
+                FutureMultiResourceName = name,
             }, callSettings);
 
         /// <summary>
@@ -493,7 +457,7 @@ namespace Testing.ResourceNames
         /// </param>
         /// <param name="cancellationToken">A <see cref="st::CancellationToken"/> to use for this RPC.</param>
         /// <returns>A Task containing the RPC response.</returns>
-        public virtual stt::Task<Response> FutureMultiMethodAsync(FutureMultiResourceNameOneOf name, st::CancellationToken cancellationToken) =>
+        public virtual stt::Task<Response> FutureMultiMethodAsync(FutureMultiResourceName name, st::CancellationToken cancellationToken) =>
             FutureMultiMethodAsync(name, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
         // TEST_END
 
@@ -599,156 +563,6 @@ namespace Testing.ResourceNames
         /// <param name="cancellationToken">A <see cref="st::CancellationToken"/> to use for this RPC.</param>
         /// <returns>A Task containing the RPC response.</returns>
         public virtual stt::Task<Response> OriginallySingleMethodRefAsync(OriginallySingleResourceName resource1, OriginallySingleResourceName resource2, st::CancellationToken cancellationToken) =>
-            OriginallySingleMethodRefAsync(resource1, resource2, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
-
-        /// <summary>
-        /// Test original single resource (ORIGINALLY_SINGLE_PATTERN),
-        /// with combinatorial method generation.
-        /// </summary>
-        /// <param name="resource1">
-        /// Two resource fields, to test combinatorial generation.
-        /// </param>
-        /// <param name="resource2">
-        /// </param>
-        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
-        /// <returns>The RPC response.</returns>
-        public virtual Response OriginallySingleMethodRef(OriginallySingleResourceNameOneOf resource1, OriginallySingleResourceName resource2, gaxgrpc::CallSettings callSettings = null) =>
-            OriginallySingleMethodRef(new OriginallySingleResourceRef
-            {
-                Resource1AsOriginallySingleResourceNameOneOf = resource1,
-                Resource2AsOriginallySingleResourceName = resource2,
-            }, callSettings);
-
-        /// <summary>
-        /// Test original single resource (ORIGINALLY_SINGLE_PATTERN),
-        /// with combinatorial method generation.
-        /// </summary>
-        /// <param name="resource1">
-        /// Two resource fields, to test combinatorial generation.
-        /// </param>
-        /// <param name="resource2">
-        /// </param>
-        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
-        /// <returns>A Task containing the RPC response.</returns>
-        public virtual stt::Task<Response> OriginallySingleMethodRefAsync(OriginallySingleResourceNameOneOf resource1, OriginallySingleResourceName resource2, gaxgrpc::CallSettings callSettings = null) =>
-            OriginallySingleMethodRefAsync(new OriginallySingleResourceRef
-            {
-                Resource1AsOriginallySingleResourceNameOneOf = resource1,
-                Resource2AsOriginallySingleResourceName = resource2,
-            }, callSettings);
-
-        /// <summary>
-        /// Test original single resource (ORIGINALLY_SINGLE_PATTERN),
-        /// with combinatorial method generation.
-        /// </summary>
-        /// <param name="resource1">
-        /// Two resource fields, to test combinatorial generation.
-        /// </param>
-        /// <param name="resource2">
-        /// </param>
-        /// <param name="cancellationToken">A <see cref="st::CancellationToken"/> to use for this RPC.</param>
-        /// <returns>A Task containing the RPC response.</returns>
-        public virtual stt::Task<Response> OriginallySingleMethodRefAsync(OriginallySingleResourceNameOneOf resource1, OriginallySingleResourceName resource2, st::CancellationToken cancellationToken) =>
-            OriginallySingleMethodRefAsync(resource1, resource2, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
-
-        /// <summary>
-        /// Test original single resource (ORIGINALLY_SINGLE_PATTERN),
-        /// with combinatorial method generation.
-        /// </summary>
-        /// <param name="resource1">
-        /// Two resource fields, to test combinatorial generation.
-        /// </param>
-        /// <param name="resource2">
-        /// </param>
-        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
-        /// <returns>The RPC response.</returns>
-        public virtual Response OriginallySingleMethodRef(OriginallySingleResourceName resource1, OriginallySingleResourceNameOneOf resource2, gaxgrpc::CallSettings callSettings = null) =>
-            OriginallySingleMethodRef(new OriginallySingleResourceRef
-            {
-                Resource1AsOriginallySingleResourceName = resource1,
-                Resource2AsOriginallySingleResourceNameOneOf = resource2,
-            }, callSettings);
-
-        /// <summary>
-        /// Test original single resource (ORIGINALLY_SINGLE_PATTERN),
-        /// with combinatorial method generation.
-        /// </summary>
-        /// <param name="resource1">
-        /// Two resource fields, to test combinatorial generation.
-        /// </param>
-        /// <param name="resource2">
-        /// </param>
-        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
-        /// <returns>A Task containing the RPC response.</returns>
-        public virtual stt::Task<Response> OriginallySingleMethodRefAsync(OriginallySingleResourceName resource1, OriginallySingleResourceNameOneOf resource2, gaxgrpc::CallSettings callSettings = null) =>
-            OriginallySingleMethodRefAsync(new OriginallySingleResourceRef
-            {
-                Resource1AsOriginallySingleResourceName = resource1,
-                Resource2AsOriginallySingleResourceNameOneOf = resource2,
-            }, callSettings);
-
-        /// <summary>
-        /// Test original single resource (ORIGINALLY_SINGLE_PATTERN),
-        /// with combinatorial method generation.
-        /// </summary>
-        /// <param name="resource1">
-        /// Two resource fields, to test combinatorial generation.
-        /// </param>
-        /// <param name="resource2">
-        /// </param>
-        /// <param name="cancellationToken">A <see cref="st::CancellationToken"/> to use for this RPC.</param>
-        /// <returns>A Task containing the RPC response.</returns>
-        public virtual stt::Task<Response> OriginallySingleMethodRefAsync(OriginallySingleResourceName resource1, OriginallySingleResourceNameOneOf resource2, st::CancellationToken cancellationToken) =>
-            OriginallySingleMethodRefAsync(resource1, resource2, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
-
-        /// <summary>
-        /// Test original single resource (ORIGINALLY_SINGLE_PATTERN),
-        /// with combinatorial method generation.
-        /// </summary>
-        /// <param name="resource1">
-        /// Two resource fields, to test combinatorial generation.
-        /// </param>
-        /// <param name="resource2">
-        /// </param>
-        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
-        /// <returns>The RPC response.</returns>
-        public virtual Response OriginallySingleMethodRef(OriginallySingleResourceNameOneOf resource1, OriginallySingleResourceNameOneOf resource2, gaxgrpc::CallSettings callSettings = null) =>
-            OriginallySingleMethodRef(new OriginallySingleResourceRef
-            {
-                Resource1AsOriginallySingleResourceNameOneOf = resource1,
-                Resource2AsOriginallySingleResourceNameOneOf = resource2,
-            }, callSettings);
-
-        /// <summary>
-        /// Test original single resource (ORIGINALLY_SINGLE_PATTERN),
-        /// with combinatorial method generation.
-        /// </summary>
-        /// <param name="resource1">
-        /// Two resource fields, to test combinatorial generation.
-        /// </param>
-        /// <param name="resource2">
-        /// </param>
-        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
-        /// <returns>A Task containing the RPC response.</returns>
-        public virtual stt::Task<Response> OriginallySingleMethodRefAsync(OriginallySingleResourceNameOneOf resource1, OriginallySingleResourceNameOneOf resource2, gaxgrpc::CallSettings callSettings = null) =>
-            OriginallySingleMethodRefAsync(new OriginallySingleResourceRef
-            {
-                Resource1AsOriginallySingleResourceNameOneOf = resource1,
-                Resource2AsOriginallySingleResourceNameOneOf = resource2,
-            }, callSettings);
-
-        /// <summary>
-        /// Test original single resource (ORIGINALLY_SINGLE_PATTERN),
-        /// with combinatorial method generation.
-        /// </summary>
-        /// <param name="resource1">
-        /// Two resource fields, to test combinatorial generation.
-        /// </param>
-        /// <param name="resource2">
-        /// </param>
-        /// <param name="cancellationToken">A <see cref="st::CancellationToken"/> to use for this RPC.</param>
-        /// <returns>A Task containing the RPC response.</returns>
-        public virtual stt::Task<Response> OriginallySingleMethodRefAsync(OriginallySingleResourceNameOneOf resource1, OriginallySingleResourceNameOneOf resource2, st::CancellationToken cancellationToken) =>
             OriginallySingleMethodRefAsync(resource1, resource2, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
         // TEST_END
     }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames/ResourceNamesResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames/ResourceNamesResourceNames.g.cs
@@ -24,12 +24,12 @@ namespace Testing.ResourceNames
     public sealed partial class SingleResourceName : gax::IResourceName, sys::IEquatable<SingleResourceName>
     {
         /// <summary>The possible contents of <see cref="SingleResourceName"/>.</summary>
-        public enum ResourceType
+        public enum ResourceNameType
         {
             /// <summary>A resource of an unknown type.</summary>
             Unknown = 0,
 
-            /// <summary>A resource of type 'item'.</summary>
+            /// <summary>A resource name with pattern <c>items/{item_id}</c>.</summary>
             Item = 1
         }
 
@@ -41,14 +41,14 @@ namespace Testing.ResourceNames
         /// A new instance of <see cref="SingleResourceName"/> containing the provided
         /// <paramref name="unknownResourceName"/>.
         /// </returns>
-        public static SingleResourceName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
-            new SingleResourceName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+        public static SingleResourceName FromUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new SingleResourceName(ResourceNameType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
 
         /// <summary>Creates a <see cref="SingleResourceName"/> with the pattern <c>items/{item_id}</c>.</summary>
         /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
         /// <returns>A new instance of <see cref="SingleResourceName"/> constructed from the provided ids.</returns>
-        public static SingleResourceName CreateItem(string itemId) =>
-            new SingleResourceName(ResourceType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+        public static SingleResourceName FromItem(string itemId) =>
+            new SingleResourceName(ResourceNameType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
 
         /// <summary>
         /// Formats the IDs into the string representation of this <see cref="SingleResourceName"/> with pattern
@@ -141,14 +141,14 @@ namespace Testing.ResourceNames
             gax::TemplatedResourceName resourceName;
             if (s_item.TryParseName(singleResourceName, out resourceName))
             {
-                result = CreateItem(resourceName[0]);
+                result = FromItem(resourceName[0]);
                 return true;
             }
             if (allowUnknown)
             {
                 if (gax::UnknownResourceName.TryParse(singleResourceName, out gax::UnknownResourceName unknownResourceName))
                 {
-                    result = CreateUnknown(unknownResourceName);
+                    result = FromUnknown(unknownResourceName);
                     return true;
                 }
             }
@@ -156,7 +156,7 @@ namespace Testing.ResourceNames
             return false;
         }
 
-        private SingleResourceName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null)
+        private SingleResourceName(ResourceNameType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null)
         {
             Type = type;
             UnknownResource = unknownResourceName;
@@ -168,12 +168,12 @@ namespace Testing.ResourceNames
         /// <c>items/{item_id}</c>
         /// </summary>
         /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
-        public SingleResourceName(string itemId) : this(ResourceType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
+        public SingleResourceName(string itemId) : this(ResourceNameType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
         {
         }
 
-        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
-        public ResourceType Type { get; }
+        /// <summary>The <see cref="ResourceNameType"/> of the contained resource name.</summary>
+        public ResourceNameType Type { get; }
 
         /// <summary>
         /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
@@ -187,15 +187,15 @@ namespace Testing.ResourceNames
         public string ItemId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
+        public gax::ResourceNameKind Kind => Type == ResourceNameType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
 
         /// <inheritdoc/>
         public override string ToString()
         {
             switch (Type)
             {
-                case ResourceType.Unknown: return UnknownResource.ToString();
-                case ResourceType.Item: return s_item.Expand(ItemId);
+                case ResourceNameType.Unknown: return UnknownResource.ToString();
+                case ResourceNameType.Item: return s_item.Expand(ItemId);
                 default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
             }
         }
@@ -220,15 +220,15 @@ namespace Testing.ResourceNames
     public sealed partial class MultiResourceName : gax::IResourceName, sys::IEquatable<MultiResourceName>
     {
         /// <summary>The possible contents of <see cref="MultiResourceName"/>.</summary>
-        public enum ResourceType
+        public enum ResourceNameType
         {
             /// <summary>A resource of an unknown type.</summary>
             Unknown = 0,
 
-            /// <summary>A resource of type 'root_a'.</summary>
+            /// <summary>A resource name with pattern <c>roota/{root_a_id}/multi/{multi_id}</c>.</summary>
             RootAMulti = 1,
 
-            /// <summary>A resource of type 'root_b'.</summary>
+            /// <summary>A resource name with pattern <c>rootb/{root_b_id}/multi/{multi_id}</c>.</summary>
             RootBMulti = 2
         }
 
@@ -242,8 +242,8 @@ namespace Testing.ResourceNames
         /// A new instance of <see cref="MultiResourceName"/> containing the provided
         /// <paramref name="unknownResourceName"/>.
         /// </returns>
-        public static MultiResourceName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
-            new MultiResourceName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+        public static MultiResourceName FromUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new MultiResourceName(ResourceNameType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
 
         /// <summary>
         /// Creates a <see cref="MultiResourceName"/> with the pattern <c>roota/{root_a_id}/multi/{multi_id}</c>.
@@ -251,8 +251,8 @@ namespace Testing.ResourceNames
         /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
         /// <param name="multiId">The <c>Multi</c> ID. Must not be <c>null</c> or empty.</param>
         /// <returns>A new instance of <see cref="MultiResourceName"/> constructed from the provided ids.</returns>
-        public static MultiResourceName CreateRootAMulti(string rootAId, string multiId) =>
-            new MultiResourceName(ResourceType.RootAMulti, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), multiId: gax::GaxPreconditions.CheckNotNullOrEmpty(multiId, nameof(multiId)));
+        public static MultiResourceName FromRootAMulti(string rootAId, string multiId) =>
+            new MultiResourceName(ResourceNameType.RootAMulti, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), multiId: gax::GaxPreconditions.CheckNotNullOrEmpty(multiId, nameof(multiId)));
 
         /// <summary>
         /// Creates a <see cref="MultiResourceName"/> with the pattern <c>rootb/{root_b_id}/multi/{multi_id}</c>.
@@ -260,8 +260,8 @@ namespace Testing.ResourceNames
         /// <param name="rootBId">The <c>RootB</c> ID. Must not be <c>null</c> or empty.</param>
         /// <param name="multiId">The <c>Multi</c> ID. Must not be <c>null</c> or empty.</param>
         /// <returns>A new instance of <see cref="MultiResourceName"/> constructed from the provided ids.</returns>
-        public static MultiResourceName CreateRootBMulti(string rootBId, string multiId) =>
-            new MultiResourceName(ResourceType.RootBMulti, rootBId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootBId, nameof(rootBId)), multiId: gax::GaxPreconditions.CheckNotNullOrEmpty(multiId, nameof(multiId)));
+        public static MultiResourceName FromRootBMulti(string rootBId, string multiId) =>
+            new MultiResourceName(ResourceNameType.RootBMulti, rootBId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootBId, nameof(rootBId)), multiId: gax::GaxPreconditions.CheckNotNullOrEmpty(multiId, nameof(multiId)));
 
         /// <summary>
         /// Formats the IDs into the string representation of this <see cref="MultiResourceName"/> with pattern
@@ -383,19 +383,19 @@ namespace Testing.ResourceNames
             gax::TemplatedResourceName resourceName;
             if (s_rootAMulti.TryParseName(multiResourceName, out resourceName))
             {
-                result = CreateRootAMulti(resourceName[0], resourceName[1]);
+                result = FromRootAMulti(resourceName[0], resourceName[1]);
                 return true;
             }
             if (s_rootBMulti.TryParseName(multiResourceName, out resourceName))
             {
-                result = CreateRootBMulti(resourceName[0], resourceName[1]);
+                result = FromRootBMulti(resourceName[0], resourceName[1]);
                 return true;
             }
             if (allowUnknown)
             {
                 if (gax::UnknownResourceName.TryParse(multiResourceName, out gax::UnknownResourceName unknownResourceName))
                 {
-                    result = CreateUnknown(unknownResourceName);
+                    result = FromUnknown(unknownResourceName);
                     return true;
                 }
             }
@@ -403,7 +403,7 @@ namespace Testing.ResourceNames
             return false;
         }
 
-        private MultiResourceName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string multiId = null, string rootAId = null, string rootBId = null)
+        private MultiResourceName(ResourceNameType type, gax::UnknownResourceName unknownResourceName = null, string multiId = null, string rootAId = null, string rootBId = null)
         {
             Type = type;
             UnknownResource = unknownResourceName;
@@ -418,12 +418,12 @@ namespace Testing.ResourceNames
         /// </summary>
         /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
         /// <param name="multiId">The <c>Multi</c> ID. Must not be <c>null</c> or empty.</param>
-        public MultiResourceName(string rootAId, string multiId) : this(ResourceType.RootAMulti, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), multiId: gax::GaxPreconditions.CheckNotNullOrEmpty(multiId, nameof(multiId)))
+        public MultiResourceName(string rootAId, string multiId) : this(ResourceNameType.RootAMulti, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), multiId: gax::GaxPreconditions.CheckNotNullOrEmpty(multiId, nameof(multiId)))
         {
         }
 
-        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
-        public ResourceType Type { get; }
+        /// <summary>The <see cref="ResourceNameType"/> of the contained resource name.</summary>
+        public ResourceNameType Type { get; }
 
         /// <summary>
         /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
@@ -447,16 +447,16 @@ namespace Testing.ResourceNames
         public string RootBId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Oneof;
+        public gax::ResourceNameKind Kind => Type == ResourceNameType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Oneof;
 
         /// <inheritdoc/>
         public override string ToString()
         {
             switch (Type)
             {
-                case ResourceType.Unknown: return UnknownResource.ToString();
-                case ResourceType.RootAMulti: return s_rootAMulti.Expand(RootAId, MultiId);
-                case ResourceType.RootBMulti: return s_rootBMulti.Expand(RootBId, MultiId);
+                case ResourceNameType.Unknown: return UnknownResource.ToString();
+                case ResourceNameType.RootAMulti: return s_rootAMulti.Expand(RootAId, MultiId);
+                case ResourceNameType.RootBMulti: return s_rootBMulti.Expand(RootBId, MultiId);
                 default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
             }
         }
@@ -481,12 +481,12 @@ namespace Testing.ResourceNames
     public sealed partial class FutureMultiResourceName : gax::IResourceName, sys::IEquatable<FutureMultiResourceName>
     {
         /// <summary>The possible contents of <see cref="FutureMultiResourceName"/>.</summary>
-        public enum ResourceType
+        public enum ResourceNameType
         {
             /// <summary>A resource of an unknown type.</summary>
             Unknown = 0,
 
-            /// <summary>A resource of type 'root_a'.</summary>
+            /// <summary>A resource name with pattern <c>root/{root_a_id}/futuremulti/{future_multi_id}</c>.</summary>
             RootAFutureMulti = 1
         }
 
@@ -498,8 +498,8 @@ namespace Testing.ResourceNames
         /// A new instance of <see cref="FutureMultiResourceName"/> containing the provided
         /// <paramref name="unknownResourceName"/>.
         /// </returns>
-        public static FutureMultiResourceName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
-            new FutureMultiResourceName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+        public static FutureMultiResourceName FromUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new FutureMultiResourceName(ResourceNameType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
 
         /// <summary>
         /// Creates a <see cref="FutureMultiResourceName"/> with the pattern
@@ -510,8 +510,8 @@ namespace Testing.ResourceNames
         /// <returns>
         /// A new instance of <see cref="FutureMultiResourceName"/> constructed from the provided ids.
         /// </returns>
-        public static FutureMultiResourceName CreateRootAFutureMulti(string rootAId, string futureMultiId) =>
-            new FutureMultiResourceName(ResourceType.RootAFutureMulti, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), futureMultiId: gax::GaxPreconditions.CheckNotNullOrEmpty(futureMultiId, nameof(futureMultiId)));
+        public static FutureMultiResourceName FromRootAFutureMulti(string rootAId, string futureMultiId) =>
+            new FutureMultiResourceName(ResourceNameType.RootAFutureMulti, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), futureMultiId: gax::GaxPreconditions.CheckNotNullOrEmpty(futureMultiId, nameof(futureMultiId)));
 
         /// <summary>
         /// Formats the IDs into the string representation of this <see cref="FutureMultiResourceName"/> with pattern
@@ -618,14 +618,14 @@ namespace Testing.ResourceNames
             gax::TemplatedResourceName resourceName;
             if (s_rootAFutureMulti.TryParseName(futureMultiResourceName, out resourceName))
             {
-                result = CreateRootAFutureMulti(resourceName[0], resourceName[1]);
+                result = FromRootAFutureMulti(resourceName[0], resourceName[1]);
                 return true;
             }
             if (allowUnknown)
             {
                 if (gax::UnknownResourceName.TryParse(futureMultiResourceName, out gax::UnknownResourceName unknownResourceName))
                 {
-                    result = CreateUnknown(unknownResourceName);
+                    result = FromUnknown(unknownResourceName);
                     return true;
                 }
             }
@@ -633,7 +633,7 @@ namespace Testing.ResourceNames
             return false;
         }
 
-        private FutureMultiResourceName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string futureMultiId = null, string rootAId = null)
+        private FutureMultiResourceName(ResourceNameType type, gax::UnknownResourceName unknownResourceName = null, string futureMultiId = null, string rootAId = null)
         {
             Type = type;
             UnknownResource = unknownResourceName;
@@ -647,12 +647,12 @@ namespace Testing.ResourceNames
         /// </summary>
         /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
         /// <param name="futureMultiId">The <c>FutureMulti</c> ID. Must not be <c>null</c> or empty.</param>
-        public FutureMultiResourceName(string rootAId, string futureMultiId) : this(ResourceType.RootAFutureMulti, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), futureMultiId: gax::GaxPreconditions.CheckNotNullOrEmpty(futureMultiId, nameof(futureMultiId)))
+        public FutureMultiResourceName(string rootAId, string futureMultiId) : this(ResourceNameType.RootAFutureMulti, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), futureMultiId: gax::GaxPreconditions.CheckNotNullOrEmpty(futureMultiId, nameof(futureMultiId)))
         {
         }
 
-        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
-        public ResourceType Type { get; }
+        /// <summary>The <see cref="ResourceNameType"/> of the contained resource name.</summary>
+        public ResourceNameType Type { get; }
 
         /// <summary>
         /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
@@ -671,15 +671,15 @@ namespace Testing.ResourceNames
         public string RootAId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
+        public gax::ResourceNameKind Kind => Type == ResourceNameType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
 
         /// <inheritdoc/>
         public override string ToString()
         {
             switch (Type)
             {
-                case ResourceType.Unknown: return UnknownResource.ToString();
-                case ResourceType.RootAFutureMulti: return s_rootAFutureMulti.Expand(RootAId, FutureMultiId);
+                case ResourceNameType.Unknown: return UnknownResource.ToString();
+                case ResourceNameType.RootAFutureMulti: return s_rootAFutureMulti.Expand(RootAId, FutureMultiId);
                 default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
             }
         }
@@ -704,15 +704,19 @@ namespace Testing.ResourceNames
     public sealed partial class OriginallySingleResourceName : gax::IResourceName, sys::IEquatable<OriginallySingleResourceName>
     {
         /// <summary>The possible contents of <see cref="OriginallySingleResourceName"/>.</summary>
-        public enum ResourceType
+        public enum ResourceNameType
         {
             /// <summary>A resource of an unknown type.</summary>
             Unknown = 0,
 
-            /// <summary>A resource of type 'root_a'.</summary>
+            /// <summary>
+            /// A resource name with pattern <c>roota/{root_a_id}/originallysingle/{originally_single_multi_id}</c>.
+            /// </summary>
             RootAOriginallySingleMulti = 1,
 
-            /// <summary>A resource of type 'root_b'.</summary>
+            /// <summary>
+            /// A resource name with pattern <c>rootb/{root_b_id}/originallysingle/{originally_single_multi_id}</c>.
+            /// </summary>
             RootBOriginallySingleMulti = 2
         }
 
@@ -726,8 +730,8 @@ namespace Testing.ResourceNames
         /// A new instance of <see cref="OriginallySingleResourceName"/> containing the provided
         /// <paramref name="unknownResourceName"/>.
         /// </returns>
-        public static OriginallySingleResourceName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
-            new OriginallySingleResourceName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+        public static OriginallySingleResourceName FromUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new OriginallySingleResourceName(ResourceNameType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
 
         /// <summary>
         /// Creates a <see cref="OriginallySingleResourceName"/> with the pattern
@@ -740,8 +744,8 @@ namespace Testing.ResourceNames
         /// <returns>
         /// A new instance of <see cref="OriginallySingleResourceName"/> constructed from the provided ids.
         /// </returns>
-        public static OriginallySingleResourceName CreateRootAOriginallySingleMulti(string rootAId, string originallySingleMultiId) =>
-            new OriginallySingleResourceName(ResourceType.RootAOriginallySingleMulti, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), originallySingleMultiId: gax::GaxPreconditions.CheckNotNullOrEmpty(originallySingleMultiId, nameof(originallySingleMultiId)));
+        public static OriginallySingleResourceName FromRootAOriginallySingleMulti(string rootAId, string originallySingleMultiId) =>
+            new OriginallySingleResourceName(ResourceNameType.RootAOriginallySingleMulti, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), originallySingleMultiId: gax::GaxPreconditions.CheckNotNullOrEmpty(originallySingleMultiId, nameof(originallySingleMultiId)));
 
         /// <summary>
         /// Creates a <see cref="OriginallySingleResourceName"/> with the pattern
@@ -754,8 +758,8 @@ namespace Testing.ResourceNames
         /// <returns>
         /// A new instance of <see cref="OriginallySingleResourceName"/> constructed from the provided ids.
         /// </returns>
-        public static OriginallySingleResourceName CreateRootBOriginallySingleMulti(string rootBId, string originallySingleMultiId) =>
-            new OriginallySingleResourceName(ResourceType.RootBOriginallySingleMulti, rootBId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootBId, nameof(rootBId)), originallySingleMultiId: gax::GaxPreconditions.CheckNotNullOrEmpty(originallySingleMultiId, nameof(originallySingleMultiId)));
+        public static OriginallySingleResourceName FromRootBOriginallySingleMulti(string rootBId, string originallySingleMultiId) =>
+            new OriginallySingleResourceName(ResourceNameType.RootBOriginallySingleMulti, rootBId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootBId, nameof(rootBId)), originallySingleMultiId: gax::GaxPreconditions.CheckNotNullOrEmpty(originallySingleMultiId, nameof(originallySingleMultiId)));
 
         /// <summary>
         /// Formats the IDs into the string representation of this <see cref="OriginallySingleResourceName"/> with
@@ -912,19 +916,19 @@ namespace Testing.ResourceNames
             gax::TemplatedResourceName resourceName;
             if (s_rootAOriginallySingleMulti.TryParseName(originallySingleResourceName, out resourceName))
             {
-                result = CreateRootAOriginallySingleMulti(resourceName[0], resourceName[1]);
+                result = FromRootAOriginallySingleMulti(resourceName[0], resourceName[1]);
                 return true;
             }
             if (s_rootBOriginallySingleMulti.TryParseName(originallySingleResourceName, out resourceName))
             {
-                result = CreateRootBOriginallySingleMulti(resourceName[0], resourceName[1]);
+                result = FromRootBOriginallySingleMulti(resourceName[0], resourceName[1]);
                 return true;
             }
             if (allowUnknown)
             {
                 if (gax::UnknownResourceName.TryParse(originallySingleResourceName, out gax::UnknownResourceName unknownResourceName))
                 {
-                    result = CreateUnknown(unknownResourceName);
+                    result = FromUnknown(unknownResourceName);
                     return true;
                 }
             }
@@ -932,7 +936,7 @@ namespace Testing.ResourceNames
             return false;
         }
 
-        private OriginallySingleResourceName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string originallySingleMultiId = null, string rootAId = null, string rootBId = null)
+        private OriginallySingleResourceName(ResourceNameType type, gax::UnknownResourceName unknownResourceName = null, string originallySingleMultiId = null, string rootAId = null, string rootBId = null)
         {
             Type = type;
             UnknownResource = unknownResourceName;
@@ -949,12 +953,12 @@ namespace Testing.ResourceNames
         /// <param name="originallySingleMultiId">
         /// The <c>OriginallySingleMulti</c> ID. Must not be <c>null</c> or empty.
         /// </param>
-        public OriginallySingleResourceName(string rootAId, string originallySingleMultiId) : this(ResourceType.RootAOriginallySingleMulti, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), originallySingleMultiId: gax::GaxPreconditions.CheckNotNullOrEmpty(originallySingleMultiId, nameof(originallySingleMultiId)))
+        public OriginallySingleResourceName(string rootAId, string originallySingleMultiId) : this(ResourceNameType.RootAOriginallySingleMulti, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), originallySingleMultiId: gax::GaxPreconditions.CheckNotNullOrEmpty(originallySingleMultiId, nameof(originallySingleMultiId)))
         {
         }
 
-        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
-        public ResourceType Type { get; }
+        /// <summary>The <see cref="ResourceNameType"/> of the contained resource name.</summary>
+        public ResourceNameType Type { get; }
 
         /// <summary>
         /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
@@ -979,16 +983,16 @@ namespace Testing.ResourceNames
         public string RootBId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Oneof;
+        public gax::ResourceNameKind Kind => Type == ResourceNameType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Oneof;
 
         /// <inheritdoc/>
         public override string ToString()
         {
             switch (Type)
             {
-                case ResourceType.Unknown: return UnknownResource.ToString();
-                case ResourceType.RootAOriginallySingleMulti: return s_rootAOriginallySingleMulti.Expand(RootAId, OriginallySingleMultiId);
-                case ResourceType.RootBOriginallySingleMulti: return s_rootBOriginallySingleMulti.Expand(RootBId, OriginallySingleMultiId);
+                case ResourceNameType.Unknown: return UnknownResource.ToString();
+                case ResourceNameType.RootAOriginallySingleMulti: return s_rootAOriginallySingleMulti.Expand(RootAId, OriginallySingleMultiId);
+                case ResourceNameType.RootBOriginallySingleMulti: return s_rootBOriginallySingleMulti.Expand(RootBId, OriginallySingleMultiId);
                 default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
             }
         }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames/ResourceNamesResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames/ResourceNamesResourceNames.g.cs
@@ -23,74 +23,182 @@ namespace Testing.ResourceNames
     /// <summary>Resource name for the <c>SingleResource</c> resource.</summary>
     public sealed partial class SingleResourceName : gax::IResourceName, sys::IEquatable<SingleResourceName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("items/{item_id}");
-
-        /// <summary>
-        /// Parses the given <c>SingleResource</c> resource name in string form into a new
-        /// <see cref="SingleResourceName"/> instance.
-        /// </summary>
-        /// <param name="singleResourceName">
-        /// The <c>SingleResource</c> resource name in string form. Must not be <c>null</c>.
-        /// </param>
-        /// <returns>The parsed <see cref="SingleResourceName"/> if successful.</returns>
-        public static SingleResourceName Parse(string singleResourceName)
+        /// <summary>The possible contents of <see cref="SingleResourceName"/>.</summary>
+        public enum ResourceType
         {
-            gax::GaxPreconditions.CheckNotNull(singleResourceName, nameof(singleResourceName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(singleResourceName);
-            return new SingleResourceName(resourceName[0]);
+            /// <summary>A resource of an unknown type.</summary>
+            Unknown = 0,
+
+            /// <summary>A resource of type 'item'.</summary>
+            Item = 1
         }
 
+        private static gax::PathTemplate s_item = new gax::PathTemplate("items/{item_id}");
+
+        /// <summary>Creates a <see cref="SingleResourceName"/> containing an unknown resource name.</summary>
+        /// <param name="unknownResourceName">The unknown resource name. Must not be <c>null</c>.</param>
+        /// <returns>
+        /// A new instance of <see cref="SingleResourceName"/> containing the provided
+        /// <paramref name="unknownResourceName"/>.
+        /// </returns>
+        public static SingleResourceName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new SingleResourceName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+
+        /// <summary>Creates a <see cref="SingleResourceName"/> with the pattern <c>items/{item_id}</c>.</summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>A new instance of <see cref="SingleResourceName"/> constructed from the provided ids.</returns>
+        public static SingleResourceName CreateItem(string itemId) =>
+            new SingleResourceName(ResourceType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+
         /// <summary>
-        /// Tries to parse the given session resource name in string form into a new <see cref="SingleResourceName"/>
-        /// instance.
+        /// Formats the IDs into the string representation of this <see cref="SingleResourceName"/> with pattern
+        /// <c>items/{item_id}</c>.
+        /// </summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="SingleResourceName"/> with pattern <c>items/{item_id}</c>.
+        /// </returns>
+        public static string Format(string itemId) => FormatItem(itemId);
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="SingleResourceName"/> with pattern
+        /// <c>items/{item_id}</c>.
+        /// </summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="SingleResourceName"/> with pattern <c>items/{item_id}</c>.
+        /// </returns>
+        public static string FormatItem(string itemId) =>
+            s_item.Expand(gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+
+        /// <summary>
+        /// Parses the given resource name string into a new <see cref="SingleResourceName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="singleResourceName"/>
-        /// is <c>null</c>, as this would usually indicate a programming error rather than a data error.
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}</c></description></item></list>
         /// </remarks>
-        /// <param name="singleResourceName">
-        /// The <c>SingleResource</c> resource name in string form. Must not be <c>null</c>.
-        /// </param>
-        /// <param name="result">
-        /// When this method returns, the parsed <see cref="SingleResourceName"/>, or <c>null</c> if parsing fails.
-        /// </param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string singleResourceName, out SingleResourceName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(singleResourceName, nameof(singleResourceName));
-            if (s_template.TryParseName(singleResourceName, out gax::TemplatedResourceName resourceName))
-            {
-                result = new SingleResourceName(resourceName[0]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>Formats the IDs into the string representation of the <see cref="SingleResourceName"/>.</summary>
-        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c>.</param>
-        /// <returns>The string representation of the <see cref="SingleResourceName"/>.</returns>
-        public static string Format(string itemId) =>
-            s_template.Expand(gax::GaxPreconditions.CheckNotNull(itemId, nameof(itemId)));
+        /// <param name="singleResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="SingleResourceName"/> if successful.</returns>
+        public static SingleResourceName Parse(string singleResourceName) => Parse(singleResourceName, false);
 
         /// <summary>
-        /// Constructs a new instance of the <see cref="SingleResourceName"/> resource name class from its component
-        /// parts.
+        /// Parses the given resource name string into a new <see cref="SingleResourceName"/> instance; optionally
+        /// allowing an unknown resource name to be successfully parsed
         /// </summary>
-        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c>.</param>
-        public SingleResourceName(string itemId) => ItemId = gax::GaxPreconditions.CheckNotNull(itemId, nameof(itemId));
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}</c></description></item></list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="singleResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
+        /// </param>
+        /// <returns>The parsed <see cref="SingleResourceName"/> if successful.</returns>
+        public static SingleResourceName Parse(string singleResourceName, bool allowUnknown) =>
+            TryParse(singleResourceName, allowUnknown, out SingleResourceName result) ? result : throw new sys::ArgumentException("The given resource-name matches no pattern.");
 
-        /// <summary>The <c>Item</c> ID. Never <c>null</c>.</summary>
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="SingleResourceName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}</c></description></item></list>
+        /// </remarks>
+        /// <param name="singleResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="SingleResourceName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string singleResourceName, out SingleResourceName result) =>
+            TryParse(singleResourceName, false, out result);
+
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="SingleResourceName"/> instance;
+        /// optionally allowing an unknown resource name to be successfully parsed.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}</c></description></item></list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="singleResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
+        /// </param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="SingleResourceName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string singleResourceName, bool allowUnknown, out SingleResourceName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(singleResourceName, nameof(singleResourceName));
+            gax::TemplatedResourceName resourceName;
+            if (s_item.TryParseName(singleResourceName, out resourceName))
+            {
+                result = CreateItem(resourceName[0]);
+                return true;
+            }
+            if (allowUnknown)
+            {
+                if (gax::UnknownResourceName.TryParse(singleResourceName, out gax::UnknownResourceName unknownResourceName))
+                {
+                    result = CreateUnknown(unknownResourceName);
+                    return true;
+                }
+            }
+            result = null;
+            return false;
+        }
+
+        private SingleResourceName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null)
+        {
+            Type = type;
+            UnknownResource = unknownResourceName;
+            ItemId = itemId;
+        }
+
+        /// <summary>
+        /// Constructs a new instance of a <see cref="SingleResourceName"/> class from the component parts of pattern
+        /// <c>items/{item_id}</c>
+        /// </summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        public SingleResourceName(string itemId) : this(ResourceType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
+        {
+        }
+
+        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
+        public ResourceType Type { get; }
+
+        /// <summary>
+        /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
+        /// unknown resource name.
+        /// </summary>
+        public gax::UnknownResourceName UnknownResource { get; }
+
+        /// <summary>
+        /// The <c>Item</c> ID. Will not be <c>null</c>, unless this instance contains an unknown resource name.
+        /// </summary>
         public string ItemId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
 
         /// <inheritdoc/>
-        public override string ToString() => s_template.Expand(ItemId);
+        public override string ToString()
+        {
+            switch (Type)
+            {
+                case ResourceType.Unknown: return UnknownResource.ToString();
+                case ResourceType.Item: return s_item.Expand(ItemId);
+                default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
+            }
+        }
 
         /// <inheritdoc/>
         public override int GetHashCode() => ToString().GetHashCode();
@@ -108,567 +216,416 @@ namespace Testing.ResourceNames
         public static bool operator !=(SingleResourceName a, SingleResourceName b) => !(a == b);
     }
 
-    /// <summary>Resource name for the <c>RootAMulti</c> resource.</summary>
-    public sealed partial class RootAMultiName : gax::IResourceName, sys::IEquatable<RootAMultiName>
+    /// <summary>Resource name for the <c>MultiResource</c> resource.</summary>
+    public sealed partial class MultiResourceName : gax::IResourceName, sys::IEquatable<MultiResourceName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("roota/{root_a_id}/multi/{multi_id}");
-
-        /// <summary>
-        /// Parses the given <c>RootAMulti</c> resource name in string form into a new <see cref="RootAMultiName"/>
-        /// instance.
-        /// </summary>
-        /// <param name="rootAMultiName">
-        /// The <c>RootAMulti</c> resource name in string form. Must not be <c>null</c>.
-        /// </param>
-        /// <returns>The parsed <see cref="RootAMultiName"/> if successful.</returns>
-        public static RootAMultiName Parse(string rootAMultiName)
+        /// <summary>The possible contents of <see cref="MultiResourceName"/>.</summary>
+        public enum ResourceType
         {
-            gax::GaxPreconditions.CheckNotNull(rootAMultiName, nameof(rootAMultiName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(rootAMultiName);
-            return new RootAMultiName(resourceName[0], resourceName[1]);
+            /// <summary>A resource of an unknown type.</summary>
+            Unknown = 0,
+
+            /// <summary>A resource of type 'root_a'.</summary>
+            RootAMulti = 1,
+
+            /// <summary>A resource of type 'root_b'.</summary>
+            RootBMulti = 2
         }
 
+        private static gax::PathTemplate s_rootAMulti = new gax::PathTemplate("roota/{root_a_id}/multi/{multi_id}");
+
+        private static gax::PathTemplate s_rootBMulti = new gax::PathTemplate("rootb/{root_b_id}/multi/{multi_id}");
+
+        /// <summary>Creates a <see cref="MultiResourceName"/> containing an unknown resource name.</summary>
+        /// <param name="unknownResourceName">The unknown resource name. Must not be <c>null</c>.</param>
+        /// <returns>
+        /// A new instance of <see cref="MultiResourceName"/> containing the provided
+        /// <paramref name="unknownResourceName"/>.
+        /// </returns>
+        public static MultiResourceName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new MultiResourceName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+
         /// <summary>
-        /// Tries to parse the given session resource name in string form into a new <see cref="RootAMultiName"/>
-        /// instance.
+        /// Creates a <see cref="MultiResourceName"/> with the pattern <c>roota/{root_a_id}/multi/{multi_id}</c>.
+        /// </summary>
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="multiId">The <c>Multi</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>A new instance of <see cref="MultiResourceName"/> constructed from the provided ids.</returns>
+        public static MultiResourceName CreateRootAMulti(string rootAId, string multiId) =>
+            new MultiResourceName(ResourceType.RootAMulti, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), multiId: gax::GaxPreconditions.CheckNotNullOrEmpty(multiId, nameof(multiId)));
+
+        /// <summary>
+        /// Creates a <see cref="MultiResourceName"/> with the pattern <c>rootb/{root_b_id}/multi/{multi_id}</c>.
+        /// </summary>
+        /// <param name="rootBId">The <c>RootB</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="multiId">The <c>Multi</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>A new instance of <see cref="MultiResourceName"/> constructed from the provided ids.</returns>
+        public static MultiResourceName CreateRootBMulti(string rootBId, string multiId) =>
+            new MultiResourceName(ResourceType.RootBMulti, rootBId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootBId, nameof(rootBId)), multiId: gax::GaxPreconditions.CheckNotNullOrEmpty(multiId, nameof(multiId)));
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="MultiResourceName"/> with pattern
+        /// <c>roota/{root_a_id}/multi/{multi_id}</c>.
+        /// </summary>
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="multiId">The <c>Multi</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="MultiResourceName"/> with pattern
+        /// <c>roota/{root_a_id}/multi/{multi_id}</c>.
+        /// </returns>
+        public static string Format(string rootAId, string multiId) => FormatRootAMulti(rootAId, multiId);
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="MultiResourceName"/> with pattern
+        /// <c>roota/{root_a_id}/multi/{multi_id}</c>.
+        /// </summary>
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="multiId">The <c>Multi</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="MultiResourceName"/> with pattern
+        /// <c>roota/{root_a_id}/multi/{multi_id}</c>.
+        /// </returns>
+        public static string FormatRootAMulti(string rootAId, string multiId) =>
+            s_rootAMulti.Expand(gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), gax::GaxPreconditions.CheckNotNullOrEmpty(multiId, nameof(multiId)));
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="MultiResourceName"/> with pattern
+        /// <c>rootb/{root_b_id}/multi/{multi_id}</c>.
+        /// </summary>
+        /// <param name="rootBId">The <c>RootB</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="multiId">The <c>Multi</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="MultiResourceName"/> with pattern
+        /// <c>rootb/{root_b_id}/multi/{multi_id}</c>.
+        /// </returns>
+        public static string FormatRootBMulti(string rootBId, string multiId) =>
+            s_rootBMulti.Expand(gax::GaxPreconditions.CheckNotNullOrEmpty(rootBId, nameof(rootBId)), gax::GaxPreconditions.CheckNotNullOrEmpty(multiId, nameof(multiId)));
+
+        /// <summary>
+        /// Parses the given resource name string into a new <see cref="MultiResourceName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="rootAMultiName"/> is
-        /// <c>null</c>, as this would usually indicate a programming error rather than a data error.
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet">
+        /// <item><description><c>roota/{root_a_id}/multi/{multi_id}</c></description></item>
+        /// <item><description><c>rootb/{root_b_id}/multi/{multi_id}</c></description></item>
+        /// </list>
         /// </remarks>
-        /// <param name="rootAMultiName">
-        /// The <c>RootAMulti</c> resource name in string form. Must not be <c>null</c>.
-        /// </param>
-        /// <param name="result">
-        /// When this method returns, the parsed <see cref="RootAMultiName"/>, or <c>null</c> if parsing fails.
-        /// </param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string rootAMultiName, out RootAMultiName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(rootAMultiName, nameof(rootAMultiName));
-            if (s_template.TryParseName(rootAMultiName, out gax::TemplatedResourceName resourceName))
-            {
-                result = new RootAMultiName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>Formats the IDs into the string representation of the <see cref="RootAMultiName"/>.</summary>
-        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c>.</param>
-        /// <param name="multiId">The <c>Multi</c> ID. Must not be <c>null</c>.</param>
-        /// <returns>The string representation of the <see cref="RootAMultiName"/>.</returns>
-        public static string Format(string rootAId, string multiId) =>
-            s_template.Expand(gax::GaxPreconditions.CheckNotNull(rootAId, nameof(rootAId)), gax::GaxPreconditions.CheckNotNull(multiId, nameof(multiId)));
+        /// <param name="multiResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="MultiResourceName"/> if successful.</returns>
+        public static MultiResourceName Parse(string multiResourceName) => Parse(multiResourceName, false);
 
         /// <summary>
-        /// Constructs a new instance of the <see cref="RootAMultiName"/> resource name class from its component parts.
+        /// Parses the given resource name string into a new <see cref="MultiResourceName"/> instance; optionally
+        /// allowing an unknown resource name to be successfully parsed
         /// </summary>
-        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c>.</param>
-        /// <param name="multiId">The <c>Multi</c> ID. Must not be <c>null</c>.</param>
-        public RootAMultiName(string rootAId, string multiId)
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet">
+        /// <item><description><c>roota/{root_a_id}/multi/{multi_id}</c></description></item>
+        /// <item><description><c>rootb/{root_b_id}/multi/{multi_id}</c></description></item>
+        /// </list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="multiResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
+        /// </param>
+        /// <returns>The parsed <see cref="MultiResourceName"/> if successful.</returns>
+        public static MultiResourceName Parse(string multiResourceName, bool allowUnknown) =>
+            TryParse(multiResourceName, allowUnknown, out MultiResourceName result) ? result : throw new sys::ArgumentException("The given resource-name matches no pattern.");
+
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="MultiResourceName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet">
+        /// <item><description><c>roota/{root_a_id}/multi/{multi_id}</c></description></item>
+        /// <item><description><c>rootb/{root_b_id}/multi/{multi_id}</c></description></item>
+        /// </list>
+        /// </remarks>
+        /// <param name="multiResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="MultiResourceName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string multiResourceName, out MultiResourceName result) =>
+            TryParse(multiResourceName, false, out result);
+
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="MultiResourceName"/> instance;
+        /// optionally allowing an unknown resource name to be successfully parsed.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet">
+        /// <item><description><c>roota/{root_a_id}/multi/{multi_id}</c></description></item>
+        /// <item><description><c>rootb/{root_b_id}/multi/{multi_id}</c></description></item>
+        /// </list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="multiResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
+        /// </param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="MultiResourceName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string multiResourceName, bool allowUnknown, out MultiResourceName result)
         {
-            RootAId = gax::GaxPreconditions.CheckNotNull(rootAId, nameof(rootAId));
-            MultiId = gax::GaxPreconditions.CheckNotNull(multiId, nameof(multiId));
+            gax::GaxPreconditions.CheckNotNull(multiResourceName, nameof(multiResourceName));
+            gax::TemplatedResourceName resourceName;
+            if (s_rootAMulti.TryParseName(multiResourceName, out resourceName))
+            {
+                result = CreateRootAMulti(resourceName[0], resourceName[1]);
+                return true;
+            }
+            if (s_rootBMulti.TryParseName(multiResourceName, out resourceName))
+            {
+                result = CreateRootBMulti(resourceName[0], resourceName[1]);
+                return true;
+            }
+            if (allowUnknown)
+            {
+                if (gax::UnknownResourceName.TryParse(multiResourceName, out gax::UnknownResourceName unknownResourceName))
+                {
+                    result = CreateUnknown(unknownResourceName);
+                    return true;
+                }
+            }
+            result = null;
+            return false;
         }
 
-        /// <summary>The <c>RootA</c> ID. Never <c>null</c>.</summary>
-        public string RootAId { get; }
+        private MultiResourceName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string multiId = null, string rootAId = null, string rootBId = null)
+        {
+            Type = type;
+            UnknownResource = unknownResourceName;
+            MultiId = multiId;
+            RootAId = rootAId;
+            RootBId = rootBId;
+        }
 
-        /// <summary>The <c>Multi</c> ID. Never <c>null</c>.</summary>
+        /// <summary>
+        /// Constructs a new instance of a <see cref="MultiResourceName"/> class from the component parts of pattern
+        /// <c>roota/{root_a_id}/multi/{multi_id}</c>
+        /// </summary>
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="multiId">The <c>Multi</c> ID. Must not be <c>null</c> or empty.</param>
+        public MultiResourceName(string rootAId, string multiId) : this(ResourceType.RootAMulti, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), multiId: gax::GaxPreconditions.CheckNotNullOrEmpty(multiId, nameof(multiId)))
+        {
+        }
+
+        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
+        public ResourceType Type { get; }
+
+        /// <summary>
+        /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
+        /// unknown resource name.
+        /// </summary>
+        public gax::UnknownResourceName UnknownResource { get; }
+
+        /// <summary>
+        /// The <c>Multi</c> ID. May be <c>null</c>, depending on which resource name is contained by this instance.
+        /// </summary>
         public string MultiId { get; }
 
-        /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc/>
-        public override string ToString() => s_template.Expand(RootAId, MultiId);
-
-        /// <inheritdoc/>
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as RootAMultiName);
-
-        /// <inheritdoc/>
-        public bool Equals(RootAMultiName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc/>
-        public static bool operator ==(RootAMultiName a, RootAMultiName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc/>
-        public static bool operator !=(RootAMultiName a, RootAMultiName b) => !(a == b);
-    }
-
-    /// <summary>Resource name for the <c>RootBMulti</c> resource.</summary>
-    public sealed partial class RootBMultiName : gax::IResourceName, sys::IEquatable<RootBMultiName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("rootb/{root_b_id}/multi/{multi_id}");
+        /// <summary>
+        /// The <c>RootA</c> ID. May be <c>null</c>, depending on which resource name is contained by this instance.
+        /// </summary>
+        public string RootAId { get; }
 
         /// <summary>
-        /// Parses the given <c>RootBMulti</c> resource name in string form into a new <see cref="RootBMultiName"/>
-        /// instance.
+        /// The <c>RootB</c> ID. May be <c>null</c>, depending on which resource name is contained by this instance.
         /// </summary>
-        /// <param name="rootBMultiName">
-        /// The <c>RootBMulti</c> resource name in string form. Must not be <c>null</c>.
-        /// </param>
-        /// <returns>The parsed <see cref="RootBMultiName"/> if successful.</returns>
-        public static RootBMultiName Parse(string rootBMultiName)
-        {
-            gax::GaxPreconditions.CheckNotNull(rootBMultiName, nameof(rootBMultiName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(rootBMultiName);
-            return new RootBMultiName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given session resource name in string form into a new <see cref="RootBMultiName"/>
-        /// instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="rootBMultiName"/> is
-        /// <c>null</c>, as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="rootBMultiName">
-        /// The <c>RootBMulti</c> resource name in string form. Must not be <c>null</c>.
-        /// </param>
-        /// <param name="result">
-        /// When this method returns, the parsed <see cref="RootBMultiName"/>, or <c>null</c> if parsing fails.
-        /// </param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string rootBMultiName, out RootBMultiName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(rootBMultiName, nameof(rootBMultiName));
-            if (s_template.TryParseName(rootBMultiName, out gax::TemplatedResourceName resourceName))
-            {
-                result = new RootBMultiName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>Formats the IDs into the string representation of the <see cref="RootBMultiName"/>.</summary>
-        /// <param name="rootBId">The <c>RootB</c> ID. Must not be <c>null</c>.</param>
-        /// <param name="multiId">The <c>Multi</c> ID. Must not be <c>null</c>.</param>
-        /// <returns>The string representation of the <see cref="RootBMultiName"/>.</returns>
-        public static string Format(string rootBId, string multiId) =>
-            s_template.Expand(gax::GaxPreconditions.CheckNotNull(rootBId, nameof(rootBId)), gax::GaxPreconditions.CheckNotNull(multiId, nameof(multiId)));
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="RootBMultiName"/> resource name class from its component parts.
-        /// </summary>
-        /// <param name="rootBId">The <c>RootB</c> ID. Must not be <c>null</c>.</param>
-        /// <param name="multiId">The <c>Multi</c> ID. Must not be <c>null</c>.</param>
-        public RootBMultiName(string rootBId, string multiId)
-        {
-            RootBId = gax::GaxPreconditions.CheckNotNull(rootBId, nameof(rootBId));
-            MultiId = gax::GaxPreconditions.CheckNotNull(multiId, nameof(multiId));
-        }
-
-        /// <summary>The <c>RootB</c> ID. Never <c>null</c>.</summary>
         public string RootBId { get; }
 
-        /// <summary>The <c>Multi</c> ID. Never <c>null</c>.</summary>
-        public string MultiId { get; }
+        /// <inheritdoc/>
+        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Oneof;
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc/>
-        public override string ToString() => s_template.Expand(RootBId, MultiId);
+        public override string ToString()
+        {
+            switch (Type)
+            {
+                case ResourceType.Unknown: return UnknownResource.ToString();
+                case ResourceType.RootAMulti: return s_rootAMulti.Expand(RootAId, MultiId);
+                case ResourceType.RootBMulti: return s_rootBMulti.Expand(RootBId, MultiId);
+                default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
+            }
+        }
 
         /// <inheritdoc/>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as RootBMultiName);
+        public override bool Equals(object obj) => Equals(obj as MultiResourceName);
 
         /// <inheritdoc/>
-        public bool Equals(RootBMultiName other) => ToString() == other?.ToString();
+        public bool Equals(MultiResourceName other) => ToString() == other?.ToString();
 
         /// <inheritdoc/>
-        public static bool operator ==(RootBMultiName a, RootBMultiName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+        public static bool operator ==(MultiResourceName a, MultiResourceName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
 
         /// <inheritdoc/>
-        public static bool operator !=(RootBMultiName a, RootBMultiName b) => !(a == b);
+        public static bool operator !=(MultiResourceName a, MultiResourceName b) => !(a == b);
     }
 
-    /// <summary>Resource name which will contain one of a choice of resource names.</summary>
-    /// <remarks>
-    /// This resource name will contain one of the following:
-    /// <list type="bullet">
-    /// <item><description>RootAMultiName: A resource of type 'root_a'.</description></item>
-    /// <item><description>RootBMultiName: A resource of type 'root_b'.</description></item>
-    /// </list>
-    /// </remarks>
-    public sealed partial class MultiResourceNameOneOf : gax::IResourceName, sys::IEquatable<MultiResourceNameOneOf>
+    /// <summary>Resource name for the <c>FutureMultiResource</c> resource.</summary>
+    public sealed partial class FutureMultiResourceName : gax::IResourceName, sys::IEquatable<FutureMultiResourceName>
     {
-        /// <summary>The possible contents of <see cref="MultiResourceNameOneOf"/>.</summary>
-        public enum OneofType
+        /// <summary>The possible contents of <see cref="FutureMultiResourceName"/>.</summary>
+        public enum ResourceType
         {
             /// <summary>A resource of an unknown type.</summary>
             Unknown = 0,
 
-            /// <summary>A resource of type 'root_a'</summary>
-            RootAMultiName = 1,
-
-            /// <summary>A resource of type 'root_b'</summary>
-            RootBMultiName = 2
+            /// <summary>A resource of type 'root_a'.</summary>
+            RootAFutureMulti = 1
         }
 
+        private static gax::PathTemplate s_rootAFutureMulti = new gax::PathTemplate("root/{root_a_id}/futuremulti/{future_multi_id}");
+
+        /// <summary>Creates a <see cref="FutureMultiResourceName"/> containing an unknown resource name.</summary>
+        /// <param name="unknownResourceName">The unknown resource name. Must not be <c>null</c>.</param>
+        /// <returns>
+        /// A new instance of <see cref="FutureMultiResourceName"/> containing the provided
+        /// <paramref name="unknownResourceName"/>.
+        /// </returns>
+        public static FutureMultiResourceName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new FutureMultiResourceName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+
         /// <summary>
-        /// Parses the given <c>MultiResource</c> resource name in string form into a new
-        /// <see cref="MultiResourceNameOneOf"/> instance.
+        /// Creates a <see cref="FutureMultiResourceName"/> with the pattern
+        /// <c>root/{root_a_id}/futuremulti/{future_multi_id}</c>.
+        /// </summary>
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="futureMultiId">The <c>FutureMulti</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// A new instance of <see cref="FutureMultiResourceName"/> constructed from the provided ids.
+        /// </returns>
+        public static FutureMultiResourceName CreateRootAFutureMulti(string rootAId, string futureMultiId) =>
+            new FutureMultiResourceName(ResourceType.RootAFutureMulti, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), futureMultiId: gax::GaxPreconditions.CheckNotNullOrEmpty(futureMultiId, nameof(futureMultiId)));
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="FutureMultiResourceName"/> with pattern
+        /// <c>root/{root_a_id}/futuremulti/{future_multi_id}</c>.
+        /// </summary>
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="futureMultiId">The <c>FutureMulti</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="FutureMultiResourceName"/> with pattern
+        /// <c>root/{root_a_id}/futuremulti/{future_multi_id}</c>.
+        /// </returns>
+        public static string Format(string rootAId, string futureMultiId) => FormatRootAFutureMulti(rootAId, futureMultiId);
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="FutureMultiResourceName"/> with pattern
+        /// <c>root/{root_a_id}/futuremulti/{future_multi_id}</c>.
+        /// </summary>
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="futureMultiId">The <c>FutureMulti</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="FutureMultiResourceName"/> with pattern
+        /// <c>root/{root_a_id}/futuremulti/{future_multi_id}</c>.
+        /// </returns>
+        public static string FormatRootAFutureMulti(string rootAId, string futureMultiId) =>
+            s_rootAFutureMulti.Expand(gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), gax::GaxPreconditions.CheckNotNullOrEmpty(futureMultiId, nameof(futureMultiId)));
+
+        /// <summary>
+        /// Parses the given resource name string into a new <see cref="FutureMultiResourceName"/> instance.
         /// </summary>
         /// <remarks>
-        /// To parse successfully the resource name must be one of the following:
+        /// To parse successfully, the resource name must be formatted as one of the following:
         /// <list type="bullet">
-        /// <item><description>RootAMultiName: A resource of type 'root_a'.</description></item>
-        /// <item><description>RootBMultiName: A resource of type 'root_b'.</description></item>
+        /// <item><description><c>root/{root_a_id}/futuremulti/{future_multi_id}</c></description></item>
         /// </list>
-        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>
         /// </remarks>
-        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="allowUnknown">
-        /// If <c>true</c>, will successfully parse an unknown resource name into an
-        /// <see cref="gax::UnknownResourceName"/>; otherwise will throw an<see cref="sys::ArgumentException"/> if an
-        /// unknown resource name is given.
-        /// </param>
-        /// <returns>The parsed <see cref="MultiResourceNameOneOf"/> if successful.</returns>
-        public static MultiResourceNameOneOf Parse(string name, bool allowUnknown)
-        {
-            if (TryParse(name, allowUnknown, out MultiResourceNameOneOf result))
-            {
-                return result;
-            }
-            throw new sys::ArgumentException("Invalid name", nameof(name));
-        }
+        /// <param name="futureMultiResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="FutureMultiResourceName"/> if successful.</returns>
+        public static FutureMultiResourceName Parse(string futureMultiResourceName) => Parse(futureMultiResourceName, false);
 
         /// <summary>
-        /// Tries to parse a resource name in string form into a new <see cref="MultiResourceNameOneOf"/> instance.
+        /// Parses the given resource name string into a new <see cref="FutureMultiResourceName"/> instance; optionally
+        /// allowing an unknown resource name to be successfully parsed
         /// </summary>
         /// <remarks>
-        /// To parse successfully the resource name must be one of the following:
+        /// To parse successfully, the resource name must be formatted as one of the following:
         /// <list type="bullet">
-        /// <item><description>RootAMultiName: A resource of type 'root_a'.</description></item>
-        /// <item><description>RootBMultiName: A resource of type 'root_b'.</description></item>
+        /// <item><description><c>root/{root_a_id}/futuremulti/{future_multi_id}</c></description></item>
         /// </list>
-        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
         /// </remarks>
-        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="futureMultiResourceName">The resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="allowUnknown">
-        /// If <c>true</c>, will successfully parse an unknown resource name into an
-        /// <see cref="gax::UnknownResourceName"/>.
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
         /// </param>
+        /// <returns>The parsed <see cref="FutureMultiResourceName"/> if successful.</returns>
+        public static FutureMultiResourceName Parse(string futureMultiResourceName, bool allowUnknown) =>
+            TryParse(futureMultiResourceName, allowUnknown, out FutureMultiResourceName result) ? result : throw new sys::ArgumentException("The given resource-name matches no pattern.");
+
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="FutureMultiResourceName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet">
+        /// <item><description><c>root/{root_a_id}/futuremulti/{future_multi_id}</c></description></item>
+        /// </list>
+        /// </remarks>
+        /// <param name="futureMultiResourceName">The resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">
-        /// When this method returns, the parsed <see cref="MultiResourceNameOneOf"/>, or <c>null</c> if parsing fails.
-        /// </param>
-        /// <returns><c>true</c> if the name was parsed succssfully; othrewise <c>false</c></returns>
-        public static bool TryParse(string name, bool allowUnknown, out MultiResourceNameOneOf result)
-        {
-            gax::GaxPreconditions.CheckNotNull(name, nameof(name));
-            if (RootAMultiName.TryParse(name, out RootAMultiName rootAMultiName))
-            {
-                result = new MultiResourceNameOneOf(OneofType.RootAMultiName, rootAMultiName);
-                return true;
-            }
-            if (RootBMultiName.TryParse(name, out RootBMultiName rootBMultiName))
-            {
-                result = new MultiResourceNameOneOf(OneofType.RootBMultiName, rootBMultiName);
-                return true;
-            }
-            if (allowUnknown)
-            {
-                if (gax::UnknownResourceName.TryParse(name, out gax::UnknownResourceName unknownResourceName))
-                {
-                    result = new MultiResourceNameOneOf(OneofType.Unknown, unknownResourceName);
-                    return true;
-                }
-            }
-            result = null;
-            return false;
-        }
-
-        /// <summary>
-        /// Constructs a new instance of <see cref="MultiResourceNameOneOf"/> from the provided
-        /// <see cref="RootAMultiName"/>.
-        /// </summary>
-        /// <param name="rootAMultiName">
-        /// The <see cref="RootAMultiName"/> to be contained within the returned <see cref="MultiResourceNameOneOf"/>.
-        /// Must not be <c>null</c>
-        /// </param>
-        /// <returns>A new <see cref="MultiResourceNameOneOf"/>, containing <paramref name="rootAMultiName"/>.</returns>
-        public static MultiResourceNameOneOf From(RootAMultiName rootAMultiName) =>
-            new MultiResourceNameOneOf(OneofType.RootAMultiName, rootAMultiName);
-
-        /// <summary>
-        /// Constructs a new instance of <see cref="MultiResourceNameOneOf"/> from the provided
-        /// <see cref="RootBMultiName"/>.
-        /// </summary>
-        /// <param name="rootBMultiName">
-        /// The <see cref="RootBMultiName"/> to be contained within the returned <see cref="MultiResourceNameOneOf"/>.
-        /// Must not be <c>null</c>
-        /// </param>
-        /// <returns>A new <see cref="MultiResourceNameOneOf"/>, containing <paramref name="rootBMultiName"/>.</returns>
-        public static MultiResourceNameOneOf From(RootBMultiName rootBMultiName) =>
-            new MultiResourceNameOneOf(OneofType.RootBMultiName, rootBMultiName);
-
-        private static bool IsValid(OneofType type, gax::IResourceName name)
-        {
-            switch (type)
-            {
-                case OneofType.Unknown: return true;
-                case OneofType.RootAMultiName: return name is RootAMultiName;
-                case OneofType.RootBMultiName: return name is RootBMultiName;
-                default: return false;
-            }
-        }
-
-        public MultiResourceNameOneOf(OneofType type, gax::IResourceName name)
-        {
-            Type = gax::GaxPreconditions.CheckEnumValue<OneofType>(type, nameof(type));
-            Name = gax::GaxPreconditions.CheckNotNull(name, nameof(name));
-            if (!IsValid(type, name))
-            {
-                throw new sys::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
-            }
-        }
-
-        /// <summary>The <see cref="OneofType"/> of the Name contained in this instance.</summary>
-        public OneofType Type { get; }
-
-        /// <summary>The <see cref="gax::IResourceName"/> contained in this instance.</summary>
-        public gax::IResourceName Name { get; }
-
-        private T CheckAndReturn<T>(OneofType type)
-        {
-            if (Type != type)
-            {
-                throw new sys::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
-            }
-            return (T)Name;
-        }
-
-        /// <summary>Get the contained <see cref="gax::IResourceName"/> as <see cref="RootAMultiName"/>.</summary>
-        /// <remarks>
-        /// An <see cref="sys::InvalidOperationException"/> will be thrown is this does not contain an instance of
-        /// <see cref="RootAMultiName"/>.
-        /// </remarks>
-        public RootAMultiName RootAMultiName => CheckAndReturn<RootAMultiName>(OneofType.RootAMultiName);
-
-        /// <summary>Get the contained <see cref="gax::IResourceName"/> as <see cref="RootBMultiName"/>.</summary>
-        /// <remarks>
-        /// An <see cref="sys::InvalidOperationException"/> will be thrown is this does not contain an instance of
-        /// <see cref="RootBMultiName"/>.
-        /// </remarks>
-        public RootBMultiName RootBMultiName => CheckAndReturn<RootBMultiName>(OneofType.RootBMultiName);
-
-        /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Oneof;
-
-        /// <inheritdoc/>
-        public override string ToString() => this.Name.ToString();
-
-        /// <inheritdoc/>
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as MultiResourceNameOneOf);
-
-        /// <inheritdoc/>
-        public bool Equals(MultiResourceNameOneOf other) => ToString() == other?.ToString();
-
-        /// <inheritdoc/>
-        public static bool operator ==(MultiResourceNameOneOf a, MultiResourceNameOneOf b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc/>
-        public static bool operator !=(MultiResourceNameOneOf a, MultiResourceNameOneOf b) => !(a == b);
-    }
-
-    /// <summary>Resource name for the <c>RootAFutureMulti</c> resource.</summary>
-    public sealed partial class RootAFutureMultiName : gax::IResourceName, sys::IEquatable<RootAFutureMultiName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("root/{root_a_id}/futuremulti/{future_multi_id}");
-
-        /// <summary>
-        /// Parses the given <c>RootAFutureMulti</c> resource name in string form into a new
-        /// <see cref="RootAFutureMultiName"/> instance.
-        /// </summary>
-        /// <param name="rootAFutureMultiName">
-        /// The <c>RootAFutureMulti</c> resource name in string form. Must not be <c>null</c>.
-        /// </param>
-        /// <returns>The parsed <see cref="RootAFutureMultiName"/> if successful.</returns>
-        public static RootAFutureMultiName Parse(string rootAFutureMultiName)
-        {
-            gax::GaxPreconditions.CheckNotNull(rootAFutureMultiName, nameof(rootAFutureMultiName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(rootAFutureMultiName);
-            return new RootAFutureMultiName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given session resource name in string form into a new <see cref="RootAFutureMultiName"/>
-        /// instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="rootAFutureMultiName"/>
-        /// is <c>null</c>, as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="rootAFutureMultiName">
-        /// The <c>RootAFutureMulti</c> resource name in string form. Must not be <c>null</c>.
-        /// </param>
-        /// <param name="result">
-        /// When this method returns, the parsed <see cref="RootAFutureMultiName"/>, or <c>null</c> if parsing fails.
+        /// When this method returns, the parsed <see cref="FutureMultiResourceName"/>, or <c>null</c> if parsing
+        /// failed.
         /// </param>
         /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string rootAFutureMultiName, out RootAFutureMultiName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(rootAFutureMultiName, nameof(rootAFutureMultiName));
-            if (s_template.TryParseName(rootAFutureMultiName, out gax::TemplatedResourceName resourceName))
-            {
-                result = new RootAFutureMultiName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>Formats the IDs into the string representation of the <see cref="RootAFutureMultiName"/>.</summary>
-        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c>.</param>
-        /// <param name="futureMultiId">The <c>FutureMulti</c> ID. Must not be <c>null</c>.</param>
-        /// <returns>The string representation of the <see cref="RootAFutureMultiName"/>.</returns>
-        public static string Format(string rootAId, string futureMultiId) =>
-            s_template.Expand(gax::GaxPreconditions.CheckNotNull(rootAId, nameof(rootAId)), gax::GaxPreconditions.CheckNotNull(futureMultiId, nameof(futureMultiId)));
+        public static bool TryParse(string futureMultiResourceName, out FutureMultiResourceName result) =>
+            TryParse(futureMultiResourceName, false, out result);
 
         /// <summary>
-        /// Constructs a new instance of the <see cref="RootAFutureMultiName"/> resource name class from its component
-        /// parts.
-        /// </summary>
-        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c>.</param>
-        /// <param name="futureMultiId">The <c>FutureMulti</c> ID. Must not be <c>null</c>.</param>
-        public RootAFutureMultiName(string rootAId, string futureMultiId)
-        {
-            RootAId = gax::GaxPreconditions.CheckNotNull(rootAId, nameof(rootAId));
-            FutureMultiId = gax::GaxPreconditions.CheckNotNull(futureMultiId, nameof(futureMultiId));
-        }
-
-        /// <summary>The <c>RootA</c> ID. Never <c>null</c>.</summary>
-        public string RootAId { get; }
-
-        /// <summary>The <c>FutureMulti</c> ID. Never <c>null</c>.</summary>
-        public string FutureMultiId { get; }
-
-        /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc/>
-        public override string ToString() => s_template.Expand(RootAId, FutureMultiId);
-
-        /// <inheritdoc/>
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as RootAFutureMultiName);
-
-        /// <inheritdoc/>
-        public bool Equals(RootAFutureMultiName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc/>
-        public static bool operator ==(RootAFutureMultiName a, RootAFutureMultiName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc/>
-        public static bool operator !=(RootAFutureMultiName a, RootAFutureMultiName b) => !(a == b);
-    }
-
-    /// <summary>Resource name which will contain one of a choice of resource names.</summary>
-    /// <remarks>
-    /// This resource name will contain one of the following:
-    /// <list type="bullet">
-    /// <item><description>RootAFutureMultiName: A resource of type 'root_a'.</description></item>
-    /// </list>
-    /// </remarks>
-    public sealed partial class FutureMultiResourceNameOneOf : gax::IResourceName, sys::IEquatable<FutureMultiResourceNameOneOf>
-    {
-        /// <summary>The possible contents of <see cref="FutureMultiResourceNameOneOf"/>.</summary>
-        public enum OneofType
-        {
-            /// <summary>A resource of an unknown type.</summary>
-            Unknown = 0,
-
-            /// <summary>A resource of type 'root_a'</summary>
-            RootAFutureMultiName = 1
-        }
-
-        /// <summary>
-        /// Parses the given <c>FutureMultiResource</c> resource name in string form into a new
-        /// <see cref="FutureMultiResourceNameOneOf"/> instance.
+        /// Tries to parse the given resource name string into a new <see cref="FutureMultiResourceName"/> instance;
+        /// optionally allowing an unknown resource name to be successfully parsed.
         /// </summary>
         /// <remarks>
-        /// To parse successfully the resource name must be one of the following:
+        /// To parse successfully, the resource name must be formatted as one of the following:
         /// <list type="bullet">
-        /// <item><description>RootAFutureMultiName: A resource of type 'root_a'.</description></item>
+        /// <item><description><c>root/{root_a_id}/futuremulti/{future_multi_id}</c></description></item>
         /// </list>
-        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
         /// </remarks>
-        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="futureMultiResourceName">The resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="allowUnknown">
-        /// If <c>true</c>, will successfully parse an unknown resource name into an
-        /// <see cref="gax::UnknownResourceName"/>; otherwise will throw an<see cref="sys::ArgumentException"/> if an
-        /// unknown resource name is given.
-        /// </param>
-        /// <returns>The parsed <see cref="FutureMultiResourceNameOneOf"/> if successful.</returns>
-        public static FutureMultiResourceNameOneOf Parse(string name, bool allowUnknown)
-        {
-            if (TryParse(name, allowUnknown, out FutureMultiResourceNameOneOf result))
-            {
-                return result;
-            }
-            throw new sys::ArgumentException("Invalid name", nameof(name));
-        }
-
-        /// <summary>
-        /// Tries to parse a resource name in string form into a new <see cref="FutureMultiResourceNameOneOf"/>
-        /// instance.
-        /// </summary>
-        /// <remarks>
-        /// To parse successfully the resource name must be one of the following:
-        /// <list type="bullet">
-        /// <item><description>RootAFutureMultiName: A resource of type 'root_a'.</description></item>
-        /// </list>
-        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>
-        /// </remarks>
-        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="allowUnknown">
-        /// If <c>true</c>, will successfully parse an unknown resource name into an
-        /// <see cref="gax::UnknownResourceName"/>.
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
         /// </param>
         /// <param name="result">
-        /// When this method returns, the parsed <see cref="FutureMultiResourceNameOneOf"/>, or <c>null</c> if parsing
-        /// fails.
+        /// When this method returns, the parsed <see cref="FutureMultiResourceName"/>, or <c>null</c> if parsing
+        /// failed.
         /// </param>
-        /// <returns><c>true</c> if the name was parsed succssfully; othrewise <c>false</c></returns>
-        public static bool TryParse(string name, bool allowUnknown, out FutureMultiResourceNameOneOf result)
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string futureMultiResourceName, bool allowUnknown, out FutureMultiResourceName result)
         {
-            gax::GaxPreconditions.CheckNotNull(name, nameof(name));
-            if (RootAFutureMultiName.TryParse(name, out RootAFutureMultiName rootAFutureMultiName))
+            gax::GaxPreconditions.CheckNotNull(futureMultiResourceName, nameof(futureMultiResourceName));
+            gax::TemplatedResourceName resourceName;
+            if (s_rootAFutureMulti.TryParseName(futureMultiResourceName, out resourceName))
             {
-                result = new FutureMultiResourceNameOneOf(OneofType.RootAFutureMultiName, rootAFutureMultiName);
+                result = CreateRootAFutureMulti(resourceName[0], resourceName[1]);
                 return true;
             }
             if (allowUnknown)
             {
-                if (gax::UnknownResourceName.TryParse(name, out gax::UnknownResourceName unknownResourceName))
+                if (gax::UnknownResourceName.TryParse(futureMultiResourceName, out gax::UnknownResourceName unknownResourceName))
                 {
-                    result = new FutureMultiResourceNameOneOf(OneofType.Unknown, unknownResourceName);
+                    result = CreateUnknown(unknownResourceName);
                     return true;
                 }
             }
@@ -676,168 +633,365 @@ namespace Testing.ResourceNames
             return false;
         }
 
+        private FutureMultiResourceName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string futureMultiId = null, string rootAId = null)
+        {
+            Type = type;
+            UnknownResource = unknownResourceName;
+            FutureMultiId = futureMultiId;
+            RootAId = rootAId;
+        }
+
         /// <summary>
-        /// Constructs a new instance of <see cref="FutureMultiResourceNameOneOf"/> from the provided
-        /// <see cref="RootAFutureMultiName"/>.
+        /// Constructs a new instance of a <see cref="FutureMultiResourceName"/> class from the component parts of
+        /// pattern <c>root/{root_a_id}/futuremulti/{future_multi_id}</c>
         /// </summary>
-        /// <param name="rootAFutureMultiName">
-        /// The <see cref="RootAFutureMultiName"/> to be contained within the returned
-        /// <see cref="FutureMultiResourceNameOneOf"/>. Must not be <c>null</c>
-        /// </param>
-        /// <returns>
-        /// A new <see cref="FutureMultiResourceNameOneOf"/>, containing <paramref name="rootAFutureMultiName"/>.
-        /// </returns>
-        public static FutureMultiResourceNameOneOf From(RootAFutureMultiName rootAFutureMultiName) =>
-            new FutureMultiResourceNameOneOf(OneofType.RootAFutureMultiName, rootAFutureMultiName);
-
-        private static bool IsValid(OneofType type, gax::IResourceName name)
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="futureMultiId">The <c>FutureMulti</c> ID. Must not be <c>null</c> or empty.</param>
+        public FutureMultiResourceName(string rootAId, string futureMultiId) : this(ResourceType.RootAFutureMulti, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), futureMultiId: gax::GaxPreconditions.CheckNotNullOrEmpty(futureMultiId, nameof(futureMultiId)))
         {
-            switch (type)
-            {
-                case OneofType.Unknown: return true;
-                case OneofType.RootAFutureMultiName: return name is RootAFutureMultiName;
-                default: return false;
-            }
         }
 
-        public FutureMultiResourceNameOneOf(OneofType type, gax::IResourceName name)
-        {
-            Type = gax::GaxPreconditions.CheckEnumValue<OneofType>(type, nameof(type));
-            Name = gax::GaxPreconditions.CheckNotNull(name, nameof(name));
-            if (!IsValid(type, name))
-            {
-                throw new sys::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
-            }
-        }
+        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
+        public ResourceType Type { get; }
 
-        /// <summary>The <see cref="OneofType"/> of the Name contained in this instance.</summary>
-        public OneofType Type { get; }
+        /// <summary>
+        /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
+        /// unknown resource name.
+        /// </summary>
+        public gax::UnknownResourceName UnknownResource { get; }
 
-        /// <summary>The <see cref="gax::IResourceName"/> contained in this instance.</summary>
-        public gax::IResourceName Name { get; }
+        /// <summary>
+        /// The <c>FutureMulti</c> ID. Will not be <c>null</c>, unless this instance contains an unknown resource name.
+        /// </summary>
+        public string FutureMultiId { get; }
 
-        private T CheckAndReturn<T>(OneofType type)
-        {
-            if (Type != type)
-            {
-                throw new sys::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
-            }
-            return (T)Name;
-        }
-
-        /// <summary>Get the contained <see cref="gax::IResourceName"/> as <see cref="RootAFutureMultiName"/>.</summary>
-        /// <remarks>
-        /// An <see cref="sys::InvalidOperationException"/> will be thrown is this does not contain an instance of
-        /// <see cref="RootAFutureMultiName"/>.
-        /// </remarks>
-        public RootAFutureMultiName RootAFutureMultiName => CheckAndReturn<RootAFutureMultiName>(OneofType.RootAFutureMultiName);
+        /// <summary>
+        /// The <c>RootA</c> ID. Will not be <c>null</c>, unless this instance contains an unknown resource name.
+        /// </summary>
+        public string RootAId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Oneof;
+        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
 
         /// <inheritdoc/>
-        public override string ToString() => this.Name.ToString();
+        public override string ToString()
+        {
+            switch (Type)
+            {
+                case ResourceType.Unknown: return UnknownResource.ToString();
+                case ResourceType.RootAFutureMulti: return s_rootAFutureMulti.Expand(RootAId, FutureMultiId);
+                default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
+            }
+        }
 
         /// <inheritdoc/>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as FutureMultiResourceNameOneOf);
+        public override bool Equals(object obj) => Equals(obj as FutureMultiResourceName);
 
         /// <inheritdoc/>
-        public bool Equals(FutureMultiResourceNameOneOf other) => ToString() == other?.ToString();
+        public bool Equals(FutureMultiResourceName other) => ToString() == other?.ToString();
 
         /// <inheritdoc/>
-        public static bool operator ==(FutureMultiResourceNameOneOf a, FutureMultiResourceNameOneOf b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+        public static bool operator ==(FutureMultiResourceName a, FutureMultiResourceName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
 
         /// <inheritdoc/>
-        public static bool operator !=(FutureMultiResourceNameOneOf a, FutureMultiResourceNameOneOf b) => !(a == b);
+        public static bool operator !=(FutureMultiResourceName a, FutureMultiResourceName b) => !(a == b);
     }
 
     /// <summary>Resource name for the <c>OriginallySingleResource</c> resource.</summary>
     public sealed partial class OriginallySingleResourceName : gax::IResourceName, sys::IEquatable<OriginallySingleResourceName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("roota/{root_a_id}/originallysingle/{originally_single_multi_id}");
-
-        /// <summary>
-        /// Parses the given <c>OriginallySingleResource</c> resource name in string form into a new
-        /// <see cref="OriginallySingleResourceName"/> instance.
-        /// </summary>
-        /// <param name="originallySingleResourceName">
-        /// The <c>OriginallySingleResource</c> resource name in string form. Must not be <c>null</c>.
-        /// </param>
-        /// <returns>The parsed <see cref="OriginallySingleResourceName"/> if successful.</returns>
-        public static OriginallySingleResourceName Parse(string originallySingleResourceName)
+        /// <summary>The possible contents of <see cref="OriginallySingleResourceName"/>.</summary>
+        public enum ResourceType
         {
-            gax::GaxPreconditions.CheckNotNull(originallySingleResourceName, nameof(originallySingleResourceName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(originallySingleResourceName);
-            return new OriginallySingleResourceName(resourceName[0], resourceName[1]);
+            /// <summary>A resource of an unknown type.</summary>
+            Unknown = 0,
+
+            /// <summary>A resource of type 'root_a'.</summary>
+            RootAOriginallySingleMulti = 1,
+
+            /// <summary>A resource of type 'root_b'.</summary>
+            RootBOriginallySingleMulti = 2
         }
 
+        private static gax::PathTemplate s_rootAOriginallySingleMulti = new gax::PathTemplate("roota/{root_a_id}/originallysingle/{originally_single_multi_id}");
+
+        private static gax::PathTemplate s_rootBOriginallySingleMulti = new gax::PathTemplate("rootb/{root_b_id}/originallysingle/{originally_single_multi_id}");
+
+        /// <summary>Creates a <see cref="OriginallySingleResourceName"/> containing an unknown resource name.</summary>
+        /// <param name="unknownResourceName">The unknown resource name. Must not be <c>null</c>.</param>
+        /// <returns>
+        /// A new instance of <see cref="OriginallySingleResourceName"/> containing the provided
+        /// <paramref name="unknownResourceName"/>.
+        /// </returns>
+        public static OriginallySingleResourceName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new OriginallySingleResourceName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+
         /// <summary>
-        /// Tries to parse the given session resource name in string form into a new
-        /// <see cref="OriginallySingleResourceName"/> instance.
+        /// Creates a <see cref="OriginallySingleResourceName"/> with the pattern
+        /// <c>roota/{root_a_id}/originallysingle/{originally_single_multi_id}</c>.
+        /// </summary>
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="originallySingleMultiId">
+        /// The <c>OriginallySingleMulti</c> ID. Must not be <c>null</c> or empty.
+        /// </param>
+        /// <returns>
+        /// A new instance of <see cref="OriginallySingleResourceName"/> constructed from the provided ids.
+        /// </returns>
+        public static OriginallySingleResourceName CreateRootAOriginallySingleMulti(string rootAId, string originallySingleMultiId) =>
+            new OriginallySingleResourceName(ResourceType.RootAOriginallySingleMulti, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), originallySingleMultiId: gax::GaxPreconditions.CheckNotNullOrEmpty(originallySingleMultiId, nameof(originallySingleMultiId)));
+
+        /// <summary>
+        /// Creates a <see cref="OriginallySingleResourceName"/> with the pattern
+        /// <c>rootb/{root_b_id}/originallysingle/{originally_single_multi_id}</c>.
+        /// </summary>
+        /// <param name="rootBId">The <c>RootB</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="originallySingleMultiId">
+        /// The <c>OriginallySingleMulti</c> ID. Must not be <c>null</c> or empty.
+        /// </param>
+        /// <returns>
+        /// A new instance of <see cref="OriginallySingleResourceName"/> constructed from the provided ids.
+        /// </returns>
+        public static OriginallySingleResourceName CreateRootBOriginallySingleMulti(string rootBId, string originallySingleMultiId) =>
+            new OriginallySingleResourceName(ResourceType.RootBOriginallySingleMulti, rootBId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootBId, nameof(rootBId)), originallySingleMultiId: gax::GaxPreconditions.CheckNotNullOrEmpty(originallySingleMultiId, nameof(originallySingleMultiId)));
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="OriginallySingleResourceName"/> with
+        /// pattern <c>roota/{root_a_id}/originallysingle/{originally_single_multi_id}</c>.
+        /// </summary>
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="originallySingleMultiId">
+        /// The <c>OriginallySingleMulti</c> ID. Must not be <c>null</c> or empty.
+        /// </param>
+        /// <returns>
+        /// The string representation of this <see cref="OriginallySingleResourceName"/> with pattern
+        /// <c>roota/{root_a_id}/originallysingle/{originally_single_multi_id}</c>.
+        /// </returns>
+        public static string Format(string rootAId, string originallySingleMultiId) =>
+            FormatRootAOriginallySingleMulti(rootAId, originallySingleMultiId);
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="OriginallySingleResourceName"/> with
+        /// pattern <c>roota/{root_a_id}/originallysingle/{originally_single_multi_id}</c>.
+        /// </summary>
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="originallySingleMultiId">
+        /// The <c>OriginallySingleMulti</c> ID. Must not be <c>null</c> or empty.
+        /// </param>
+        /// <returns>
+        /// The string representation of this <see cref="OriginallySingleResourceName"/> with pattern
+        /// <c>roota/{root_a_id}/originallysingle/{originally_single_multi_id}</c>.
+        /// </returns>
+        public static string FormatRootAOriginallySingleMulti(string rootAId, string originallySingleMultiId) =>
+            s_rootAOriginallySingleMulti.Expand(gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), gax::GaxPreconditions.CheckNotNullOrEmpty(originallySingleMultiId, nameof(originallySingleMultiId)));
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="OriginallySingleResourceName"/> with
+        /// pattern <c>rootb/{root_b_id}/originallysingle/{originally_single_multi_id}</c>.
+        /// </summary>
+        /// <param name="rootBId">The <c>RootB</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="originallySingleMultiId">
+        /// The <c>OriginallySingleMulti</c> ID. Must not be <c>null</c> or empty.
+        /// </param>
+        /// <returns>
+        /// The string representation of this <see cref="OriginallySingleResourceName"/> with pattern
+        /// <c>rootb/{root_b_id}/originallysingle/{originally_single_multi_id}</c>.
+        /// </returns>
+        public static string FormatRootBOriginallySingleMulti(string rootBId, string originallySingleMultiId) =>
+            s_rootBOriginallySingleMulti.Expand(gax::GaxPreconditions.CheckNotNullOrEmpty(rootBId, nameof(rootBId)), gax::GaxPreconditions.CheckNotNullOrEmpty(originallySingleMultiId, nameof(originallySingleMultiId)));
+
+        /// <summary>
+        /// Parses the given resource name string into a new <see cref="OriginallySingleResourceName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if
-        /// <paramref name="originallySingleResourceName"/> is <c>null</c>, as this would usually indicate a programming
-        /// error rather than a data error.
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet">
+        /// <item>
+        /// <description><c>roota/{root_a_id}/originallysingle/{originally_single_multi_id}</c></description>
+        /// </item>
+        /// <item>
+        /// <description><c>rootb/{root_b_id}/originallysingle/{originally_single_multi_id}</c></description>
+        /// </item>
+        /// </list>
         /// </remarks>
         /// <param name="originallySingleResourceName">
-        /// The <c>OriginallySingleResource</c> resource name in string form. Must not be <c>null</c>.
+        /// The resource name in string form. Must not be <c>null</c>.
+        /// </param>
+        /// <returns>The parsed <see cref="OriginallySingleResourceName"/> if successful.</returns>
+        public static OriginallySingleResourceName Parse(string originallySingleResourceName) =>
+            Parse(originallySingleResourceName, false);
+
+        /// <summary>
+        /// Parses the given resource name string into a new <see cref="OriginallySingleResourceName"/> instance;
+        /// optionally allowing an unknown resource name to be successfully parsed
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet">
+        /// <item>
+        /// <description><c>roota/{root_a_id}/originallysingle/{originally_single_multi_id}</c></description>
+        /// </item>
+        /// <item>
+        /// <description><c>rootb/{root_b_id}/originallysingle/{originally_single_multi_id}</c></description>
+        /// </item>
+        /// </list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="originallySingleResourceName">
+        /// The resource name in string form. Must not be <c>null</c>.
+        /// </param>
+        /// <param name="allowUnknown">
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
+        /// </param>
+        /// <returns>The parsed <see cref="OriginallySingleResourceName"/> if successful.</returns>
+        public static OriginallySingleResourceName Parse(string originallySingleResourceName, bool allowUnknown) =>
+            TryParse(originallySingleResourceName, allowUnknown, out OriginallySingleResourceName result) ? result : throw new sys::ArgumentException("The given resource-name matches no pattern.");
+
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="OriginallySingleResourceName"/>
+        /// instance.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet">
+        /// <item>
+        /// <description><c>roota/{root_a_id}/originallysingle/{originally_single_multi_id}</c></description>
+        /// </item>
+        /// <item>
+        /// <description><c>rootb/{root_b_id}/originallysingle/{originally_single_multi_id}</c></description>
+        /// </item>
+        /// </list>
+        /// </remarks>
+        /// <param name="originallySingleResourceName">
+        /// The resource name in string form. Must not be <c>null</c>.
         /// </param>
         /// <param name="result">
         /// When this method returns, the parsed <see cref="OriginallySingleResourceName"/>, or <c>null</c> if parsing
-        /// fails.
+        /// failed.
         /// </param>
         /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string originallySingleResourceName, out OriginallySingleResourceName result)
+        public static bool TryParse(string originallySingleResourceName, out OriginallySingleResourceName result) =>
+            TryParse(originallySingleResourceName, false, out result);
+
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="OriginallySingleResourceName"/>
+        /// instance; optionally allowing an unknown resource name to be successfully parsed.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet">
+        /// <item>
+        /// <description><c>roota/{root_a_id}/originallysingle/{originally_single_multi_id}</c></description>
+        /// </item>
+        /// <item>
+        /// <description><c>rootb/{root_b_id}/originallysingle/{originally_single_multi_id}</c></description>
+        /// </item>
+        /// </list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="originallySingleResourceName">
+        /// The resource name in string form. Must not be <c>null</c>.
+        /// </param>
+        /// <param name="allowUnknown">
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
+        /// </param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="OriginallySingleResourceName"/>, or <c>null</c> if parsing
+        /// failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string originallySingleResourceName, bool allowUnknown, out OriginallySingleResourceName result)
         {
             gax::GaxPreconditions.CheckNotNull(originallySingleResourceName, nameof(originallySingleResourceName));
-            if (s_template.TryParseName(originallySingleResourceName, out gax::TemplatedResourceName resourceName))
+            gax::TemplatedResourceName resourceName;
+            if (s_rootAOriginallySingleMulti.TryParseName(originallySingleResourceName, out resourceName))
             {
-                result = new OriginallySingleResourceName(resourceName[0], resourceName[1]);
+                result = CreateRootAOriginallySingleMulti(resourceName[0], resourceName[1]);
                 return true;
             }
-            else
+            if (s_rootBOriginallySingleMulti.TryParseName(originallySingleResourceName, out resourceName))
             {
-                result = null;
-                return false;
+                result = CreateRootBOriginallySingleMulti(resourceName[0], resourceName[1]);
+                return true;
             }
+            if (allowUnknown)
+            {
+                if (gax::UnknownResourceName.TryParse(originallySingleResourceName, out gax::UnknownResourceName unknownResourceName))
+                {
+                    result = CreateUnknown(unknownResourceName);
+                    return true;
+                }
+            }
+            result = null;
+            return false;
         }
 
-        /// <summary>
-        /// Formats the IDs into the string representation of the <see cref="OriginallySingleResourceName"/>.
-        /// </summary>
-        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c>.</param>
-        /// <param name="originallySingleMultiId">The <c>OriginallySingleMulti</c> ID. Must not be <c>null</c>.</param>
-        /// <returns>The string representation of the <see cref="OriginallySingleResourceName"/>.</returns>
-        public static string Format(string rootAId, string originallySingleMultiId) =>
-            s_template.Expand(gax::GaxPreconditions.CheckNotNull(rootAId, nameof(rootAId)), gax::GaxPreconditions.CheckNotNull(originallySingleMultiId, nameof(originallySingleMultiId)));
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="OriginallySingleResourceName"/> resource name class from its
-        /// component parts.
-        /// </summary>
-        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c>.</param>
-        /// <param name="originallySingleMultiId">The <c>OriginallySingleMulti</c> ID. Must not be <c>null</c>.</param>
-        public OriginallySingleResourceName(string rootAId, string originallySingleMultiId)
+        private OriginallySingleResourceName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string originallySingleMultiId = null, string rootAId = null, string rootBId = null)
         {
-            RootAId = gax::GaxPreconditions.CheckNotNull(rootAId, nameof(rootAId));
-            OriginallySingleMultiId = gax::GaxPreconditions.CheckNotNull(originallySingleMultiId, nameof(originallySingleMultiId));
+            Type = type;
+            UnknownResource = unknownResourceName;
+            OriginallySingleMultiId = originallySingleMultiId;
+            RootAId = rootAId;
+            RootBId = rootBId;
         }
 
-        /// <summary>The <c>RootA</c> ID. Never <c>null</c>.</summary>
-        public string RootAId { get; }
+        /// <summary>
+        /// Constructs a new instance of a <see cref="OriginallySingleResourceName"/> class from the component parts of
+        /// pattern <c>roota/{root_a_id}/originallysingle/{originally_single_multi_id}</c>
+        /// </summary>
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="originallySingleMultiId">
+        /// The <c>OriginallySingleMulti</c> ID. Must not be <c>null</c> or empty.
+        /// </param>
+        public OriginallySingleResourceName(string rootAId, string originallySingleMultiId) : this(ResourceType.RootAOriginallySingleMulti, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), originallySingleMultiId: gax::GaxPreconditions.CheckNotNullOrEmpty(originallySingleMultiId, nameof(originallySingleMultiId)))
+        {
+        }
 
-        /// <summary>The <c>OriginallySingleMulti</c> ID. Never <c>null</c>.</summary>
+        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
+        public ResourceType Type { get; }
+
+        /// <summary>
+        /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
+        /// unknown resource name.
+        /// </summary>
+        public gax::UnknownResourceName UnknownResource { get; }
+
+        /// <summary>
+        /// The <c>OriginallySingleMulti</c> ID. May be <c>null</c>, depending on which resource name is contained by
+        /// this instance.
+        /// </summary>
         public string OriginallySingleMultiId { get; }
 
-        /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+        /// <summary>
+        /// The <c>RootA</c> ID. May be <c>null</c>, depending on which resource name is contained by this instance.
+        /// </summary>
+        public string RootAId { get; }
+
+        /// <summary>
+        /// The <c>RootB</c> ID. May be <c>null</c>, depending on which resource name is contained by this instance.
+        /// </summary>
+        public string RootBId { get; }
 
         /// <inheritdoc/>
-        public override string ToString() => s_template.Expand(RootAId, OriginallySingleMultiId);
+        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Oneof;
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            switch (Type)
+            {
+                case ResourceType.Unknown: return UnknownResource.ToString();
+                case ResourceType.RootAOriginallySingleMulti: return s_rootAOriginallySingleMulti.Expand(RootAId, OriginallySingleMultiId);
+                case ResourceType.RootBOriginallySingleMulti: return s_rootBOriginallySingleMulti.Expand(RootBId, OriginallySingleMultiId);
+                default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
+            }
+        }
 
         /// <inheritdoc/>
         public override int GetHashCode() => ToString().GetHashCode();
@@ -853,311 +1007,6 @@ namespace Testing.ResourceNames
 
         /// <inheritdoc/>
         public static bool operator !=(OriginallySingleResourceName a, OriginallySingleResourceName b) => !(a == b);
-    }
-
-    /// <summary>Resource name for the <c>RootBOriginallySingleMulti</c> resource.</summary>
-    public sealed partial class RootBOriginallySingleMultiName : gax::IResourceName, sys::IEquatable<RootBOriginallySingleMultiName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("rootb/{root_b_id}/originallysingle/{originally_single_multi_id}");
-
-        /// <summary>
-        /// Parses the given <c>RootBOriginallySingleMulti</c> resource name in string form into a new
-        /// <see cref="RootBOriginallySingleMultiName"/> instance.
-        /// </summary>
-        /// <param name="rootBOriginallySingleMultiName">
-        /// The <c>RootBOriginallySingleMulti</c> resource name in string form. Must not be <c>null</c>.
-        /// </param>
-        /// <returns>The parsed <see cref="RootBOriginallySingleMultiName"/> if successful.</returns>
-        public static RootBOriginallySingleMultiName Parse(string rootBOriginallySingleMultiName)
-        {
-            gax::GaxPreconditions.CheckNotNull(rootBOriginallySingleMultiName, nameof(rootBOriginallySingleMultiName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(rootBOriginallySingleMultiName);
-            return new RootBOriginallySingleMultiName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given session resource name in string form into a new
-        /// <see cref="RootBOriginallySingleMultiName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if
-        /// <paramref name="rootBOriginallySingleMultiName"/> is <c>null</c>, as this would usually indicate a
-        /// programming error rather than a data error.
-        /// </remarks>
-        /// <param name="rootBOriginallySingleMultiName">
-        /// The <c>RootBOriginallySingleMulti</c> resource name in string form. Must not be <c>null</c>.
-        /// </param>
-        /// <param name="result">
-        /// When this method returns, the parsed <see cref="RootBOriginallySingleMultiName"/>, or <c>null</c> if parsing
-        /// fails.
-        /// </param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string rootBOriginallySingleMultiName, out RootBOriginallySingleMultiName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(rootBOriginallySingleMultiName, nameof(rootBOriginallySingleMultiName));
-            if (s_template.TryParseName(rootBOriginallySingleMultiName, out gax::TemplatedResourceName resourceName))
-            {
-                result = new RootBOriginallySingleMultiName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Formats the IDs into the string representation of the <see cref="RootBOriginallySingleMultiName"/>.
-        /// </summary>
-        /// <param name="rootBId">The <c>RootB</c> ID. Must not be <c>null</c>.</param>
-        /// <param name="originallySingleMultiId">The <c>OriginallySingleMulti</c> ID. Must not be <c>null</c>.</param>
-        /// <returns>The string representation of the <see cref="RootBOriginallySingleMultiName"/>.</returns>
-        public static string Format(string rootBId, string originallySingleMultiId) =>
-            s_template.Expand(gax::GaxPreconditions.CheckNotNull(rootBId, nameof(rootBId)), gax::GaxPreconditions.CheckNotNull(originallySingleMultiId, nameof(originallySingleMultiId)));
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="RootBOriginallySingleMultiName"/> resource name class from its
-        /// component parts.
-        /// </summary>
-        /// <param name="rootBId">The <c>RootB</c> ID. Must not be <c>null</c>.</param>
-        /// <param name="originallySingleMultiId">The <c>OriginallySingleMulti</c> ID. Must not be <c>null</c>.</param>
-        public RootBOriginallySingleMultiName(string rootBId, string originallySingleMultiId)
-        {
-            RootBId = gax::GaxPreconditions.CheckNotNull(rootBId, nameof(rootBId));
-            OriginallySingleMultiId = gax::GaxPreconditions.CheckNotNull(originallySingleMultiId, nameof(originallySingleMultiId));
-        }
-
-        /// <summary>The <c>RootB</c> ID. Never <c>null</c>.</summary>
-        public string RootBId { get; }
-
-        /// <summary>The <c>OriginallySingleMulti</c> ID. Never <c>null</c>.</summary>
-        public string OriginallySingleMultiId { get; }
-
-        /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc/>
-        public override string ToString() => s_template.Expand(RootBId, OriginallySingleMultiId);
-
-        /// <inheritdoc/>
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as RootBOriginallySingleMultiName);
-
-        /// <inheritdoc/>
-        public bool Equals(RootBOriginallySingleMultiName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc/>
-        public static bool operator ==(RootBOriginallySingleMultiName a, RootBOriginallySingleMultiName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc/>
-        public static bool operator !=(RootBOriginallySingleMultiName a, RootBOriginallySingleMultiName b) => !(a == b);
-    }
-
-    /// <summary>Resource name which will contain one of a choice of resource names.</summary>
-    /// <remarks>
-    /// This resource name will contain one of the following:
-    /// <list type="bullet">
-    /// <item><description>OriginallySingleResourceName: A resource of type 'root_a'.</description></item>
-    /// <item><description>RootBOriginallySingleMultiName: A resource of type 'root_b'.</description></item>
-    /// </list>
-    /// </remarks>
-    public sealed partial class OriginallySingleResourceNameOneOf : gax::IResourceName, sys::IEquatable<OriginallySingleResourceNameOneOf>
-    {
-        /// <summary>The possible contents of <see cref="OriginallySingleResourceNameOneOf"/>.</summary>
-        public enum OneofType
-        {
-            /// <summary>A resource of an unknown type.</summary>
-            Unknown = 0,
-
-            /// <summary>A resource of type 'root_a'</summary>
-            OriginallySingleResourceName = 1,
-
-            /// <summary>A resource of type 'root_b'</summary>
-            RootBOriginallySingleMultiName = 2
-        }
-
-        /// <summary>
-        /// Parses the given <c>OriginallySingleResource</c> resource name in string form into a new
-        /// <see cref="OriginallySingleResourceNameOneOf"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// To parse successfully the resource name must be one of the following:
-        /// <list type="bullet">
-        /// <item><description>OriginallySingleResourceName: A resource of type 'root_a'.</description></item>
-        /// <item><description>RootBOriginallySingleMultiName: A resource of type 'root_b'.</description></item>
-        /// </list>
-        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>
-        /// </remarks>
-        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="allowUnknown">
-        /// If <c>true</c>, will successfully parse an unknown resource name into an
-        /// <see cref="gax::UnknownResourceName"/>; otherwise will throw an<see cref="sys::ArgumentException"/> if an
-        /// unknown resource name is given.
-        /// </param>
-        /// <returns>The parsed <see cref="OriginallySingleResourceNameOneOf"/> if successful.</returns>
-        public static OriginallySingleResourceNameOneOf Parse(string name, bool allowUnknown)
-        {
-            if (TryParse(name, allowUnknown, out OriginallySingleResourceNameOneOf result))
-            {
-                return result;
-            }
-            throw new sys::ArgumentException("Invalid name", nameof(name));
-        }
-
-        /// <summary>
-        /// Tries to parse a resource name in string form into a new <see cref="OriginallySingleResourceNameOneOf"/>
-        /// instance.
-        /// </summary>
-        /// <remarks>
-        /// To parse successfully the resource name must be one of the following:
-        /// <list type="bullet">
-        /// <item><description>OriginallySingleResourceName: A resource of type 'root_a'.</description></item>
-        /// <item><description>RootBOriginallySingleMultiName: A resource of type 'root_b'.</description></item>
-        /// </list>
-        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>
-        /// </remarks>
-        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="allowUnknown">
-        /// If <c>true</c>, will successfully parse an unknown resource name into an
-        /// <see cref="gax::UnknownResourceName"/>.
-        /// </param>
-        /// <param name="result">
-        /// When this method returns, the parsed <see cref="OriginallySingleResourceNameOneOf"/>, or <c>null</c> if
-        /// parsing fails.
-        /// </param>
-        /// <returns><c>true</c> if the name was parsed succssfully; othrewise <c>false</c></returns>
-        public static bool TryParse(string name, bool allowUnknown, out OriginallySingleResourceNameOneOf result)
-        {
-            gax::GaxPreconditions.CheckNotNull(name, nameof(name));
-            if (OriginallySingleResourceName.TryParse(name, out OriginallySingleResourceName originallySingleResourceName))
-            {
-                result = new OriginallySingleResourceNameOneOf(OneofType.OriginallySingleResourceName, originallySingleResourceName);
-                return true;
-            }
-            if (RootBOriginallySingleMultiName.TryParse(name, out RootBOriginallySingleMultiName rootBOriginallySingleMultiName))
-            {
-                result = new OriginallySingleResourceNameOneOf(OneofType.RootBOriginallySingleMultiName, rootBOriginallySingleMultiName);
-                return true;
-            }
-            if (allowUnknown)
-            {
-                if (gax::UnknownResourceName.TryParse(name, out gax::UnknownResourceName unknownResourceName))
-                {
-                    result = new OriginallySingleResourceNameOneOf(OneofType.Unknown, unknownResourceName);
-                    return true;
-                }
-            }
-            result = null;
-            return false;
-        }
-
-        /// <summary>
-        /// Constructs a new instance of <see cref="OriginallySingleResourceNameOneOf"/> from the provided
-        /// <see cref="OriginallySingleResourceName"/>.
-        /// </summary>
-        /// <param name="originallySingleResourceName">
-        /// The <see cref="OriginallySingleResourceName"/> to be contained within the returned
-        /// <see cref="OriginallySingleResourceNameOneOf"/>. Must not be <c>null</c>
-        /// </param>
-        /// <returns>
-        /// A new <see cref="OriginallySingleResourceNameOneOf"/>, containing
-        /// <paramref name="originallySingleResourceName"/>.
-        /// </returns>
-        public static OriginallySingleResourceNameOneOf From(OriginallySingleResourceName originallySingleResourceName) =>
-            new OriginallySingleResourceNameOneOf(OneofType.OriginallySingleResourceName, originallySingleResourceName);
-
-        /// <summary>
-        /// Constructs a new instance of <see cref="OriginallySingleResourceNameOneOf"/> from the provided
-        /// <see cref="RootBOriginallySingleMultiName"/>.
-        /// </summary>
-        /// <param name="rootBOriginallySingleMultiName">
-        /// The <see cref="RootBOriginallySingleMultiName"/> to be contained within the returned
-        /// <see cref="OriginallySingleResourceNameOneOf"/>. Must not be <c>null</c>
-        /// </param>
-        /// <returns>
-        /// A new <see cref="OriginallySingleResourceNameOneOf"/>, containing
-        /// <paramref name="rootBOriginallySingleMultiName"/>.
-        /// </returns>
-        public static OriginallySingleResourceNameOneOf From(RootBOriginallySingleMultiName rootBOriginallySingleMultiName) =>
-            new OriginallySingleResourceNameOneOf(OneofType.RootBOriginallySingleMultiName, rootBOriginallySingleMultiName);
-
-        private static bool IsValid(OneofType type, gax::IResourceName name)
-        {
-            switch (type)
-            {
-                case OneofType.Unknown: return true;
-                case OneofType.OriginallySingleResourceName: return name is OriginallySingleResourceName;
-                case OneofType.RootBOriginallySingleMultiName: return name is RootBOriginallySingleMultiName;
-                default: return false;
-            }
-        }
-
-        public OriginallySingleResourceNameOneOf(OneofType type, gax::IResourceName name)
-        {
-            Type = gax::GaxPreconditions.CheckEnumValue<OneofType>(type, nameof(type));
-            Name = gax::GaxPreconditions.CheckNotNull(name, nameof(name));
-            if (!IsValid(type, name))
-            {
-                throw new sys::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
-            }
-        }
-
-        /// <summary>The <see cref="OneofType"/> of the Name contained in this instance.</summary>
-        public OneofType Type { get; }
-
-        /// <summary>The <see cref="gax::IResourceName"/> contained in this instance.</summary>
-        public gax::IResourceName Name { get; }
-
-        private T CheckAndReturn<T>(OneofType type)
-        {
-            if (Type != type)
-            {
-                throw new sys::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
-            }
-            return (T)Name;
-        }
-
-        /// <summary>
-        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="OriginallySingleResourceName"/>.
-        /// </summary>
-        /// <remarks>
-        /// An <see cref="sys::InvalidOperationException"/> will be thrown is this does not contain an instance of
-        /// <see cref="OriginallySingleResourceName"/>.
-        /// </remarks>
-        public OriginallySingleResourceName OriginallySingleResourceName => CheckAndReturn<OriginallySingleResourceName>(OneofType.OriginallySingleResourceName);
-
-        /// <summary>
-        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="RootBOriginallySingleMultiName"/>.
-        /// </summary>
-        /// <remarks>
-        /// An <see cref="sys::InvalidOperationException"/> will be thrown is this does not contain an instance of
-        /// <see cref="RootBOriginallySingleMultiName"/>.
-        /// </remarks>
-        public RootBOriginallySingleMultiName RootBOriginallySingleMultiName => CheckAndReturn<RootBOriginallySingleMultiName>(OneofType.RootBOriginallySingleMultiName);
-
-        /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Oneof;
-
-        /// <inheritdoc/>
-        public override string ToString() => this.Name.ToString();
-
-        /// <inheritdoc/>
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as OriginallySingleResourceNameOneOf);
-
-        /// <inheritdoc/>
-        public bool Equals(OriginallySingleResourceNameOneOf other) => ToString() == other?.ToString();
-
-        /// <inheritdoc/>
-        public static bool operator ==(OriginallySingleResourceNameOneOf a, OriginallySingleResourceNameOneOf b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc/>
-        public static bool operator !=(OriginallySingleResourceNameOneOf a, OriginallySingleResourceNameOneOf b) => !(a == b);
     }
 
     public partial class SingleResource
@@ -1188,11 +1037,11 @@ namespace Testing.ResourceNames
     public partial class MultiResource
     {
         /// <summary>
-        /// <see cref="tr::MultiResourceNameOneOf"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="tr::MultiResourceName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public tr::MultiResourceNameOneOf MultiResourceNameOneOf
+        public tr::MultiResourceName MultiResourceName
         {
-            get => string.IsNullOrEmpty(Name) ? null : tr::MultiResourceNameOneOf.Parse(Name, true);
+            get => string.IsNullOrEmpty(Name) ? null : tr::MultiResourceName.Parse(Name);
             set => Name = value?.ToString() ?? "";
         }
     }
@@ -1200,11 +1049,11 @@ namespace Testing.ResourceNames
     public partial class MultiResourceRef
     {
         /// <summary>
-        /// <see cref="MultiResourceNameOneOf"/>-typed view over the <see cref="MultiResource"/> resource name property.
+        /// <see cref="MultiResourceName"/>-typed view over the <see cref="MultiResource"/> resource name property.
         /// </summary>
-        public MultiResourceNameOneOf MultiResourceAsMultiResourceNameOneOf
+        public MultiResourceName MultiResourceAsMultiResourceName
         {
-            get => string.IsNullOrEmpty(MultiResource) ? null : MultiResourceNameOneOf.Parse(MultiResource, true);
+            get => string.IsNullOrEmpty(MultiResource) ? null : MultiResourceName.Parse(MultiResource);
             set => MultiResource = value?.ToString() ?? "";
         }
     }
@@ -1212,12 +1061,11 @@ namespace Testing.ResourceNames
     public partial class FutureMultiResource
     {
         /// <summary>
-        /// <see cref="tr::FutureMultiResourceNameOneOf"/>-typed view over the <see cref="Name"/> resource name
-        /// property.
+        /// <see cref="tr::FutureMultiResourceName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public tr::FutureMultiResourceNameOneOf FutureMultiResourceNameOneOf
+        public tr::FutureMultiResourceName FutureMultiResourceName
         {
-            get => string.IsNullOrEmpty(Name) ? null : tr::FutureMultiResourceNameOneOf.Parse(Name, true);
+            get => string.IsNullOrEmpty(Name) ? null : tr::FutureMultiResourceName.Parse(Name);
             set => Name = value?.ToString() ?? "";
         }
     }
@@ -1231,16 +1079,6 @@ namespace Testing.ResourceNames
         public tr::OriginallySingleResourceName OriginallySingleResourceName
         {
             get => string.IsNullOrEmpty(Name) ? null : tr::OriginallySingleResourceName.Parse(Name);
-            set => Name = value?.ToString() ?? "";
-        }
-
-        /// <summary>
-        /// <see cref="tr::OriginallySingleResourceNameOneOf"/>-typed view over the <see cref="Name"/> resource name
-        /// property.
-        /// </summary>
-        public tr::OriginallySingleResourceNameOneOf OriginallySingleResourceNameOneOf
-        {
-            get => string.IsNullOrEmpty(Name) ? null : tr::OriginallySingleResourceNameOneOf.Parse(Name, true);
             set => Name = value?.ToString() ?? "";
         }
     }
@@ -1258,32 +1096,12 @@ namespace Testing.ResourceNames
         }
 
         /// <summary>
-        /// <see cref="OriginallySingleResourceNameOneOf"/>-typed view over the <see cref="Resource1"/> resource name
-        /// property.
-        /// </summary>
-        public OriginallySingleResourceNameOneOf Resource1AsOriginallySingleResourceNameOneOf
-        {
-            get => string.IsNullOrEmpty(Resource1) ? null : OriginallySingleResourceNameOneOf.Parse(Resource1, true);
-            set => Resource1 = value?.ToString() ?? "";
-        }
-
-        /// <summary>
         /// <see cref="OriginallySingleResourceName"/>-typed view over the <see cref="Resource2"/> resource name
         /// property.
         /// </summary>
         public OriginallySingleResourceName Resource2AsOriginallySingleResourceName
         {
             get => string.IsNullOrEmpty(Resource2) ? null : OriginallySingleResourceName.Parse(Resource2);
-            set => Resource2 = value?.ToString() ?? "";
-        }
-
-        /// <summary>
-        /// <see cref="OriginallySingleResourceNameOneOf"/>-typed view over the <see cref="Resource2"/> resource name
-        /// property.
-        /// </summary>
-        public OriginallySingleResourceNameOneOf Resource2AsOriginallySingleResourceNameOneOf
-        {
-            get => string.IsNullOrEmpty(Resource2) ? null : OriginallySingleResourceNameOneOf.Parse(Resource2, true);
             set => Resource2 = value?.ToString() ?? "";
         }
     }

--- a/Google.Api.Generator.Tests/ProtoTests/ServerStreaming/Testing.ServerStreaming/ServerStreamingResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ServerStreaming/Testing.ServerStreaming/ServerStreamingResourceNames.g.cs
@@ -23,73 +23,178 @@ namespace Testing.ServerStreaming
     /// <summary>Resource name for the <c>Resource</c> resource.</summary>
     public sealed partial class ResourceName : gax::IResourceName, sys::IEquatable<ResourceName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("items/{item_id}");
-
-        /// <summary>
-        /// Parses the given <c>Resource</c> resource name in string form into a new <see cref="ResourceName"/>
-        /// instance.
-        /// </summary>
-        /// <param name="resourceName">
-        /// The <c>Resource</c> resource name in string form. Must not be <c>null</c>.
-        /// </param>
-        /// <returns>The parsed <see cref="ResourceName"/> if successful.</returns>
-        public static ResourceName Parse(string resourceName)
+        /// <summary>The possible contents of <see cref="ResourceName"/>.</summary>
+        public enum ResourceType
         {
-            gax::GaxPreconditions.CheckNotNull(resourceName, nameof(resourceName));
-            gax::TemplatedResourceName resourceName2 = s_template.ParseName(resourceName);
-            return new ResourceName(resourceName2[0]);
+            /// <summary>A resource of an unknown type.</summary>
+            Unknown = 0,
+
+            /// <summary>A resource of type 'item'.</summary>
+            Item = 1
         }
 
+        private static gax::PathTemplate s_item = new gax::PathTemplate("items/{item_id}");
+
+        /// <summary>Creates a <see cref="ResourceName"/> containing an unknown resource name.</summary>
+        /// <param name="unknownResourceName">The unknown resource name. Must not be <c>null</c>.</param>
+        /// <returns>
+        /// A new instance of <see cref="ResourceName"/> containing the provided <paramref name="unknownResourceName"/>.
+        /// </returns>
+        public static ResourceName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new ResourceName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+
+        /// <summary>Creates a <see cref="ResourceName"/> with the pattern <c>items/{item_id}</c>.</summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>A new instance of <see cref="ResourceName"/> constructed from the provided ids.</returns>
+        public static ResourceName CreateItem(string itemId) =>
+            new ResourceName(ResourceType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+
         /// <summary>
-        /// Tries to parse the given session resource name in string form into a new <see cref="ResourceName"/>
-        /// instance.
+        /// Formats the IDs into the string representation of this <see cref="ResourceName"/> with pattern
+        /// <c>items/{item_id}</c>.
+        /// </summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="ResourceName"/> with pattern <c>items/{item_id}</c>.
+        /// </returns>
+        public static string Format(string itemId) => FormatItem(itemId);
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="ResourceName"/> with pattern
+        /// <c>items/{item_id}</c>.
+        /// </summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="ResourceName"/> with pattern <c>items/{item_id}</c>.
+        /// </returns>
+        public static string FormatItem(string itemId) =>
+            s_item.Expand(gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+
+        /// <summary>Parses the given resource name string into a new <see cref="ResourceName"/> instance.</summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}</c></description></item></list>
+        /// </remarks>
+        /// <param name="resourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="ResourceName"/> if successful.</returns>
+        public static ResourceName Parse(string resourceName) => Parse(resourceName, false);
+
+        /// <summary>
+        /// Parses the given resource name string into a new <see cref="ResourceName"/> instance; optionally allowing an
+        /// unknown resource name to be successfully parsed
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="resourceName"/> is
-        /// <c>null</c>, as this would usually indicate a programming error rather than a data error.
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}</c></description></item></list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
         /// </remarks>
-        /// <param name="resourceName">
-        /// The <c>Resource</c> resource name in string form. Must not be <c>null</c>.
+        /// <param name="resourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
         /// </param>
-        /// <param name="result">
-        /// When this method returns, the parsed <see cref="ResourceName"/>, or <c>null</c> if parsing fails.
-        /// </param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string resourceName, out ResourceName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(resourceName, nameof(resourceName));
-            if (s_template.TryParseName(resourceName, out gax::TemplatedResourceName resourceName2))
-            {
-                result = new ResourceName(resourceName2[0]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>Formats the IDs into the string representation of the <see cref="ResourceName"/>.</summary>
-        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c>.</param>
-        /// <returns>The string representation of the <see cref="ResourceName"/>.</returns>
-        public static string Format(string itemId) =>
-            s_template.Expand(gax::GaxPreconditions.CheckNotNull(itemId, nameof(itemId)));
+        /// <returns>The parsed <see cref="ResourceName"/> if successful.</returns>
+        public static ResourceName Parse(string resourceName, bool allowUnknown) =>
+            TryParse(resourceName, allowUnknown, out ResourceName result) ? result : throw new sys::ArgumentException("The given resource-name matches no pattern.");
 
         /// <summary>
-        /// Constructs a new instance of the <see cref="ResourceName"/> resource name class from its component parts.
+        /// Tries to parse the given resource name string into a new <see cref="ResourceName"/> instance.
         /// </summary>
-        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c>.</param>
-        public ResourceName(string itemId) => ItemId = gax::GaxPreconditions.CheckNotNull(itemId, nameof(itemId));
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}</c></description></item></list>
+        /// </remarks>
+        /// <param name="resourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="ResourceName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string resourceName, out ResourceName result) => TryParse(resourceName, false, out result);
 
-        /// <summary>The <c>Item</c> ID. Never <c>null</c>.</summary>
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="ResourceName"/> instance; optionally
+        /// allowing an unknown resource name to be successfully parsed.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}</c></description></item></list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="resourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
+        /// </param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="ResourceName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string resourceName, bool allowUnknown, out ResourceName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(resourceName, nameof(resourceName));
+            gax::TemplatedResourceName resourceName2;
+            if (s_item.TryParseName(resourceName, out resourceName2))
+            {
+                result = CreateItem(resourceName2[0]);
+                return true;
+            }
+            if (allowUnknown)
+            {
+                if (gax::UnknownResourceName.TryParse(resourceName, out gax::UnknownResourceName unknownResourceName))
+                {
+                    result = CreateUnknown(unknownResourceName);
+                    return true;
+                }
+            }
+            result = null;
+            return false;
+        }
+
+        private ResourceName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null)
+        {
+            Type = type;
+            UnknownResource = unknownResourceName;
+            ItemId = itemId;
+        }
+
+        /// <summary>
+        /// Constructs a new instance of a <see cref="ResourceName"/> class from the component parts of pattern
+        /// <c>items/{item_id}</c>
+        /// </summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        public ResourceName(string itemId) : this(ResourceType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
+        {
+        }
+
+        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
+        public ResourceType Type { get; }
+
+        /// <summary>
+        /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
+        /// unknown resource name.
+        /// </summary>
+        public gax::UnknownResourceName UnknownResource { get; }
+
+        /// <summary>
+        /// The <c>Item</c> ID. Will not be <c>null</c>, unless this instance contains an unknown resource name.
+        /// </summary>
         public string ItemId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
 
         /// <inheritdoc/>
-        public override string ToString() => s_template.Expand(ItemId);
+        public override string ToString()
+        {
+            switch (Type)
+            {
+                case ResourceType.Unknown: return UnknownResource.ToString();
+                case ResourceType.Item: return s_item.Expand(ItemId);
+                default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
+            }
+        }
 
         /// <inheritdoc/>
         public override int GetHashCode() => ToString().GetHashCode();

--- a/Google.Api.Generator.Tests/ProtoTests/ServerStreaming/Testing.ServerStreaming/ServerStreamingResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ServerStreaming/Testing.ServerStreaming/ServerStreamingResourceNames.g.cs
@@ -24,12 +24,12 @@ namespace Testing.ServerStreaming
     public sealed partial class ResourceName : gax::IResourceName, sys::IEquatable<ResourceName>
     {
         /// <summary>The possible contents of <see cref="ResourceName"/>.</summary>
-        public enum ResourceType
+        public enum ResourceNameType
         {
             /// <summary>A resource of an unknown type.</summary>
             Unknown = 0,
 
-            /// <summary>A resource of type 'item'.</summary>
+            /// <summary>A resource name with pattern <c>items/{item_id}</c>.</summary>
             Item = 1
         }
 
@@ -40,14 +40,14 @@ namespace Testing.ServerStreaming
         /// <returns>
         /// A new instance of <see cref="ResourceName"/> containing the provided <paramref name="unknownResourceName"/>.
         /// </returns>
-        public static ResourceName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
-            new ResourceName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+        public static ResourceName FromUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new ResourceName(ResourceNameType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
 
         /// <summary>Creates a <see cref="ResourceName"/> with the pattern <c>items/{item_id}</c>.</summary>
         /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
         /// <returns>A new instance of <see cref="ResourceName"/> constructed from the provided ids.</returns>
-        public static ResourceName CreateItem(string itemId) =>
-            new ResourceName(ResourceType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+        public static ResourceName FromItem(string itemId) =>
+            new ResourceName(ResourceNameType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
 
         /// <summary>
         /// Formats the IDs into the string representation of this <see cref="ResourceName"/> with pattern
@@ -137,14 +137,14 @@ namespace Testing.ServerStreaming
             gax::TemplatedResourceName resourceName2;
             if (s_item.TryParseName(resourceName, out resourceName2))
             {
-                result = CreateItem(resourceName2[0]);
+                result = FromItem(resourceName2[0]);
                 return true;
             }
             if (allowUnknown)
             {
                 if (gax::UnknownResourceName.TryParse(resourceName, out gax::UnknownResourceName unknownResourceName))
                 {
-                    result = CreateUnknown(unknownResourceName);
+                    result = FromUnknown(unknownResourceName);
                     return true;
                 }
             }
@@ -152,7 +152,7 @@ namespace Testing.ServerStreaming
             return false;
         }
 
-        private ResourceName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null)
+        private ResourceName(ResourceNameType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null)
         {
             Type = type;
             UnknownResource = unknownResourceName;
@@ -164,12 +164,12 @@ namespace Testing.ServerStreaming
         /// <c>items/{item_id}</c>
         /// </summary>
         /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
-        public ResourceName(string itemId) : this(ResourceType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
+        public ResourceName(string itemId) : this(ResourceNameType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
         {
         }
 
-        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
-        public ResourceType Type { get; }
+        /// <summary>The <see cref="ResourceNameType"/> of the contained resource name.</summary>
+        public ResourceNameType Type { get; }
 
         /// <summary>
         /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
@@ -183,15 +183,15 @@ namespace Testing.ServerStreaming
         public string ItemId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
+        public gax::ResourceNameKind Kind => Type == ResourceNameType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
 
         /// <inheritdoc/>
         public override string ToString()
         {
             switch (Type)
             {
-                case ResourceType.Unknown: return UnknownResource.ToString();
-                case ResourceType.Item: return s_item.Expand(ItemId);
+                case ResourceNameType.Unknown: return UnknownResource.ToString();
+                case ResourceNameType.Item: return s_item.Expand(ItemId);
                 default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
             }
         }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/SnippetsClientFakes.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/SnippetsClientFakes.cs
@@ -101,22 +101,19 @@ namespace Testing.Snippets
         public Task<Task> TaskMethodAsync(Task request) => throw new NotImplementedException();
     }
 
-    public class AResourceName : IResourceName
+    public partial class AResource : ProtoMsgFake<AResource>
     {
-        public AResourceName(string itemId, string partId) => throw new NotImplementedException();
-        public ResourceNameKind Kind => throw new NotImplementedException();
+        public string Name { get; set; }
     }
 
-    public class RootAItemName : IResourceName
+    public partial class WildcardResource : ProtoMsgFake<WildcardResource>
     {
-        public RootAItemName(string rootId, string itemId) => throw new NotImplementedException();
-        public ResourceNameKind Kind => throw new NotImplementedException();
+        public string Name { get; set; }
     }
 
-    public class MultiPatternResourceNameOneOf : IResourceName
+    public partial class MultiPatternResource : ProtoMsgFake<MultiPatternResource>
     {
-        public static MultiPatternResourceNameOneOf From(RootAItemName item) => throw new NotImplementedException();
-        public ResourceNameKind Kind => throw new NotImplementedException();
+        public string Name { get; set; }
     }
 
     public class AnotherMessage : ProtoMsgFake<AnotherMessage> { }
@@ -126,7 +123,7 @@ namespace Testing.Snippets
         Default = 0,
     }
 
-    public class DefaultValuesRequest : ProtoMsgFake<DefaultValuesRequest>
+    public partial class DefaultValuesRequest : ProtoMsgFake<DefaultValuesRequest>
     {
         public static class Types
         {
@@ -181,14 +178,6 @@ namespace Testing.Snippets
         public RepeatedField<string> RepeatedWildcardResource { get; }
         public string MultiPatternResourceName { get; set; }
         public RepeatedField<string> RepeatedMultiPatternResourceName { get; }
-
-        public AResourceName SingleResourceNameAsAResourceName { get; set; }
-        public ResourceNameList<AResourceName> RepeatedResourceNameAsAResourceNames { get; }
-        public IResourceName SingleWildcardResourceAsResourceName { get; set; }
-        public ResourceNameList<IResourceName> RepeatedWildcardResourceAsResourceNames { get; }
-        public MultiPatternResourceNameOneOf MultiPatternResourceNameAsMultiPatternResourceNameOneOf { get; set; }
-        public ResourceNameList<MultiPatternResourceNameOneOf> RepeatedMultiPatternResourceNameAsMultiPatternResourceNameOneOfs { get; }
-
         public MapField<int, string> MapIntString { get; }
     }
 
@@ -199,21 +188,17 @@ namespace Testing.Snippets
         public bool ABool { get; set; }
     }
 
-    public class SimpleResourceName : IResourceName
+    public partial class SimpleResource : ProtoMsgFake<SimpleResource>
     {
-        public SimpleResourceName(string itemId) => throw new NotImplementedException();
-        public ResourceNameKind Kind => throw new NotImplementedException();
+        public string Name { get; set; }
     }
 
-    public class ResourceSignatureRequest : ProtoMsgFake<ResourceSignatureRequest>
+
+    public partial class ResourceSignatureRequest : ProtoMsgFake<ResourceSignatureRequest>
     {
         public string FirstName { get; set; }
         public string SecondName { get; set; }
         public string ThirdName { get; set; }
-
-        public SimpleResourceName FirstNameAsSimpleResourceName { get; set; }
-        public SimpleResourceName SecondNameAsSimpleResourceName { get; set; }
-        public SimpleResourceName ThirdNameAsSimpleResourceName { get; set; }
     }
 
     public class Task : ProtoMsgFake<Task> { }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.Snippets/SnippetsClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.Snippets/SnippetsClientSnippets.g.cs
@@ -83,20 +83,20 @@ namespace Testing.Snippets.Snippets
                 {
                     DefaultValuesRequest.Types.NestedEnum.DefaultValue,
                 },
-                SingleResourceNameAsAResourceName = new AResourceName("[ITEM_ID]", "[PART_ID]"),
+                SingleResourceNameAsAResourceName = AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
                 RepeatedResourceNameAsAResourceNames =
                 {
-                    new AResourceName("[ITEM_ID]", "[PART_ID]"),
+                    AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
                 },
                 SingleWildcardResourceAsResourceName = new UnknownResourceName("a/wildcard/resource"),
                 RepeatedWildcardResourceAsResourceNames =
                 {
                     new UnknownResourceName("a/wildcard/resource"),
                 },
-                MultiPatternResourceNameAsMultiPatternResourceNameOneOf = MultiPatternResourceNameOneOf.From(new RootAItemName("[ROOT_A_ID]", "[ITEM_ID]")),
-                RepeatedMultiPatternResourceNameAsMultiPatternResourceNameOneOfs =
+                MultiPatternResourceNameAsMultiPatternResourceName = MultiPatternResourceName.CreateRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
+                RepeatedMultiPatternResourceNameAsMultiPatternResourceNames =
                 {
-                    MultiPatternResourceNameOneOf.From(new RootAItemName("[ROOT_A_ID]", "[ITEM_ID]")),
+                    MultiPatternResourceName.CreateRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
                 },
                 MapIntString = { { 0, "" }, },
             };
@@ -162,20 +162,20 @@ namespace Testing.Snippets.Snippets
                 {
                     DefaultValuesRequest.Types.NestedEnum.DefaultValue,
                 },
-                SingleResourceNameAsAResourceName = new AResourceName("[ITEM_ID]", "[PART_ID]"),
+                SingleResourceNameAsAResourceName = AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
                 RepeatedResourceNameAsAResourceNames =
                 {
-                    new AResourceName("[ITEM_ID]", "[PART_ID]"),
+                    AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
                 },
                 SingleWildcardResourceAsResourceName = new UnknownResourceName("a/wildcard/resource"),
                 RepeatedWildcardResourceAsResourceNames =
                 {
                     new UnknownResourceName("a/wildcard/resource"),
                 },
-                MultiPatternResourceNameAsMultiPatternResourceNameOneOf = MultiPatternResourceNameOneOf.From(new RootAItemName("[ROOT_A_ID]", "[ITEM_ID]")),
-                RepeatedMultiPatternResourceNameAsMultiPatternResourceNameOneOfs =
+                MultiPatternResourceNameAsMultiPatternResourceName = MultiPatternResourceName.CreateRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
+                RepeatedMultiPatternResourceNameAsMultiPatternResourceNames =
                 {
-                    MultiPatternResourceNameOneOf.From(new RootAItemName("[ROOT_A_ID]", "[ITEM_ID]")),
+                    MultiPatternResourceName.CreateRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
                 },
                 MapIntString = { { 0, "" }, },
             };
@@ -241,7 +241,7 @@ namespace Testing.Snippets.Snippets
             };
             IEnumerable<AResourceName> repeatedResourceName = new AResourceName[]
             {
-                new AResourceName("[ITEM_ID]", "[PART_ID]"),
+                AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
             };
             // Make the request
             Response response = snippetsClient.MethodDefaultValues(repeatedDouble, repeatedNestedMessage, repeatedResourceName);
@@ -263,7 +263,7 @@ namespace Testing.Snippets.Snippets
             };
             IEnumerable<AResourceName> repeatedResourceName = new AResourceName[]
             {
-                new AResourceName("[ITEM_ID]", "[PART_ID]"),
+                AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
             };
             // Make the request
             Response response = await snippetsClient.MethodDefaultValuesAsync(repeatedDouble, repeatedNestedMessage, repeatedResourceName);
@@ -467,9 +467,9 @@ namespace Testing.Snippets.Snippets
             // Initialize request argument(s)
             ResourceSignatureRequest request = new ResourceSignatureRequest
             {
-                FirstNameAsSimpleResourceName = new SimpleResourceName("[ITEM_ID]"),
-                SecondNameAsSimpleResourceName = new SimpleResourceName("[ITEM_ID]"),
-                ThirdNameAsSimpleResourceName = new SimpleResourceName("[ITEM_ID]"),
+                FirstNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
+                SecondNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
+                ThirdNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
             };
             // Make the request
             Response response = snippetsClient.MethodResourceSignature(request);
@@ -486,9 +486,9 @@ namespace Testing.Snippets.Snippets
             // Initialize request argument(s)
             ResourceSignatureRequest request = new ResourceSignatureRequest
             {
-                FirstNameAsSimpleResourceName = new SimpleResourceName("[ITEM_ID]"),
-                SecondNameAsSimpleResourceName = new SimpleResourceName("[ITEM_ID]"),
-                ThirdNameAsSimpleResourceName = new SimpleResourceName("[ITEM_ID]"),
+                FirstNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
+                SecondNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
+                ThirdNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
             };
             // Make the request
             Response response = await snippetsClient.MethodResourceSignatureAsync(request);
@@ -533,9 +533,9 @@ namespace Testing.Snippets.Snippets
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
-            SimpleResourceName firstName = new SimpleResourceName("[ITEM_ID]");
-            SimpleResourceName secondName = new SimpleResourceName("[ITEM_ID]");
-            SimpleResourceName thirdName = new SimpleResourceName("[ITEM_ID]");
+            SimpleResourceName firstName = SimpleResourceName.CreateItem("[ITEM_ID]");
+            SimpleResourceName secondName = SimpleResourceName.CreateItem("[ITEM_ID]");
+            SimpleResourceName thirdName = SimpleResourceName.CreateItem("[ITEM_ID]");
             // Make the request
             Response response = snippetsClient.MethodResourceSignature(firstName, secondName, thirdName);
             // End snippet
@@ -549,9 +549,9 @@ namespace Testing.Snippets.Snippets
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            SimpleResourceName firstName = new SimpleResourceName("[ITEM_ID]");
-            SimpleResourceName secondName = new SimpleResourceName("[ITEM_ID]");
-            SimpleResourceName thirdName = new SimpleResourceName("[ITEM_ID]");
+            SimpleResourceName firstName = SimpleResourceName.CreateItem("[ITEM_ID]");
+            SimpleResourceName secondName = SimpleResourceName.CreateItem("[ITEM_ID]");
+            SimpleResourceName thirdName = SimpleResourceName.CreateItem("[ITEM_ID]");
             // Make the request
             Response response = await snippetsClient.MethodResourceSignatureAsync(firstName, secondName, thirdName);
             // End snippet
@@ -591,7 +591,7 @@ namespace Testing.Snippets.Snippets
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
-            SimpleResourceName firstName = new SimpleResourceName("[ITEM_ID]");
+            SimpleResourceName firstName = SimpleResourceName.CreateItem("[ITEM_ID]");
             // Make the request
             Response response = snippetsClient.MethodResourceSignature(firstName);
             // End snippet
@@ -605,7 +605,7 @@ namespace Testing.Snippets.Snippets
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            SimpleResourceName firstName = new SimpleResourceName("[ITEM_ID]");
+            SimpleResourceName firstName = SimpleResourceName.CreateItem("[ITEM_ID]");
             // Make the request
             Response response = await snippetsClient.MethodResourceSignatureAsync(firstName);
             // End snippet
@@ -752,9 +752,9 @@ namespace Testing.Snippets.Snippets
             // Initialize request argument(s)
             ResourceSignatureRequest request = new ResourceSignatureRequest
             {
-                FirstNameAsSimpleResourceName = new SimpleResourceName("[ITEM_ID]"),
-                SecondNameAsSimpleResourceName = new SimpleResourceName("[ITEM_ID]"),
-                ThirdNameAsSimpleResourceName = new SimpleResourceName("[ITEM_ID]"),
+                FirstNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
+                SecondNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
+                ThirdNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
             };
             // Make the request
             Operation<LroResponse, LroMetadata> response = snippetsClient.MethodLroResourceSignature(request);
@@ -787,9 +787,9 @@ namespace Testing.Snippets.Snippets
             // Initialize request argument(s)
             ResourceSignatureRequest request = new ResourceSignatureRequest
             {
-                FirstNameAsSimpleResourceName = new SimpleResourceName("[ITEM_ID]"),
-                SecondNameAsSimpleResourceName = new SimpleResourceName("[ITEM_ID]"),
-                ThirdNameAsSimpleResourceName = new SimpleResourceName("[ITEM_ID]"),
+                FirstNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
+                SecondNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
+                ThirdNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
             };
             // Make the request
             Operation<LroResponse, LroMetadata> response = await snippetsClient.MethodLroResourceSignatureAsync(request);
@@ -882,9 +882,9 @@ namespace Testing.Snippets.Snippets
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
-            SimpleResourceName firstName = new SimpleResourceName("[ITEM_ID]");
-            SimpleResourceName secondName = new SimpleResourceName("[ITEM_ID]");
-            SimpleResourceName thirdName = new SimpleResourceName("[ITEM_ID]");
+            SimpleResourceName firstName = SimpleResourceName.CreateItem("[ITEM_ID]");
+            SimpleResourceName secondName = SimpleResourceName.CreateItem("[ITEM_ID]");
+            SimpleResourceName thirdName = SimpleResourceName.CreateItem("[ITEM_ID]");
             // Make the request
             Operation<LroResponse, LroMetadata> response = snippetsClient.MethodLroResourceSignature(firstName, secondName, thirdName);
 
@@ -914,9 +914,9 @@ namespace Testing.Snippets.Snippets
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            SimpleResourceName firstName = new SimpleResourceName("[ITEM_ID]");
-            SimpleResourceName secondName = new SimpleResourceName("[ITEM_ID]");
-            SimpleResourceName thirdName = new SimpleResourceName("[ITEM_ID]");
+            SimpleResourceName firstName = SimpleResourceName.CreateItem("[ITEM_ID]");
+            SimpleResourceName secondName = SimpleResourceName.CreateItem("[ITEM_ID]");
+            SimpleResourceName thirdName = SimpleResourceName.CreateItem("[ITEM_ID]");
             // Make the request
             Operation<LroResponse, LroMetadata> response = await snippetsClient.MethodLroResourceSignatureAsync(firstName, secondName, thirdName);
 
@@ -1020,9 +1020,9 @@ namespace Testing.Snippets.Snippets
             // Initialize request argument(s)
             ResourceSignatureRequest request = new ResourceSignatureRequest
             {
-                FirstNameAsSimpleResourceName = new SimpleResourceName("[ITEM_ID]"),
-                SecondNameAsSimpleResourceName = new SimpleResourceName("[ITEM_ID]"),
-                ThirdNameAsSimpleResourceName = new SimpleResourceName("[ITEM_ID]"),
+                FirstNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
+                SecondNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
+                ThirdNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
             };
             // Make the request, returning a streaming response
             SnippetsClient.MethodServerStreamingResourcesStream response = snippetsClient.MethodServerStreamingResources(request);
@@ -1071,9 +1071,9 @@ namespace Testing.Snippets.Snippets
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
-            SimpleResourceName firstName = new SimpleResourceName("[ITEM_ID]");
-            SimpleResourceName secondName = new SimpleResourceName("[ITEM_ID]");
-            SimpleResourceName thirdName = new SimpleResourceName("[ITEM_ID]");
+            SimpleResourceName firstName = SimpleResourceName.CreateItem("[ITEM_ID]");
+            SimpleResourceName secondName = SimpleResourceName.CreateItem("[ITEM_ID]");
+            SimpleResourceName thirdName = SimpleResourceName.CreateItem("[ITEM_ID]");
             // Make the request, returning a streaming response
             SnippetsClient.MethodServerStreamingResourcesStream response = snippetsClient.MethodServerStreamingResources(firstName, secondName, thirdName);
 

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.Snippets/SnippetsClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.Snippets/SnippetsClientSnippets.g.cs
@@ -83,20 +83,20 @@ namespace Testing.Snippets.Snippets
                 {
                     DefaultValuesRequest.Types.NestedEnum.DefaultValue,
                 },
-                SingleResourceNameAsAResourceName = AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
+                SingleResourceNameAsAResourceName = AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
                 RepeatedResourceNameAsAResourceNames =
                 {
-                    AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
+                    AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
                 },
                 SingleWildcardResourceAsResourceName = new UnknownResourceName("a/wildcard/resource"),
                 RepeatedWildcardResourceAsResourceNames =
                 {
                     new UnknownResourceName("a/wildcard/resource"),
                 },
-                MultiPatternResourceNameAsMultiPatternResourceName = MultiPatternResourceName.CreateRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
+                MultiPatternResourceNameAsMultiPatternResourceName = MultiPatternResourceName.FromRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
                 RepeatedMultiPatternResourceNameAsMultiPatternResourceNames =
                 {
-                    MultiPatternResourceName.CreateRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
+                    MultiPatternResourceName.FromRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
                 },
                 MapIntString = { { 0, "" }, },
             };
@@ -162,20 +162,20 @@ namespace Testing.Snippets.Snippets
                 {
                     DefaultValuesRequest.Types.NestedEnum.DefaultValue,
                 },
-                SingleResourceNameAsAResourceName = AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
+                SingleResourceNameAsAResourceName = AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
                 RepeatedResourceNameAsAResourceNames =
                 {
-                    AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
+                    AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
                 },
                 SingleWildcardResourceAsResourceName = new UnknownResourceName("a/wildcard/resource"),
                 RepeatedWildcardResourceAsResourceNames =
                 {
                     new UnknownResourceName("a/wildcard/resource"),
                 },
-                MultiPatternResourceNameAsMultiPatternResourceName = MultiPatternResourceName.CreateRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
+                MultiPatternResourceNameAsMultiPatternResourceName = MultiPatternResourceName.FromRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
                 RepeatedMultiPatternResourceNameAsMultiPatternResourceNames =
                 {
-                    MultiPatternResourceName.CreateRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
+                    MultiPatternResourceName.FromRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
                 },
                 MapIntString = { { 0, "" }, },
             };
@@ -241,7 +241,7 @@ namespace Testing.Snippets.Snippets
             };
             IEnumerable<AResourceName> repeatedResourceName = new AResourceName[]
             {
-                AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
+                AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
             };
             // Make the request
             Response response = snippetsClient.MethodDefaultValues(repeatedDouble, repeatedNestedMessage, repeatedResourceName);
@@ -263,7 +263,7 @@ namespace Testing.Snippets.Snippets
             };
             IEnumerable<AResourceName> repeatedResourceName = new AResourceName[]
             {
-                AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
+                AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
             };
             // Make the request
             Response response = await snippetsClient.MethodDefaultValuesAsync(repeatedDouble, repeatedNestedMessage, repeatedResourceName);
@@ -467,9 +467,9 @@ namespace Testing.Snippets.Snippets
             // Initialize request argument(s)
             ResourceSignatureRequest request = new ResourceSignatureRequest
             {
-                FirstNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
-                SecondNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
-                ThirdNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
+                FirstNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                SecondNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                ThirdNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
             };
             // Make the request
             Response response = snippetsClient.MethodResourceSignature(request);
@@ -486,9 +486,9 @@ namespace Testing.Snippets.Snippets
             // Initialize request argument(s)
             ResourceSignatureRequest request = new ResourceSignatureRequest
             {
-                FirstNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
-                SecondNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
-                ThirdNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
+                FirstNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                SecondNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                ThirdNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
             };
             // Make the request
             Response response = await snippetsClient.MethodResourceSignatureAsync(request);
@@ -533,9 +533,9 @@ namespace Testing.Snippets.Snippets
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
-            SimpleResourceName firstName = SimpleResourceName.CreateItem("[ITEM_ID]");
-            SimpleResourceName secondName = SimpleResourceName.CreateItem("[ITEM_ID]");
-            SimpleResourceName thirdName = SimpleResourceName.CreateItem("[ITEM_ID]");
+            SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
+            SimpleResourceName secondName = SimpleResourceName.FromItem("[ITEM_ID]");
+            SimpleResourceName thirdName = SimpleResourceName.FromItem("[ITEM_ID]");
             // Make the request
             Response response = snippetsClient.MethodResourceSignature(firstName, secondName, thirdName);
             // End snippet
@@ -549,9 +549,9 @@ namespace Testing.Snippets.Snippets
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            SimpleResourceName firstName = SimpleResourceName.CreateItem("[ITEM_ID]");
-            SimpleResourceName secondName = SimpleResourceName.CreateItem("[ITEM_ID]");
-            SimpleResourceName thirdName = SimpleResourceName.CreateItem("[ITEM_ID]");
+            SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
+            SimpleResourceName secondName = SimpleResourceName.FromItem("[ITEM_ID]");
+            SimpleResourceName thirdName = SimpleResourceName.FromItem("[ITEM_ID]");
             // Make the request
             Response response = await snippetsClient.MethodResourceSignatureAsync(firstName, secondName, thirdName);
             // End snippet
@@ -591,7 +591,7 @@ namespace Testing.Snippets.Snippets
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
-            SimpleResourceName firstName = SimpleResourceName.CreateItem("[ITEM_ID]");
+            SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
             // Make the request
             Response response = snippetsClient.MethodResourceSignature(firstName);
             // End snippet
@@ -605,7 +605,7 @@ namespace Testing.Snippets.Snippets
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            SimpleResourceName firstName = SimpleResourceName.CreateItem("[ITEM_ID]");
+            SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
             // Make the request
             Response response = await snippetsClient.MethodResourceSignatureAsync(firstName);
             // End snippet
@@ -752,9 +752,9 @@ namespace Testing.Snippets.Snippets
             // Initialize request argument(s)
             ResourceSignatureRequest request = new ResourceSignatureRequest
             {
-                FirstNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
-                SecondNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
-                ThirdNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
+                FirstNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                SecondNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                ThirdNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
             };
             // Make the request
             Operation<LroResponse, LroMetadata> response = snippetsClient.MethodLroResourceSignature(request);
@@ -787,9 +787,9 @@ namespace Testing.Snippets.Snippets
             // Initialize request argument(s)
             ResourceSignatureRequest request = new ResourceSignatureRequest
             {
-                FirstNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
-                SecondNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
-                ThirdNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
+                FirstNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                SecondNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                ThirdNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
             };
             // Make the request
             Operation<LroResponse, LroMetadata> response = await snippetsClient.MethodLroResourceSignatureAsync(request);
@@ -882,9 +882,9 @@ namespace Testing.Snippets.Snippets
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
-            SimpleResourceName firstName = SimpleResourceName.CreateItem("[ITEM_ID]");
-            SimpleResourceName secondName = SimpleResourceName.CreateItem("[ITEM_ID]");
-            SimpleResourceName thirdName = SimpleResourceName.CreateItem("[ITEM_ID]");
+            SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
+            SimpleResourceName secondName = SimpleResourceName.FromItem("[ITEM_ID]");
+            SimpleResourceName thirdName = SimpleResourceName.FromItem("[ITEM_ID]");
             // Make the request
             Operation<LroResponse, LroMetadata> response = snippetsClient.MethodLroResourceSignature(firstName, secondName, thirdName);
 
@@ -914,9 +914,9 @@ namespace Testing.Snippets.Snippets
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            SimpleResourceName firstName = SimpleResourceName.CreateItem("[ITEM_ID]");
-            SimpleResourceName secondName = SimpleResourceName.CreateItem("[ITEM_ID]");
-            SimpleResourceName thirdName = SimpleResourceName.CreateItem("[ITEM_ID]");
+            SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
+            SimpleResourceName secondName = SimpleResourceName.FromItem("[ITEM_ID]");
+            SimpleResourceName thirdName = SimpleResourceName.FromItem("[ITEM_ID]");
             // Make the request
             Operation<LroResponse, LroMetadata> response = await snippetsClient.MethodLroResourceSignatureAsync(firstName, secondName, thirdName);
 
@@ -1020,9 +1020,9 @@ namespace Testing.Snippets.Snippets
             // Initialize request argument(s)
             ResourceSignatureRequest request = new ResourceSignatureRequest
             {
-                FirstNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
-                SecondNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
-                ThirdNameAsSimpleResourceName = SimpleResourceName.CreateItem("[ITEM_ID]"),
+                FirstNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                SecondNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                ThirdNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
             };
             // Make the request, returning a streaming response
             SnippetsClient.MethodServerStreamingResourcesStream response = snippetsClient.MethodServerStreamingResources(request);
@@ -1071,9 +1071,9 @@ namespace Testing.Snippets.Snippets
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
-            SimpleResourceName firstName = SimpleResourceName.CreateItem("[ITEM_ID]");
-            SimpleResourceName secondName = SimpleResourceName.CreateItem("[ITEM_ID]");
-            SimpleResourceName thirdName = SimpleResourceName.CreateItem("[ITEM_ID]");
+            SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
+            SimpleResourceName secondName = SimpleResourceName.FromItem("[ITEM_ID]");
+            SimpleResourceName thirdName = SimpleResourceName.FromItem("[ITEM_ID]");
             // Make the request, returning a streaming response
             SnippetsClient.MethodServerStreamingResourcesStream response = snippetsClient.MethodServerStreamingResources(firstName, secondName, thirdName);
 

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets/SnippetsResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets/SnippetsResourceNames.g.cs
@@ -24,12 +24,12 @@ namespace Testing.Snippets
     public sealed partial class AResourceName : gax::IResourceName, sys::IEquatable<AResourceName>
     {
         /// <summary>The possible contents of <see cref="AResourceName"/>.</summary>
-        public enum ResourceType
+        public enum ResourceNameType
         {
             /// <summary>A resource of an unknown type.</summary>
             Unknown = 0,
 
-            /// <summary>A resource of type 'item'.</summary>
+            /// <summary>A resource name with pattern <c>items/{item_id}/parts/{part_id}</c>.</summary>
             ItemPart = 1
         }
 
@@ -41,8 +41,8 @@ namespace Testing.Snippets
         /// A new instance of <see cref="AResourceName"/> containing the provided <paramref name="unknownResourceName"/>
         /// .
         /// </returns>
-        public static AResourceName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
-            new AResourceName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+        public static AResourceName FromUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new AResourceName(ResourceNameType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
 
         /// <summary>
         /// Creates a <see cref="AResourceName"/> with the pattern <c>items/{item_id}/parts/{part_id}</c>.
@@ -50,8 +50,8 @@ namespace Testing.Snippets
         /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
         /// <param name="partId">The <c>Part</c> ID. Must not be <c>null</c> or empty.</param>
         /// <returns>A new instance of <see cref="AResourceName"/> constructed from the provided ids.</returns>
-        public static AResourceName CreateItemPart(string itemId, string partId) =>
-            new AResourceName(ResourceType.ItemPart, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)), partId: gax::GaxPreconditions.CheckNotNullOrEmpty(partId, nameof(partId)));
+        public static AResourceName FromItemPart(string itemId, string partId) =>
+            new AResourceName(ResourceNameType.ItemPart, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)), partId: gax::GaxPreconditions.CheckNotNullOrEmpty(partId, nameof(partId)));
 
         /// <summary>
         /// Formats the IDs into the string representation of this <see cref="AResourceName"/> with pattern
@@ -145,14 +145,14 @@ namespace Testing.Snippets
             gax::TemplatedResourceName resourceName;
             if (s_itemPart.TryParseName(aResourceName, out resourceName))
             {
-                result = CreateItemPart(resourceName[0], resourceName[1]);
+                result = FromItemPart(resourceName[0], resourceName[1]);
                 return true;
             }
             if (allowUnknown)
             {
                 if (gax::UnknownResourceName.TryParse(aResourceName, out gax::UnknownResourceName unknownResourceName))
                 {
-                    result = CreateUnknown(unknownResourceName);
+                    result = FromUnknown(unknownResourceName);
                     return true;
                 }
             }
@@ -160,7 +160,7 @@ namespace Testing.Snippets
             return false;
         }
 
-        private AResourceName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null, string partId = null)
+        private AResourceName(ResourceNameType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null, string partId = null)
         {
             Type = type;
             UnknownResource = unknownResourceName;
@@ -174,12 +174,12 @@ namespace Testing.Snippets
         /// </summary>
         /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
         /// <param name="partId">The <c>Part</c> ID. Must not be <c>null</c> or empty.</param>
-        public AResourceName(string itemId, string partId) : this(ResourceType.ItemPart, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)), partId: gax::GaxPreconditions.CheckNotNullOrEmpty(partId, nameof(partId)))
+        public AResourceName(string itemId, string partId) : this(ResourceNameType.ItemPart, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)), partId: gax::GaxPreconditions.CheckNotNullOrEmpty(partId, nameof(partId)))
         {
         }
 
-        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
-        public ResourceType Type { get; }
+        /// <summary>The <see cref="ResourceNameType"/> of the contained resource name.</summary>
+        public ResourceNameType Type { get; }
 
         /// <summary>
         /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
@@ -198,15 +198,15 @@ namespace Testing.Snippets
         public string PartId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
+        public gax::ResourceNameKind Kind => Type == ResourceNameType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
 
         /// <inheritdoc/>
         public override string ToString()
         {
             switch (Type)
             {
-                case ResourceType.Unknown: return UnknownResource.ToString();
-                case ResourceType.ItemPart: return s_itemPart.Expand(ItemId, PartId);
+                case ResourceNameType.Unknown: return UnknownResource.ToString();
+                case ResourceNameType.ItemPart: return s_itemPart.Expand(ItemId, PartId);
                 default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
             }
         }
@@ -231,15 +231,15 @@ namespace Testing.Snippets
     public sealed partial class MultiPatternResourceName : gax::IResourceName, sys::IEquatable<MultiPatternResourceName>
     {
         /// <summary>The possible contents of <see cref="MultiPatternResourceName"/>.</summary>
-        public enum ResourceType
+        public enum ResourceNameType
         {
             /// <summary>A resource of an unknown type.</summary>
             Unknown = 0,
 
-            /// <summary>A resource of type 'root_a'.</summary>
+            /// <summary>A resource name with pattern <c>root/{root_a_id}/items/{item_id}</c>.</summary>
             RootAItem = 1,
 
-            /// <summary>A resource of type 'root_b'.</summary>
+            /// <summary>A resource name with pattern <c>root/{root_b_id}/items/{item_id}</c>.</summary>
             RootBItem = 2
         }
 
@@ -253,8 +253,8 @@ namespace Testing.Snippets
         /// A new instance of <see cref="MultiPatternResourceName"/> containing the provided
         /// <paramref name="unknownResourceName"/>.
         /// </returns>
-        public static MultiPatternResourceName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
-            new MultiPatternResourceName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+        public static MultiPatternResourceName FromUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new MultiPatternResourceName(ResourceNameType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
 
         /// <summary>
         /// Creates a <see cref="MultiPatternResourceName"/> with the pattern <c>root/{root_a_id}/items/{item_id}</c>.
@@ -264,8 +264,8 @@ namespace Testing.Snippets
         /// <returns>
         /// A new instance of <see cref="MultiPatternResourceName"/> constructed from the provided ids.
         /// </returns>
-        public static MultiPatternResourceName CreateRootAItem(string rootAId, string itemId) =>
-            new MultiPatternResourceName(ResourceType.RootAItem, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+        public static MultiPatternResourceName FromRootAItem(string rootAId, string itemId) =>
+            new MultiPatternResourceName(ResourceNameType.RootAItem, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
 
         /// <summary>
         /// Creates a <see cref="MultiPatternResourceName"/> with the pattern <c>root/{root_b_id}/items/{item_id}</c>.
@@ -275,8 +275,8 @@ namespace Testing.Snippets
         /// <returns>
         /// A new instance of <see cref="MultiPatternResourceName"/> constructed from the provided ids.
         /// </returns>
-        public static MultiPatternResourceName CreateRootBItem(string rootBId, string itemId) =>
-            new MultiPatternResourceName(ResourceType.RootBItem, rootBId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootBId, nameof(rootBId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+        public static MultiPatternResourceName FromRootBItem(string rootBId, string itemId) =>
+            new MultiPatternResourceName(ResourceNameType.RootBItem, rootBId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootBId, nameof(rootBId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
 
         /// <summary>
         /// Formats the IDs into the string representation of this <see cref="MultiPatternResourceName"/> with pattern
@@ -401,19 +401,19 @@ namespace Testing.Snippets
             gax::TemplatedResourceName resourceName;
             if (s_rootAItem.TryParseName(multiPatternResourceName, out resourceName))
             {
-                result = CreateRootAItem(resourceName[0], resourceName[1]);
+                result = FromRootAItem(resourceName[0], resourceName[1]);
                 return true;
             }
             if (s_rootBItem.TryParseName(multiPatternResourceName, out resourceName))
             {
-                result = CreateRootBItem(resourceName[0], resourceName[1]);
+                result = FromRootBItem(resourceName[0], resourceName[1]);
                 return true;
             }
             if (allowUnknown)
             {
                 if (gax::UnknownResourceName.TryParse(multiPatternResourceName, out gax::UnknownResourceName unknownResourceName))
                 {
-                    result = CreateUnknown(unknownResourceName);
+                    result = FromUnknown(unknownResourceName);
                     return true;
                 }
             }
@@ -421,7 +421,7 @@ namespace Testing.Snippets
             return false;
         }
 
-        private MultiPatternResourceName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null, string rootAId = null, string rootBId = null)
+        private MultiPatternResourceName(ResourceNameType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null, string rootAId = null, string rootBId = null)
         {
             Type = type;
             UnknownResource = unknownResourceName;
@@ -436,12 +436,12 @@ namespace Testing.Snippets
         /// </summary>
         /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
         /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
-        public MultiPatternResourceName(string rootAId, string itemId) : this(ResourceType.RootAItem, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
+        public MultiPatternResourceName(string rootAId, string itemId) : this(ResourceNameType.RootAItem, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
         {
         }
 
-        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
-        public ResourceType Type { get; }
+        /// <summary>The <see cref="ResourceNameType"/> of the contained resource name.</summary>
+        public ResourceNameType Type { get; }
 
         /// <summary>
         /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
@@ -465,16 +465,16 @@ namespace Testing.Snippets
         public string RootBId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Oneof;
+        public gax::ResourceNameKind Kind => Type == ResourceNameType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Oneof;
 
         /// <inheritdoc/>
         public override string ToString()
         {
             switch (Type)
             {
-                case ResourceType.Unknown: return UnknownResource.ToString();
-                case ResourceType.RootAItem: return s_rootAItem.Expand(RootAId, ItemId);
-                case ResourceType.RootBItem: return s_rootBItem.Expand(RootBId, ItemId);
+                case ResourceNameType.Unknown: return UnknownResource.ToString();
+                case ResourceNameType.RootAItem: return s_rootAItem.Expand(RootAId, ItemId);
+                case ResourceNameType.RootBItem: return s_rootBItem.Expand(RootBId, ItemId);
                 default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
             }
         }
@@ -499,12 +499,12 @@ namespace Testing.Snippets
     public sealed partial class SimpleResourceName : gax::IResourceName, sys::IEquatable<SimpleResourceName>
     {
         /// <summary>The possible contents of <see cref="SimpleResourceName"/>.</summary>
-        public enum ResourceType
+        public enum ResourceNameType
         {
             /// <summary>A resource of an unknown type.</summary>
             Unknown = 0,
 
-            /// <summary>A resource of type 'item'.</summary>
+            /// <summary>A resource name with pattern <c>items/{item_id}</c>.</summary>
             Item = 1
         }
 
@@ -516,14 +516,14 @@ namespace Testing.Snippets
         /// A new instance of <see cref="SimpleResourceName"/> containing the provided
         /// <paramref name="unknownResourceName"/>.
         /// </returns>
-        public static SimpleResourceName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
-            new SimpleResourceName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+        public static SimpleResourceName FromUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new SimpleResourceName(ResourceNameType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
 
         /// <summary>Creates a <see cref="SimpleResourceName"/> with the pattern <c>items/{item_id}</c>.</summary>
         /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
         /// <returns>A new instance of <see cref="SimpleResourceName"/> constructed from the provided ids.</returns>
-        public static SimpleResourceName CreateItem(string itemId) =>
-            new SimpleResourceName(ResourceType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+        public static SimpleResourceName FromItem(string itemId) =>
+            new SimpleResourceName(ResourceNameType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
 
         /// <summary>
         /// Formats the IDs into the string representation of this <see cref="SimpleResourceName"/> with pattern
@@ -616,14 +616,14 @@ namespace Testing.Snippets
             gax::TemplatedResourceName resourceName;
             if (s_item.TryParseName(simpleResourceName, out resourceName))
             {
-                result = CreateItem(resourceName[0]);
+                result = FromItem(resourceName[0]);
                 return true;
             }
             if (allowUnknown)
             {
                 if (gax::UnknownResourceName.TryParse(simpleResourceName, out gax::UnknownResourceName unknownResourceName))
                 {
-                    result = CreateUnknown(unknownResourceName);
+                    result = FromUnknown(unknownResourceName);
                     return true;
                 }
             }
@@ -631,7 +631,7 @@ namespace Testing.Snippets
             return false;
         }
 
-        private SimpleResourceName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null)
+        private SimpleResourceName(ResourceNameType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null)
         {
             Type = type;
             UnknownResource = unknownResourceName;
@@ -643,12 +643,12 @@ namespace Testing.Snippets
         /// <c>items/{item_id}</c>
         /// </summary>
         /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
-        public SimpleResourceName(string itemId) : this(ResourceType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
+        public SimpleResourceName(string itemId) : this(ResourceNameType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
         {
         }
 
-        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
-        public ResourceType Type { get; }
+        /// <summary>The <see cref="ResourceNameType"/> of the contained resource name.</summary>
+        public ResourceNameType Type { get; }
 
         /// <summary>
         /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
@@ -662,15 +662,15 @@ namespace Testing.Snippets
         public string ItemId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
+        public gax::ResourceNameKind Kind => Type == ResourceNameType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
 
         /// <inheritdoc/>
         public override string ToString()
         {
             switch (Type)
             {
-                case ResourceType.Unknown: return UnknownResource.ToString();
-                case ResourceType.Item: return s_item.Expand(ItemId);
+                case ResourceNameType.Unknown: return UnknownResource.ToString();
+                case ResourceNameType.Item: return s_item.Expand(ItemId);
                 default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
             }
         }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets/SnippetsResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets/SnippetsResourceNames.g.cs
@@ -1,1 +1,829 @@
-﻿// TEST_DISABLE
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+using gax = Google.Api.Gax;
+using sys = System;
+using ts = Testing.Snippets;
+
+namespace Testing.Snippets
+{
+    /// <summary>Resource name for the <c>AResource</c> resource.</summary>
+    public sealed partial class AResourceName : gax::IResourceName, sys::IEquatable<AResourceName>
+    {
+        /// <summary>The possible contents of <see cref="AResourceName"/>.</summary>
+        public enum ResourceType
+        {
+            /// <summary>A resource of an unknown type.</summary>
+            Unknown = 0,
+
+            /// <summary>A resource of type 'item'.</summary>
+            ItemPart = 1
+        }
+
+        private static gax::PathTemplate s_itemPart = new gax::PathTemplate("items/{item_id}/parts/{part_id}");
+
+        /// <summary>Creates a <see cref="AResourceName"/> containing an unknown resource name.</summary>
+        /// <param name="unknownResourceName">The unknown resource name. Must not be <c>null</c>.</param>
+        /// <returns>
+        /// A new instance of <see cref="AResourceName"/> containing the provided <paramref name="unknownResourceName"/>
+        /// .
+        /// </returns>
+        public static AResourceName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new AResourceName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+
+        /// <summary>
+        /// Creates a <see cref="AResourceName"/> with the pattern <c>items/{item_id}/parts/{part_id}</c>.
+        /// </summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="partId">The <c>Part</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>A new instance of <see cref="AResourceName"/> constructed from the provided ids.</returns>
+        public static AResourceName CreateItemPart(string itemId, string partId) =>
+            new AResourceName(ResourceType.ItemPart, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)), partId: gax::GaxPreconditions.CheckNotNullOrEmpty(partId, nameof(partId)));
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="AResourceName"/> with pattern
+        /// <c>items/{item_id}/parts/{part_id}</c>.
+        /// </summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="partId">The <c>Part</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="AResourceName"/> with pattern
+        /// <c>items/{item_id}/parts/{part_id}</c>.
+        /// </returns>
+        public static string Format(string itemId, string partId) => FormatItemPart(itemId, partId);
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="AResourceName"/> with pattern
+        /// <c>items/{item_id}/parts/{part_id}</c>.
+        /// </summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="partId">The <c>Part</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="AResourceName"/> with pattern
+        /// <c>items/{item_id}/parts/{part_id}</c>.
+        /// </returns>
+        public static string FormatItemPart(string itemId, string partId) =>
+            s_itemPart.Expand(gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)), gax::GaxPreconditions.CheckNotNullOrEmpty(partId, nameof(partId)));
+
+        /// <summary>Parses the given resource name string into a new <see cref="AResourceName"/> instance.</summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}/parts/{part_id}</c></description></item></list>
+        /// </remarks>
+        /// <param name="aResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="AResourceName"/> if successful.</returns>
+        public static AResourceName Parse(string aResourceName) => Parse(aResourceName, false);
+
+        /// <summary>
+        /// Parses the given resource name string into a new <see cref="AResourceName"/> instance; optionally allowing
+        /// an unknown resource name to be successfully parsed
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}/parts/{part_id}</c></description></item></list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="aResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
+        /// </param>
+        /// <returns>The parsed <see cref="AResourceName"/> if successful.</returns>
+        public static AResourceName Parse(string aResourceName, bool allowUnknown) =>
+            TryParse(aResourceName, allowUnknown, out AResourceName result) ? result : throw new sys::ArgumentException("The given resource-name matches no pattern.");
+
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="AResourceName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}/parts/{part_id}</c></description></item></list>
+        /// </remarks>
+        /// <param name="aResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="AResourceName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string aResourceName, out AResourceName result) => TryParse(aResourceName, false, out result);
+
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="AResourceName"/> instance; optionally
+        /// allowing an unknown resource name to be successfully parsed.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}/parts/{part_id}</c></description></item></list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="aResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
+        /// </param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="AResourceName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string aResourceName, bool allowUnknown, out AResourceName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(aResourceName, nameof(aResourceName));
+            gax::TemplatedResourceName resourceName;
+            if (s_itemPart.TryParseName(aResourceName, out resourceName))
+            {
+                result = CreateItemPart(resourceName[0], resourceName[1]);
+                return true;
+            }
+            if (allowUnknown)
+            {
+                if (gax::UnknownResourceName.TryParse(aResourceName, out gax::UnknownResourceName unknownResourceName))
+                {
+                    result = CreateUnknown(unknownResourceName);
+                    return true;
+                }
+            }
+            result = null;
+            return false;
+        }
+
+        private AResourceName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null, string partId = null)
+        {
+            Type = type;
+            UnknownResource = unknownResourceName;
+            ItemId = itemId;
+            PartId = partId;
+        }
+
+        /// <summary>
+        /// Constructs a new instance of a <see cref="AResourceName"/> class from the component parts of pattern
+        /// <c>items/{item_id}/parts/{part_id}</c>
+        /// </summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="partId">The <c>Part</c> ID. Must not be <c>null</c> or empty.</param>
+        public AResourceName(string itemId, string partId) : this(ResourceType.ItemPart, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)), partId: gax::GaxPreconditions.CheckNotNullOrEmpty(partId, nameof(partId)))
+        {
+        }
+
+        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
+        public ResourceType Type { get; }
+
+        /// <summary>
+        /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
+        /// unknown resource name.
+        /// </summary>
+        public gax::UnknownResourceName UnknownResource { get; }
+
+        /// <summary>
+        /// The <c>Item</c> ID. Will not be <c>null</c>, unless this instance contains an unknown resource name.
+        /// </summary>
+        public string ItemId { get; }
+
+        /// <summary>
+        /// The <c>Part</c> ID. Will not be <c>null</c>, unless this instance contains an unknown resource name.
+        /// </summary>
+        public string PartId { get; }
+
+        /// <inheritdoc/>
+        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            switch (Type)
+            {
+                case ResourceType.Unknown: return UnknownResource.ToString();
+                case ResourceType.ItemPart: return s_itemPart.Expand(ItemId, PartId);
+                default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
+            }
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj) => Equals(obj as AResourceName);
+
+        /// <inheritdoc/>
+        public bool Equals(AResourceName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc/>
+        public static bool operator ==(AResourceName a, AResourceName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc/>
+        public static bool operator !=(AResourceName a, AResourceName b) => !(a == b);
+    }
+
+    /// <summary>Resource name for the <c>MultiPatternResource</c> resource.</summary>
+    public sealed partial class MultiPatternResourceName : gax::IResourceName, sys::IEquatable<MultiPatternResourceName>
+    {
+        /// <summary>The possible contents of <see cref="MultiPatternResourceName"/>.</summary>
+        public enum ResourceType
+        {
+            /// <summary>A resource of an unknown type.</summary>
+            Unknown = 0,
+
+            /// <summary>A resource of type 'root_a'.</summary>
+            RootAItem = 1,
+
+            /// <summary>A resource of type 'root_b'.</summary>
+            RootBItem = 2
+        }
+
+        private static gax::PathTemplate s_rootAItem = new gax::PathTemplate("root/{root_a_id}/items/{item_id}");
+
+        private static gax::PathTemplate s_rootBItem = new gax::PathTemplate("root/{root_b_id}/items/{item_id}");
+
+        /// <summary>Creates a <see cref="MultiPatternResourceName"/> containing an unknown resource name.</summary>
+        /// <param name="unknownResourceName">The unknown resource name. Must not be <c>null</c>.</param>
+        /// <returns>
+        /// A new instance of <see cref="MultiPatternResourceName"/> containing the provided
+        /// <paramref name="unknownResourceName"/>.
+        /// </returns>
+        public static MultiPatternResourceName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new MultiPatternResourceName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+
+        /// <summary>
+        /// Creates a <see cref="MultiPatternResourceName"/> with the pattern <c>root/{root_a_id}/items/{item_id}</c>.
+        /// </summary>
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// A new instance of <see cref="MultiPatternResourceName"/> constructed from the provided ids.
+        /// </returns>
+        public static MultiPatternResourceName CreateRootAItem(string rootAId, string itemId) =>
+            new MultiPatternResourceName(ResourceType.RootAItem, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+
+        /// <summary>
+        /// Creates a <see cref="MultiPatternResourceName"/> with the pattern <c>root/{root_b_id}/items/{item_id}</c>.
+        /// </summary>
+        /// <param name="rootBId">The <c>RootB</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// A new instance of <see cref="MultiPatternResourceName"/> constructed from the provided ids.
+        /// </returns>
+        public static MultiPatternResourceName CreateRootBItem(string rootBId, string itemId) =>
+            new MultiPatternResourceName(ResourceType.RootBItem, rootBId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootBId, nameof(rootBId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="MultiPatternResourceName"/> with pattern
+        /// <c>root/{root_a_id}/items/{item_id}</c>.
+        /// </summary>
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="MultiPatternResourceName"/> with pattern
+        /// <c>root/{root_a_id}/items/{item_id}</c>.
+        /// </returns>
+        public static string Format(string rootAId, string itemId) => FormatRootAItem(rootAId, itemId);
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="MultiPatternResourceName"/> with pattern
+        /// <c>root/{root_a_id}/items/{item_id}</c>.
+        /// </summary>
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="MultiPatternResourceName"/> with pattern
+        /// <c>root/{root_a_id}/items/{item_id}</c>.
+        /// </returns>
+        public static string FormatRootAItem(string rootAId, string itemId) =>
+            s_rootAItem.Expand(gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="MultiPatternResourceName"/> with pattern
+        /// <c>root/{root_b_id}/items/{item_id}</c>.
+        /// </summary>
+        /// <param name="rootBId">The <c>RootB</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="MultiPatternResourceName"/> with pattern
+        /// <c>root/{root_b_id}/items/{item_id}</c>.
+        /// </returns>
+        public static string FormatRootBItem(string rootBId, string itemId) =>
+            s_rootBItem.Expand(gax::GaxPreconditions.CheckNotNullOrEmpty(rootBId, nameof(rootBId)), gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+
+        /// <summary>
+        /// Parses the given resource name string into a new <see cref="MultiPatternResourceName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet">
+        /// <item><description><c>root/{root_a_id}/items/{item_id}</c></description></item>
+        /// <item><description><c>root/{root_b_id}/items/{item_id}</c></description></item>
+        /// </list>
+        /// </remarks>
+        /// <param name="multiPatternResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="MultiPatternResourceName"/> if successful.</returns>
+        public static MultiPatternResourceName Parse(string multiPatternResourceName) =>
+            Parse(multiPatternResourceName, false);
+
+        /// <summary>
+        /// Parses the given resource name string into a new <see cref="MultiPatternResourceName"/> instance; optionally
+        /// allowing an unknown resource name to be successfully parsed
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet">
+        /// <item><description><c>root/{root_a_id}/items/{item_id}</c></description></item>
+        /// <item><description><c>root/{root_b_id}/items/{item_id}</c></description></item>
+        /// </list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="multiPatternResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
+        /// </param>
+        /// <returns>The parsed <see cref="MultiPatternResourceName"/> if successful.</returns>
+        public static MultiPatternResourceName Parse(string multiPatternResourceName, bool allowUnknown) =>
+            TryParse(multiPatternResourceName, allowUnknown, out MultiPatternResourceName result) ? result : throw new sys::ArgumentException("The given resource-name matches no pattern.");
+
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="MultiPatternResourceName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet">
+        /// <item><description><c>root/{root_a_id}/items/{item_id}</c></description></item>
+        /// <item><description><c>root/{root_b_id}/items/{item_id}</c></description></item>
+        /// </list>
+        /// </remarks>
+        /// <param name="multiPatternResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="MultiPatternResourceName"/>, or <c>null</c> if parsing
+        /// failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string multiPatternResourceName, out MultiPatternResourceName result) =>
+            TryParse(multiPatternResourceName, false, out result);
+
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="MultiPatternResourceName"/> instance;
+        /// optionally allowing an unknown resource name to be successfully parsed.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet">
+        /// <item><description><c>root/{root_a_id}/items/{item_id}</c></description></item>
+        /// <item><description><c>root/{root_b_id}/items/{item_id}</c></description></item>
+        /// </list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="multiPatternResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
+        /// </param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="MultiPatternResourceName"/>, or <c>null</c> if parsing
+        /// failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string multiPatternResourceName, bool allowUnknown, out MultiPatternResourceName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(multiPatternResourceName, nameof(multiPatternResourceName));
+            gax::TemplatedResourceName resourceName;
+            if (s_rootAItem.TryParseName(multiPatternResourceName, out resourceName))
+            {
+                result = CreateRootAItem(resourceName[0], resourceName[1]);
+                return true;
+            }
+            if (s_rootBItem.TryParseName(multiPatternResourceName, out resourceName))
+            {
+                result = CreateRootBItem(resourceName[0], resourceName[1]);
+                return true;
+            }
+            if (allowUnknown)
+            {
+                if (gax::UnknownResourceName.TryParse(multiPatternResourceName, out gax::UnknownResourceName unknownResourceName))
+                {
+                    result = CreateUnknown(unknownResourceName);
+                    return true;
+                }
+            }
+            result = null;
+            return false;
+        }
+
+        private MultiPatternResourceName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null, string rootAId = null, string rootBId = null)
+        {
+            Type = type;
+            UnknownResource = unknownResourceName;
+            ItemId = itemId;
+            RootAId = rootAId;
+            RootBId = rootBId;
+        }
+
+        /// <summary>
+        /// Constructs a new instance of a <see cref="MultiPatternResourceName"/> class from the component parts of
+        /// pattern <c>root/{root_a_id}/items/{item_id}</c>
+        /// </summary>
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        public MultiPatternResourceName(string rootAId, string itemId) : this(ResourceType.RootAItem, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
+        {
+        }
+
+        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
+        public ResourceType Type { get; }
+
+        /// <summary>
+        /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
+        /// unknown resource name.
+        /// </summary>
+        public gax::UnknownResourceName UnknownResource { get; }
+
+        /// <summary>
+        /// The <c>Item</c> ID. May be <c>null</c>, depending on which resource name is contained by this instance.
+        /// </summary>
+        public string ItemId { get; }
+
+        /// <summary>
+        /// The <c>RootA</c> ID. May be <c>null</c>, depending on which resource name is contained by this instance.
+        /// </summary>
+        public string RootAId { get; }
+
+        /// <summary>
+        /// The <c>RootB</c> ID. May be <c>null</c>, depending on which resource name is contained by this instance.
+        /// </summary>
+        public string RootBId { get; }
+
+        /// <inheritdoc/>
+        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Oneof;
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            switch (Type)
+            {
+                case ResourceType.Unknown: return UnknownResource.ToString();
+                case ResourceType.RootAItem: return s_rootAItem.Expand(RootAId, ItemId);
+                case ResourceType.RootBItem: return s_rootBItem.Expand(RootBId, ItemId);
+                default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
+            }
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj) => Equals(obj as MultiPatternResourceName);
+
+        /// <inheritdoc/>
+        public bool Equals(MultiPatternResourceName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc/>
+        public static bool operator ==(MultiPatternResourceName a, MultiPatternResourceName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc/>
+        public static bool operator !=(MultiPatternResourceName a, MultiPatternResourceName b) => !(a == b);
+    }
+
+    /// <summary>Resource name for the <c>SimpleResource</c> resource.</summary>
+    public sealed partial class SimpleResourceName : gax::IResourceName, sys::IEquatable<SimpleResourceName>
+    {
+        /// <summary>The possible contents of <see cref="SimpleResourceName"/>.</summary>
+        public enum ResourceType
+        {
+            /// <summary>A resource of an unknown type.</summary>
+            Unknown = 0,
+
+            /// <summary>A resource of type 'item'.</summary>
+            Item = 1
+        }
+
+        private static gax::PathTemplate s_item = new gax::PathTemplate("items/{item_id}");
+
+        /// <summary>Creates a <see cref="SimpleResourceName"/> containing an unknown resource name.</summary>
+        /// <param name="unknownResourceName">The unknown resource name. Must not be <c>null</c>.</param>
+        /// <returns>
+        /// A new instance of <see cref="SimpleResourceName"/> containing the provided
+        /// <paramref name="unknownResourceName"/>.
+        /// </returns>
+        public static SimpleResourceName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new SimpleResourceName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+
+        /// <summary>Creates a <see cref="SimpleResourceName"/> with the pattern <c>items/{item_id}</c>.</summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>A new instance of <see cref="SimpleResourceName"/> constructed from the provided ids.</returns>
+        public static SimpleResourceName CreateItem(string itemId) =>
+            new SimpleResourceName(ResourceType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="SimpleResourceName"/> with pattern
+        /// <c>items/{item_id}</c>.
+        /// </summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="SimpleResourceName"/> with pattern <c>items/{item_id}</c>.
+        /// </returns>
+        public static string Format(string itemId) => FormatItem(itemId);
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="SimpleResourceName"/> with pattern
+        /// <c>items/{item_id}</c>.
+        /// </summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="SimpleResourceName"/> with pattern <c>items/{item_id}</c>.
+        /// </returns>
+        public static string FormatItem(string itemId) =>
+            s_item.Expand(gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+
+        /// <summary>
+        /// Parses the given resource name string into a new <see cref="SimpleResourceName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}</c></description></item></list>
+        /// </remarks>
+        /// <param name="simpleResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="SimpleResourceName"/> if successful.</returns>
+        public static SimpleResourceName Parse(string simpleResourceName) => Parse(simpleResourceName, false);
+
+        /// <summary>
+        /// Parses the given resource name string into a new <see cref="SimpleResourceName"/> instance; optionally
+        /// allowing an unknown resource name to be successfully parsed
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}</c></description></item></list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="simpleResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
+        /// </param>
+        /// <returns>The parsed <see cref="SimpleResourceName"/> if successful.</returns>
+        public static SimpleResourceName Parse(string simpleResourceName, bool allowUnknown) =>
+            TryParse(simpleResourceName, allowUnknown, out SimpleResourceName result) ? result : throw new sys::ArgumentException("The given resource-name matches no pattern.");
+
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="SimpleResourceName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}</c></description></item></list>
+        /// </remarks>
+        /// <param name="simpleResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="SimpleResourceName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string simpleResourceName, out SimpleResourceName result) =>
+            TryParse(simpleResourceName, false, out result);
+
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="SimpleResourceName"/> instance;
+        /// optionally allowing an unknown resource name to be successfully parsed.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}</c></description></item></list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="simpleResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
+        /// </param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="SimpleResourceName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string simpleResourceName, bool allowUnknown, out SimpleResourceName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(simpleResourceName, nameof(simpleResourceName));
+            gax::TemplatedResourceName resourceName;
+            if (s_item.TryParseName(simpleResourceName, out resourceName))
+            {
+                result = CreateItem(resourceName[0]);
+                return true;
+            }
+            if (allowUnknown)
+            {
+                if (gax::UnknownResourceName.TryParse(simpleResourceName, out gax::UnknownResourceName unknownResourceName))
+                {
+                    result = CreateUnknown(unknownResourceName);
+                    return true;
+                }
+            }
+            result = null;
+            return false;
+        }
+
+        private SimpleResourceName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null)
+        {
+            Type = type;
+            UnknownResource = unknownResourceName;
+            ItemId = itemId;
+        }
+
+        /// <summary>
+        /// Constructs a new instance of a <see cref="SimpleResourceName"/> class from the component parts of pattern
+        /// <c>items/{item_id}</c>
+        /// </summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        public SimpleResourceName(string itemId) : this(ResourceType.Item, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
+        {
+        }
+
+        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
+        public ResourceType Type { get; }
+
+        /// <summary>
+        /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
+        /// unknown resource name.
+        /// </summary>
+        public gax::UnknownResourceName UnknownResource { get; }
+
+        /// <summary>
+        /// The <c>Item</c> ID. Will not be <c>null</c>, unless this instance contains an unknown resource name.
+        /// </summary>
+        public string ItemId { get; }
+
+        /// <inheritdoc/>
+        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            switch (Type)
+            {
+                case ResourceType.Unknown: return UnknownResource.ToString();
+                case ResourceType.Item: return s_item.Expand(ItemId);
+                default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
+            }
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj) => Equals(obj as SimpleResourceName);
+
+        /// <inheritdoc/>
+        public bool Equals(SimpleResourceName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc/>
+        public static bool operator ==(SimpleResourceName a, SimpleResourceName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc/>
+        public static bool operator !=(SimpleResourceName a, SimpleResourceName b) => !(a == b);
+    }
+
+    public partial class AResource
+    {
+        /// <summary>
+        /// <see cref="ts::AResourceName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// </summary>
+        public ts::AResourceName AResourceName
+        {
+            get => string.IsNullOrEmpty(Name) ? null : ts::AResourceName.Parse(Name);
+            set => Name = value?.ToString() ?? "";
+        }
+    }
+
+    public partial class WildcardResource
+    {
+        /// <summary>
+        /// <see cref="gax::IResourceName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// </summary>
+        public gax::IResourceName AsResourceName
+        {
+            get => string.IsNullOrEmpty(Name) ? null : gax::UnknownResourceName.Parse(Name);
+            set => Name = value?.ToString() ?? "";
+        }
+    }
+
+    public partial class MultiPatternResource
+    {
+        /// <summary>
+        /// <see cref="ts::MultiPatternResourceName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// </summary>
+        public ts::MultiPatternResourceName MultiPatternResourceName
+        {
+            get => string.IsNullOrEmpty(Name) ? null : ts::MultiPatternResourceName.Parse(Name);
+            set => Name = value?.ToString() ?? "";
+        }
+    }
+
+    public partial class DefaultValuesRequest
+    {
+        /// <summary>
+        /// <see cref="AResourceName"/>-typed view over the <see cref="SingleResourceName"/> resource name property.
+        /// </summary>
+        public AResourceName SingleResourceNameAsAResourceName
+        {
+            get => string.IsNullOrEmpty(SingleResourceName) ? null : AResourceName.Parse(SingleResourceName);
+            set => SingleResourceName = value?.ToString() ?? "";
+        }
+
+        /// <summary>
+        /// <see cref="AResourceName"/>-typed view over the <see cref="RepeatedResourceName"/> resource name property.
+        /// </summary>
+        public gax::ResourceNameList<AResourceName> RepeatedResourceNameAsAResourceNames
+        {
+            get => new gax::ResourceNameList<AResourceName>(RepeatedResourceName, s => AResourceName.Parse(s));
+        }
+
+        /// <summary>
+        /// <see cref="gax::IResourceName"/>-typed view over the <see cref="SingleWildcardResource"/> resource name
+        /// property.
+        /// </summary>
+        public gax::IResourceName SingleWildcardResourceAsResourceName
+        {
+            get => string.IsNullOrEmpty(SingleWildcardResource) ? null : gax::UnknownResourceName.Parse(SingleWildcardResource);
+            set => SingleWildcardResource = value?.ToString() ?? "";
+        }
+
+        /// <summary>
+        /// <see cref="gax::IResourceName"/>-typed view over the <see cref="RepeatedWildcardResource"/> resource name
+        /// property.
+        /// </summary>
+        public gax::ResourceNameList<gax::IResourceName> RepeatedWildcardResourceAsResourceNames
+        {
+            get => new gax::ResourceNameList<gax::IResourceName>(RepeatedWildcardResource, s => gax::UnknownResourceName.Parse(s));
+        }
+
+        /// <summary>
+        /// <see cref="ts::MultiPatternResourceName"/>-typed view over the <see cref="MultiPatternResourceName"/>
+        /// resource name property.
+        /// </summary>
+        public ts::MultiPatternResourceName MultiPatternResourceNameAsMultiPatternResourceName
+        {
+            get => string.IsNullOrEmpty(MultiPatternResourceName) ? null : ts::MultiPatternResourceName.Parse(MultiPatternResourceName);
+            set => MultiPatternResourceName = value?.ToString() ?? "";
+        }
+
+        /// <summary>
+        /// <see cref="ts::MultiPatternResourceName"/>-typed view over the
+        /// <see cref="RepeatedMultiPatternResourceName"/> resource name property.
+        /// </summary>
+        public gax::ResourceNameList<ts::MultiPatternResourceName> RepeatedMultiPatternResourceNameAsMultiPatternResourceNames
+        {
+            get => new gax::ResourceNameList<ts::MultiPatternResourceName>(RepeatedMultiPatternResourceName, s => ts::MultiPatternResourceName.Parse(s));
+        }
+    }
+
+    public partial class SimpleResource
+    {
+        /// <summary>
+        /// <see cref="ts::SimpleResourceName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// </summary>
+        public ts::SimpleResourceName SimpleResourceName
+        {
+            get => string.IsNullOrEmpty(Name) ? null : ts::SimpleResourceName.Parse(Name);
+            set => Name = value?.ToString() ?? "";
+        }
+    }
+
+    public partial class ResourceSignatureRequest
+    {
+        /// <summary>
+        /// <see cref="SimpleResourceName"/>-typed view over the <see cref="FirstName"/> resource name property.
+        /// </summary>
+        public SimpleResourceName FirstNameAsSimpleResourceName
+        {
+            get => string.IsNullOrEmpty(FirstName) ? null : SimpleResourceName.Parse(FirstName);
+            set => FirstName = value?.ToString() ?? "";
+        }
+
+        /// <summary>
+        /// <see cref="SimpleResourceName"/>-typed view over the <see cref="SecondName"/> resource name property.
+        /// </summary>
+        public SimpleResourceName SecondNameAsSimpleResourceName
+        {
+            get => string.IsNullOrEmpty(SecondName) ? null : SimpleResourceName.Parse(SecondName);
+            set => SecondName = value?.ToString() ?? "";
+        }
+
+        /// <summary>
+        /// <see cref="SimpleResourceName"/>-typed view over the <see cref="ThirdName"/> resource name property.
+        /// </summary>
+        public SimpleResourceName ThirdNameAsSimpleResourceName
+        {
+            get => string.IsNullOrEmpty(ThirdName) ? null : SimpleResourceName.Parse(ThirdName);
+            set => ThirdName = value?.ToString() ?? "";
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/UnitTests/Testing.UnitTests.Tests/UnitTestsClientTest.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/UnitTests/Testing.UnitTests.Tests/UnitTestsClientTest.g.cs
@@ -107,20 +107,20 @@ namespace Testing.UnitTests.Tests
                 {
                     ValuesRequest.Types.NestedEnum.Default,
                 },
-                SingleResourceNameAsAResourceName = AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
+                SingleResourceNameAsAResourceName = AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
                 RepeatedResourceNameAsAResourceNames =
                 {
-                    AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
+                    AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
                 },
                 SingleWildcardResourceAsResourceName = new gax::UnknownResourceName("a/wildcard/resource"),
                 RepeatedWildcardResourceAsResourceNames =
                 {
                     new gax::UnknownResourceName("a/wildcard/resource"),
                 },
-                MultiPatternResourceNameAsMultiPatternResourceName = MultiPatternResourceName.CreateRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
+                MultiPatternResourceNameAsMultiPatternResourceName = MultiPatternResourceName.FromRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
                 RepeatedMultiPatternResourceNameAsMultiPatternResourceNames =
                 {
-                    MultiPatternResourceName.CreateRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
+                    MultiPatternResourceName.FromRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
                 },
                 MapIntString =
                 {
@@ -216,20 +216,20 @@ namespace Testing.UnitTests.Tests
                 {
                     ValuesRequest.Types.NestedEnum.Default,
                 },
-                SingleResourceNameAsAResourceName = AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
+                SingleResourceNameAsAResourceName = AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
                 RepeatedResourceNameAsAResourceNames =
                 {
-                    AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
+                    AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
                 },
                 SingleWildcardResourceAsResourceName = new gax::UnknownResourceName("a/wildcard/resource"),
                 RepeatedWildcardResourceAsResourceNames =
                 {
                     new gax::UnknownResourceName("a/wildcard/resource"),
                 },
-                MultiPatternResourceNameAsMultiPatternResourceName = MultiPatternResourceName.CreateRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
+                MultiPatternResourceNameAsMultiPatternResourceName = MultiPatternResourceName.FromRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
                 RepeatedMultiPatternResourceNameAsMultiPatternResourceNames =
                 {
-                    MultiPatternResourceName.CreateRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
+                    MultiPatternResourceName.FromRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
                 },
                 MapIntString =
                 {
@@ -303,7 +303,7 @@ namespace Testing.UnitTests.Tests
                 },
                 RepeatedResourceNameAsAResourceNames =
                 {
-                    AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
+                    AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
                 },
             };
             Response expectedResponse = new Response { };
@@ -332,7 +332,7 @@ namespace Testing.UnitTests.Tests
                 },
                 RepeatedResourceNameAsAResourceNames =
                 {
-                    AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
+                    AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
                 },
             };
             Response expectedResponse = new Response { };
@@ -363,7 +363,7 @@ namespace Testing.UnitTests.Tests
                 },
                 RepeatedResourceNameAsAResourceNames =
                 {
-                    AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
+                    AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
                 },
             };
             Response expectedResponse = new Response { };
@@ -392,7 +392,7 @@ namespace Testing.UnitTests.Tests
                 },
                 RepeatedResourceNameAsAResourceNames =
                 {
-                    AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
+                    AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
                 },
             };
             Response expectedResponse = new Response { };

--- a/Google.Api.Generator.Tests/ProtoTests/UnitTests/Testing.UnitTests.Tests/UnitTestsClientTest.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/UnitTests/Testing.UnitTests.Tests/UnitTestsClientTest.g.cs
@@ -107,20 +107,20 @@ namespace Testing.UnitTests.Tests
                 {
                     ValuesRequest.Types.NestedEnum.Default,
                 },
-                SingleResourceNameAsAResourceName = new AResourceName("[ITEM_ID]", "[PART_ID]"),
+                SingleResourceNameAsAResourceName = AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
                 RepeatedResourceNameAsAResourceNames =
                 {
-                    new AResourceName("[ITEM_ID]", "[PART_ID]"),
+                    AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
                 },
                 SingleWildcardResourceAsResourceName = new gax::UnknownResourceName("a/wildcard/resource"),
                 RepeatedWildcardResourceAsResourceNames =
                 {
                     new gax::UnknownResourceName("a/wildcard/resource"),
                 },
-                MultiPatternResourceNameAsMultiPatternResourceNameOneOf = MultiPatternResourceNameOneOf.From(new RootAItemName("[ROOT_A_ID]", "[ITEM_ID]")),
-                RepeatedMultiPatternResourceNameAsMultiPatternResourceNameOneOfs =
+                MultiPatternResourceNameAsMultiPatternResourceName = MultiPatternResourceName.CreateRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
+                RepeatedMultiPatternResourceNameAsMultiPatternResourceNames =
                 {
-                    MultiPatternResourceNameOneOf.From(new RootAItemName("[ROOT_A_ID]", "[ITEM_ID]")),
+                    MultiPatternResourceName.CreateRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
                 },
                 MapIntString =
                 {
@@ -216,20 +216,20 @@ namespace Testing.UnitTests.Tests
                 {
                     ValuesRequest.Types.NestedEnum.Default,
                 },
-                SingleResourceNameAsAResourceName = new AResourceName("[ITEM_ID]", "[PART_ID]"),
+                SingleResourceNameAsAResourceName = AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
                 RepeatedResourceNameAsAResourceNames =
                 {
-                    new AResourceName("[ITEM_ID]", "[PART_ID]"),
+                    AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
                 },
                 SingleWildcardResourceAsResourceName = new gax::UnknownResourceName("a/wildcard/resource"),
                 RepeatedWildcardResourceAsResourceNames =
                 {
                     new gax::UnknownResourceName("a/wildcard/resource"),
                 },
-                MultiPatternResourceNameAsMultiPatternResourceNameOneOf = MultiPatternResourceNameOneOf.From(new RootAItemName("[ROOT_A_ID]", "[ITEM_ID]")),
-                RepeatedMultiPatternResourceNameAsMultiPatternResourceNameOneOfs =
+                MultiPatternResourceNameAsMultiPatternResourceName = MultiPatternResourceName.CreateRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
+                RepeatedMultiPatternResourceNameAsMultiPatternResourceNames =
                 {
-                    MultiPatternResourceNameOneOf.From(new RootAItemName("[ROOT_A_ID]", "[ITEM_ID]")),
+                    MultiPatternResourceName.CreateRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
                 },
                 MapIntString =
                 {
@@ -303,7 +303,7 @@ namespace Testing.UnitTests.Tests
                 },
                 RepeatedResourceNameAsAResourceNames =
                 {
-                    new AResourceName("[ITEM_ID]", "[PART_ID]"),
+                    AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
                 },
             };
             Response expectedResponse = new Response { };
@@ -332,7 +332,7 @@ namespace Testing.UnitTests.Tests
                 },
                 RepeatedResourceNameAsAResourceNames =
                 {
-                    new AResourceName("[ITEM_ID]", "[PART_ID]"),
+                    AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
                 },
             };
             Response expectedResponse = new Response { };
@@ -363,7 +363,7 @@ namespace Testing.UnitTests.Tests
                 },
                 RepeatedResourceNameAsAResourceNames =
                 {
-                    new AResourceName("[ITEM_ID]", "[PART_ID]"),
+                    AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
                 },
             };
             Response expectedResponse = new Response { };
@@ -392,7 +392,7 @@ namespace Testing.UnitTests.Tests
                 },
                 RepeatedResourceNameAsAResourceNames =
                 {
-                    new AResourceName("[ITEM_ID]", "[PART_ID]"),
+                    AResourceName.CreateItemPart("[ITEM_ID]", "[PART_ID]"),
                 },
             };
             Response expectedResponse = new Response { };

--- a/Google.Api.Generator.Tests/ProtoTests/UnitTests/Testing.UnitTests/UnitTestsResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/UnitTests/Testing.UnitTests/UnitTestsResourceNames.g.cs
@@ -23,82 +23,193 @@ namespace Testing.UnitTests
     /// <summary>Resource name for the <c>AResource</c> resource.</summary>
     public sealed partial class AResourceName : gax::IResourceName, sys::IEquatable<AResourceName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("items/{item_id}/parts/{part_id}");
-
-        /// <summary>
-        /// Parses the given <c>AResource</c> resource name in string form into a new <see cref="AResourceName"/>
-        /// instance.
-        /// </summary>
-        /// <param name="aResourceName">
-        /// The <c>AResource</c> resource name in string form. Must not be <c>null</c>.
-        /// </param>
-        /// <returns>The parsed <see cref="AResourceName"/> if successful.</returns>
-        public static AResourceName Parse(string aResourceName)
+        /// <summary>The possible contents of <see cref="AResourceName"/>.</summary>
+        public enum ResourceType
         {
-            gax::GaxPreconditions.CheckNotNull(aResourceName, nameof(aResourceName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(aResourceName);
-            return new AResourceName(resourceName[0], resourceName[1]);
+            /// <summary>A resource of an unknown type.</summary>
+            Unknown = 0,
+
+            /// <summary>A resource of type 'item'.</summary>
+            ItemPart = 1
         }
 
+        private static gax::PathTemplate s_itemPart = new gax::PathTemplate("items/{item_id}/parts/{part_id}");
+
+        /// <summary>Creates a <see cref="AResourceName"/> containing an unknown resource name.</summary>
+        /// <param name="unknownResourceName">The unknown resource name. Must not be <c>null</c>.</param>
+        /// <returns>
+        /// A new instance of <see cref="AResourceName"/> containing the provided <paramref name="unknownResourceName"/>
+        /// .
+        /// </returns>
+        public static AResourceName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new AResourceName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+
         /// <summary>
-        /// Tries to parse the given session resource name in string form into a new <see cref="AResourceName"/>
-        /// instance.
+        /// Creates a <see cref="AResourceName"/> with the pattern <c>items/{item_id}/parts/{part_id}</c>.
+        /// </summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="partId">The <c>Part</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>A new instance of <see cref="AResourceName"/> constructed from the provided ids.</returns>
+        public static AResourceName CreateItemPart(string itemId, string partId) =>
+            new AResourceName(ResourceType.ItemPart, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)), partId: gax::GaxPreconditions.CheckNotNullOrEmpty(partId, nameof(partId)));
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="AResourceName"/> with pattern
+        /// <c>items/{item_id}/parts/{part_id}</c>.
+        /// </summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="partId">The <c>Part</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="AResourceName"/> with pattern
+        /// <c>items/{item_id}/parts/{part_id}</c>.
+        /// </returns>
+        public static string Format(string itemId, string partId) => FormatItemPart(itemId, partId);
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="AResourceName"/> with pattern
+        /// <c>items/{item_id}/parts/{part_id}</c>.
+        /// </summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="partId">The <c>Part</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="AResourceName"/> with pattern
+        /// <c>items/{item_id}/parts/{part_id}</c>.
+        /// </returns>
+        public static string FormatItemPart(string itemId, string partId) =>
+            s_itemPart.Expand(gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)), gax::GaxPreconditions.CheckNotNullOrEmpty(partId, nameof(partId)));
+
+        /// <summary>Parses the given resource name string into a new <see cref="AResourceName"/> instance.</summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}/parts/{part_id}</c></description></item></list>
+        /// </remarks>
+        /// <param name="aResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="AResourceName"/> if successful.</returns>
+        public static AResourceName Parse(string aResourceName) => Parse(aResourceName, false);
+
+        /// <summary>
+        /// Parses the given resource name string into a new <see cref="AResourceName"/> instance; optionally allowing
+        /// an unknown resource name to be successfully parsed
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="aResourceName"/> is
-        /// <c>null</c>, as this would usually indicate a programming error rather than a data error.
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}/parts/{part_id}</c></description></item></list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
         /// </remarks>
-        /// <param name="aResourceName">
-        /// The <c>AResource</c> resource name in string form. Must not be <c>null</c>.
+        /// <param name="aResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
         /// </param>
-        /// <param name="result">
-        /// When this method returns, the parsed <see cref="AResourceName"/>, or <c>null</c> if parsing fails.
-        /// </param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string aResourceName, out AResourceName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(aResourceName, nameof(aResourceName));
-            if (s_template.TryParseName(aResourceName, out gax::TemplatedResourceName resourceName))
-            {
-                result = new AResourceName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>Formats the IDs into the string representation of the <see cref="AResourceName"/>.</summary>
-        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c>.</param>
-        /// <param name="partId">The <c>Part</c> ID. Must not be <c>null</c>.</param>
-        /// <returns>The string representation of the <see cref="AResourceName"/>.</returns>
-        public static string Format(string itemId, string partId) =>
-            s_template.Expand(gax::GaxPreconditions.CheckNotNull(itemId, nameof(itemId)), gax::GaxPreconditions.CheckNotNull(partId, nameof(partId)));
+        /// <returns>The parsed <see cref="AResourceName"/> if successful.</returns>
+        public static AResourceName Parse(string aResourceName, bool allowUnknown) =>
+            TryParse(aResourceName, allowUnknown, out AResourceName result) ? result : throw new sys::ArgumentException("The given resource-name matches no pattern.");
 
         /// <summary>
-        /// Constructs a new instance of the <see cref="AResourceName"/> resource name class from its component parts.
+        /// Tries to parse the given resource name string into a new <see cref="AResourceName"/> instance.
         /// </summary>
-        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c>.</param>
-        /// <param name="partId">The <c>Part</c> ID. Must not be <c>null</c>.</param>
-        public AResourceName(string itemId, string partId)
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}/parts/{part_id}</c></description></item></list>
+        /// </remarks>
+        /// <param name="aResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="AResourceName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string aResourceName, out AResourceName result) => TryParse(aResourceName, false, out result);
+
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="AResourceName"/> instance; optionally
+        /// allowing an unknown resource name to be successfully parsed.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>items/{item_id}/parts/{part_id}</c></description></item></list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="aResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
+        /// </param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="AResourceName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string aResourceName, bool allowUnknown, out AResourceName result)
         {
-            ItemId = gax::GaxPreconditions.CheckNotNull(itemId, nameof(itemId));
-            PartId = gax::GaxPreconditions.CheckNotNull(partId, nameof(partId));
+            gax::GaxPreconditions.CheckNotNull(aResourceName, nameof(aResourceName));
+            gax::TemplatedResourceName resourceName;
+            if (s_itemPart.TryParseName(aResourceName, out resourceName))
+            {
+                result = CreateItemPart(resourceName[0], resourceName[1]);
+                return true;
+            }
+            if (allowUnknown)
+            {
+                if (gax::UnknownResourceName.TryParse(aResourceName, out gax::UnknownResourceName unknownResourceName))
+                {
+                    result = CreateUnknown(unknownResourceName);
+                    return true;
+                }
+            }
+            result = null;
+            return false;
         }
 
-        /// <summary>The <c>Item</c> ID. Never <c>null</c>.</summary>
+        private AResourceName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null, string partId = null)
+        {
+            Type = type;
+            UnknownResource = unknownResourceName;
+            ItemId = itemId;
+            PartId = partId;
+        }
+
+        /// <summary>
+        /// Constructs a new instance of a <see cref="AResourceName"/> class from the component parts of pattern
+        /// <c>items/{item_id}/parts/{part_id}</c>
+        /// </summary>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="partId">The <c>Part</c> ID. Must not be <c>null</c> or empty.</param>
+        public AResourceName(string itemId, string partId) : this(ResourceType.ItemPart, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)), partId: gax::GaxPreconditions.CheckNotNullOrEmpty(partId, nameof(partId)))
+        {
+        }
+
+        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
+        public ResourceType Type { get; }
+
+        /// <summary>
+        /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
+        /// unknown resource name.
+        /// </summary>
+        public gax::UnknownResourceName UnknownResource { get; }
+
+        /// <summary>
+        /// The <c>Item</c> ID. Will not be <c>null</c>, unless this instance contains an unknown resource name.
+        /// </summary>
         public string ItemId { get; }
 
-        /// <summary>The <c>Part</c> ID. Never <c>null</c>.</summary>
+        /// <summary>
+        /// The <c>Part</c> ID. Will not be <c>null</c>, unless this instance contains an unknown resource name.
+        /// </summary>
         public string PartId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
 
         /// <inheritdoc/>
-        public override string ToString() => s_template.Expand(ItemId, PartId);
+        public override string ToString()
+        {
+            switch (Type)
+            {
+                case ResourceType.Unknown: return UnknownResource.ToString();
+                case ResourceType.ItemPart: return s_itemPart.Expand(ItemId, PartId);
+                default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
+            }
+        }
 
         /// <inheritdoc/>
         public override int GetHashCode() => ToString().GetHashCode();
@@ -116,289 +227,193 @@ namespace Testing.UnitTests
         public static bool operator !=(AResourceName a, AResourceName b) => !(a == b);
     }
 
-    /// <summary>Resource name for the <c>RootAItem</c> resource.</summary>
-    public sealed partial class RootAItemName : gax::IResourceName, sys::IEquatable<RootAItemName>
+    /// <summary>Resource name for the <c>MultiPatternResource</c> resource.</summary>
+    public sealed partial class MultiPatternResourceName : gax::IResourceName, sys::IEquatable<MultiPatternResourceName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("root/{root_a_id}/items/{item_id}");
-
-        /// <summary>
-        /// Parses the given <c>RootAItem</c> resource name in string form into a new <see cref="RootAItemName"/>
-        /// instance.
-        /// </summary>
-        /// <param name="rootAItemName">
-        /// The <c>RootAItem</c> resource name in string form. Must not be <c>null</c>.
-        /// </param>
-        /// <returns>The parsed <see cref="RootAItemName"/> if successful.</returns>
-        public static RootAItemName Parse(string rootAItemName)
-        {
-            gax::GaxPreconditions.CheckNotNull(rootAItemName, nameof(rootAItemName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(rootAItemName);
-            return new RootAItemName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given session resource name in string form into a new <see cref="RootAItemName"/>
-        /// instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="rootAItemName"/> is
-        /// <c>null</c>, as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="rootAItemName">
-        /// The <c>RootAItem</c> resource name in string form. Must not be <c>null</c>.
-        /// </param>
-        /// <param name="result">
-        /// When this method returns, the parsed <see cref="RootAItemName"/>, or <c>null</c> if parsing fails.
-        /// </param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string rootAItemName, out RootAItemName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(rootAItemName, nameof(rootAItemName));
-            if (s_template.TryParseName(rootAItemName, out gax::TemplatedResourceName resourceName))
-            {
-                result = new RootAItemName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>Formats the IDs into the string representation of the <see cref="RootAItemName"/>.</summary>
-        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c>.</param>
-        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c>.</param>
-        /// <returns>The string representation of the <see cref="RootAItemName"/>.</returns>
-        public static string Format(string rootAId, string itemId) =>
-            s_template.Expand(gax::GaxPreconditions.CheckNotNull(rootAId, nameof(rootAId)), gax::GaxPreconditions.CheckNotNull(itemId, nameof(itemId)));
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="RootAItemName"/> resource name class from its component parts.
-        /// </summary>
-        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c>.</param>
-        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c>.</param>
-        public RootAItemName(string rootAId, string itemId)
-        {
-            RootAId = gax::GaxPreconditions.CheckNotNull(rootAId, nameof(rootAId));
-            ItemId = gax::GaxPreconditions.CheckNotNull(itemId, nameof(itemId));
-        }
-
-        /// <summary>The <c>RootA</c> ID. Never <c>null</c>.</summary>
-        public string RootAId { get; }
-
-        /// <summary>The <c>Item</c> ID. Never <c>null</c>.</summary>
-        public string ItemId { get; }
-
-        /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc/>
-        public override string ToString() => s_template.Expand(RootAId, ItemId);
-
-        /// <inheritdoc/>
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as RootAItemName);
-
-        /// <inheritdoc/>
-        public bool Equals(RootAItemName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc/>
-        public static bool operator ==(RootAItemName a, RootAItemName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc/>
-        public static bool operator !=(RootAItemName a, RootAItemName b) => !(a == b);
-    }
-
-    /// <summary>Resource name for the <c>RootBItem</c> resource.</summary>
-    public sealed partial class RootBItemName : gax::IResourceName, sys::IEquatable<RootBItemName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("root/{root_b_id}/items/{item_id}");
-
-        /// <summary>
-        /// Parses the given <c>RootBItem</c> resource name in string form into a new <see cref="RootBItemName"/>
-        /// instance.
-        /// </summary>
-        /// <param name="rootBItemName">
-        /// The <c>RootBItem</c> resource name in string form. Must not be <c>null</c>.
-        /// </param>
-        /// <returns>The parsed <see cref="RootBItemName"/> if successful.</returns>
-        public static RootBItemName Parse(string rootBItemName)
-        {
-            gax::GaxPreconditions.CheckNotNull(rootBItemName, nameof(rootBItemName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(rootBItemName);
-            return new RootBItemName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given session resource name in string form into a new <see cref="RootBItemName"/>
-        /// instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="rootBItemName"/> is
-        /// <c>null</c>, as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="rootBItemName">
-        /// The <c>RootBItem</c> resource name in string form. Must not be <c>null</c>.
-        /// </param>
-        /// <param name="result">
-        /// When this method returns, the parsed <see cref="RootBItemName"/>, or <c>null</c> if parsing fails.
-        /// </param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string rootBItemName, out RootBItemName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(rootBItemName, nameof(rootBItemName));
-            if (s_template.TryParseName(rootBItemName, out gax::TemplatedResourceName resourceName))
-            {
-                result = new RootBItemName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>Formats the IDs into the string representation of the <see cref="RootBItemName"/>.</summary>
-        /// <param name="rootBId">The <c>RootB</c> ID. Must not be <c>null</c>.</param>
-        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c>.</param>
-        /// <returns>The string representation of the <see cref="RootBItemName"/>.</returns>
-        public static string Format(string rootBId, string itemId) =>
-            s_template.Expand(gax::GaxPreconditions.CheckNotNull(rootBId, nameof(rootBId)), gax::GaxPreconditions.CheckNotNull(itemId, nameof(itemId)));
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="RootBItemName"/> resource name class from its component parts.
-        /// </summary>
-        /// <param name="rootBId">The <c>RootB</c> ID. Must not be <c>null</c>.</param>
-        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c>.</param>
-        public RootBItemName(string rootBId, string itemId)
-        {
-            RootBId = gax::GaxPreconditions.CheckNotNull(rootBId, nameof(rootBId));
-            ItemId = gax::GaxPreconditions.CheckNotNull(itemId, nameof(itemId));
-        }
-
-        /// <summary>The <c>RootB</c> ID. Never <c>null</c>.</summary>
-        public string RootBId { get; }
-
-        /// <summary>The <c>Item</c> ID. Never <c>null</c>.</summary>
-        public string ItemId { get; }
-
-        /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc/>
-        public override string ToString() => s_template.Expand(RootBId, ItemId);
-
-        /// <inheritdoc/>
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as RootBItemName);
-
-        /// <inheritdoc/>
-        public bool Equals(RootBItemName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc/>
-        public static bool operator ==(RootBItemName a, RootBItemName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc/>
-        public static bool operator !=(RootBItemName a, RootBItemName b) => !(a == b);
-    }
-
-    /// <summary>Resource name which will contain one of a choice of resource names.</summary>
-    /// <remarks>
-    /// This resource name will contain one of the following:
-    /// <list type="bullet">
-    /// <item><description>RootAItemName: A resource of type 'root_a'.</description></item>
-    /// <item><description>RootBItemName: A resource of type 'root_b'.</description></item>
-    /// </list>
-    /// </remarks>
-    public sealed partial class MultiPatternResourceNameOneOf : gax::IResourceName, sys::IEquatable<MultiPatternResourceNameOneOf>
-    {
-        /// <summary>The possible contents of <see cref="MultiPatternResourceNameOneOf"/>.</summary>
-        public enum OneofType
+        /// <summary>The possible contents of <see cref="MultiPatternResourceName"/>.</summary>
+        public enum ResourceType
         {
             /// <summary>A resource of an unknown type.</summary>
             Unknown = 0,
 
-            /// <summary>A resource of type 'root_a'</summary>
-            RootAItemName = 1,
+            /// <summary>A resource of type 'root_a'.</summary>
+            RootAItem = 1,
 
-            /// <summary>A resource of type 'root_b'</summary>
-            RootBItemName = 2
+            /// <summary>A resource of type 'root_b'.</summary>
+            RootBItem = 2
         }
 
+        private static gax::PathTemplate s_rootAItem = new gax::PathTemplate("root/{root_a_id}/items/{item_id}");
+
+        private static gax::PathTemplate s_rootBItem = new gax::PathTemplate("root/{root_b_id}/items/{item_id}");
+
+        /// <summary>Creates a <see cref="MultiPatternResourceName"/> containing an unknown resource name.</summary>
+        /// <param name="unknownResourceName">The unknown resource name. Must not be <c>null</c>.</param>
+        /// <returns>
+        /// A new instance of <see cref="MultiPatternResourceName"/> containing the provided
+        /// <paramref name="unknownResourceName"/>.
+        /// </returns>
+        public static MultiPatternResourceName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new MultiPatternResourceName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+
         /// <summary>
-        /// Parses the given <c>MultiPatternResource</c> resource name in string form into a new
-        /// <see cref="MultiPatternResourceNameOneOf"/> instance.
+        /// Creates a <see cref="MultiPatternResourceName"/> with the pattern <c>root/{root_a_id}/items/{item_id}</c>.
+        /// </summary>
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// A new instance of <see cref="MultiPatternResourceName"/> constructed from the provided ids.
+        /// </returns>
+        public static MultiPatternResourceName CreateRootAItem(string rootAId, string itemId) =>
+            new MultiPatternResourceName(ResourceType.RootAItem, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+
+        /// <summary>
+        /// Creates a <see cref="MultiPatternResourceName"/> with the pattern <c>root/{root_b_id}/items/{item_id}</c>.
+        /// </summary>
+        /// <param name="rootBId">The <c>RootB</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// A new instance of <see cref="MultiPatternResourceName"/> constructed from the provided ids.
+        /// </returns>
+        public static MultiPatternResourceName CreateRootBItem(string rootBId, string itemId) =>
+            new MultiPatternResourceName(ResourceType.RootBItem, rootBId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootBId, nameof(rootBId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="MultiPatternResourceName"/> with pattern
+        /// <c>root/{root_a_id}/items/{item_id}</c>.
+        /// </summary>
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="MultiPatternResourceName"/> with pattern
+        /// <c>root/{root_a_id}/items/{item_id}</c>.
+        /// </returns>
+        public static string Format(string rootAId, string itemId) => FormatRootAItem(rootAId, itemId);
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="MultiPatternResourceName"/> with pattern
+        /// <c>root/{root_a_id}/items/{item_id}</c>.
+        /// </summary>
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="MultiPatternResourceName"/> with pattern
+        /// <c>root/{root_a_id}/items/{item_id}</c>.
+        /// </returns>
+        public static string FormatRootAItem(string rootAId, string itemId) =>
+            s_rootAItem.Expand(gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="MultiPatternResourceName"/> with pattern
+        /// <c>root/{root_b_id}/items/{item_id}</c>.
+        /// </summary>
+        /// <param name="rootBId">The <c>RootB</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="MultiPatternResourceName"/> with pattern
+        /// <c>root/{root_b_id}/items/{item_id}</c>.
+        /// </returns>
+        public static string FormatRootBItem(string rootBId, string itemId) =>
+            s_rootBItem.Expand(gax::GaxPreconditions.CheckNotNullOrEmpty(rootBId, nameof(rootBId)), gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+
+        /// <summary>
+        /// Parses the given resource name string into a new <see cref="MultiPatternResourceName"/> instance.
         /// </summary>
         /// <remarks>
-        /// To parse successfully the resource name must be one of the following:
+        /// To parse successfully, the resource name must be formatted as one of the following:
         /// <list type="bullet">
-        /// <item><description>RootAItemName: A resource of type 'root_a'.</description></item>
-        /// <item><description>RootBItemName: A resource of type 'root_b'.</description></item>
+        /// <item><description><c>root/{root_a_id}/items/{item_id}</c></description></item>
+        /// <item><description><c>root/{root_b_id}/items/{item_id}</c></description></item>
         /// </list>
-        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>
         /// </remarks>
-        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="multiPatternResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="MultiPatternResourceName"/> if successful.</returns>
+        public static MultiPatternResourceName Parse(string multiPatternResourceName) =>
+            Parse(multiPatternResourceName, false);
+
+        /// <summary>
+        /// Parses the given resource name string into a new <see cref="MultiPatternResourceName"/> instance; optionally
+        /// allowing an unknown resource name to be successfully parsed
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet">
+        /// <item><description><c>root/{root_a_id}/items/{item_id}</c></description></item>
+        /// <item><description><c>root/{root_b_id}/items/{item_id}</c></description></item>
+        /// </list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="multiPatternResourceName">The resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="allowUnknown">
-        /// If <c>true</c>, will successfully parse an unknown resource name into an
-        /// <see cref="gax::UnknownResourceName"/>; otherwise will throw an<see cref="sys::ArgumentException"/> if an
-        /// unknown resource name is given.
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
         /// </param>
-        /// <returns>The parsed <see cref="MultiPatternResourceNameOneOf"/> if successful.</returns>
-        public static MultiPatternResourceNameOneOf Parse(string name, bool allowUnknown)
-        {
-            if (TryParse(name, allowUnknown, out MultiPatternResourceNameOneOf result))
-            {
-                return result;
-            }
-            throw new sys::ArgumentException("Invalid name", nameof(name));
-        }
+        /// <returns>The parsed <see cref="MultiPatternResourceName"/> if successful.</returns>
+        public static MultiPatternResourceName Parse(string multiPatternResourceName, bool allowUnknown) =>
+            TryParse(multiPatternResourceName, allowUnknown, out MultiPatternResourceName result) ? result : throw new sys::ArgumentException("The given resource-name matches no pattern.");
 
         /// <summary>
-        /// Tries to parse a resource name in string form into a new <see cref="MultiPatternResourceNameOneOf"/>
-        /// instance.
+        /// Tries to parse the given resource name string into a new <see cref="MultiPatternResourceName"/> instance.
         /// </summary>
         /// <remarks>
-        /// To parse successfully the resource name must be one of the following:
+        /// To parse successfully, the resource name must be formatted as one of the following:
         /// <list type="bullet">
-        /// <item><description>RootAItemName: A resource of type 'root_a'.</description></item>
-        /// <item><description>RootBItemName: A resource of type 'root_b'.</description></item>
+        /// <item><description><c>root/{root_a_id}/items/{item_id}</c></description></item>
+        /// <item><description><c>root/{root_b_id}/items/{item_id}</c></description></item>
         /// </list>
-        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>
         /// </remarks>
-        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="multiPatternResourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="MultiPatternResourceName"/>, or <c>null</c> if parsing
+        /// failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string multiPatternResourceName, out MultiPatternResourceName result) =>
+            TryParse(multiPatternResourceName, false, out result);
+
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="MultiPatternResourceName"/> instance;
+        /// optionally allowing an unknown resource name to be successfully parsed.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet">
+        /// <item><description><c>root/{root_a_id}/items/{item_id}</c></description></item>
+        /// <item><description><c>root/{root_b_id}/items/{item_id}</c></description></item>
+        /// </list>
+        /// Or may be in any format if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="multiPatternResourceName">The resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="allowUnknown">
-        /// If <c>true</c>, will successfully parse an unknown resource name into an
-        /// <see cref="gax::UnknownResourceName"/>.
+        /// If <c>true</c> will successfully parse an unknown resource name into the <see cref="UnknownResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unknown resource name is
+        /// specified.
         /// </param>
         /// <param name="result">
-        /// When this method returns, the parsed <see cref="MultiPatternResourceNameOneOf"/>, or <c>null</c> if parsing
-        /// fails.
+        /// When this method returns, the parsed <see cref="MultiPatternResourceName"/>, or <c>null</c> if parsing
+        /// failed.
         /// </param>
-        /// <returns><c>true</c> if the name was parsed succssfully; othrewise <c>false</c></returns>
-        public static bool TryParse(string name, bool allowUnknown, out MultiPatternResourceNameOneOf result)
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string multiPatternResourceName, bool allowUnknown, out MultiPatternResourceName result)
         {
-            gax::GaxPreconditions.CheckNotNull(name, nameof(name));
-            if (RootAItemName.TryParse(name, out RootAItemName rootAItemName))
+            gax::GaxPreconditions.CheckNotNull(multiPatternResourceName, nameof(multiPatternResourceName));
+            gax::TemplatedResourceName resourceName;
+            if (s_rootAItem.TryParseName(multiPatternResourceName, out resourceName))
             {
-                result = new MultiPatternResourceNameOneOf(OneofType.RootAItemName, rootAItemName);
+                result = CreateRootAItem(resourceName[0], resourceName[1]);
                 return true;
             }
-            if (RootBItemName.TryParse(name, out RootBItemName rootBItemName))
+            if (s_rootBItem.TryParseName(multiPatternResourceName, out resourceName))
             {
-                result = new MultiPatternResourceNameOneOf(OneofType.RootBItemName, rootBItemName);
+                result = CreateRootBItem(resourceName[0], resourceName[1]);
                 return true;
             }
             if (allowUnknown)
             {
-                if (gax::UnknownResourceName.TryParse(name, out gax::UnknownResourceName unknownResourceName))
+                if (gax::UnknownResourceName.TryParse(multiPatternResourceName, out gax::UnknownResourceName unknownResourceName))
                 {
-                    result = new MultiPatternResourceNameOneOf(OneofType.Unknown, unknownResourceName);
+                    result = CreateUnknown(unknownResourceName);
                     return true;
                 }
             }
@@ -406,104 +421,78 @@ namespace Testing.UnitTests
             return false;
         }
 
-        /// <summary>
-        /// Constructs a new instance of <see cref="MultiPatternResourceNameOneOf"/> from the provided
-        /// <see cref="RootAItemName"/>.
-        /// </summary>
-        /// <param name="rootAItemName">
-        /// The <see cref="RootAItemName"/> to be contained within the returned
-        /// <see cref="MultiPatternResourceNameOneOf"/>. Must not be <c>null</c>
-        /// </param>
-        /// <returns>
-        /// A new <see cref="MultiPatternResourceNameOneOf"/>, containing <paramref name="rootAItemName"/>.
-        /// </returns>
-        public static MultiPatternResourceNameOneOf From(RootAItemName rootAItemName) =>
-            new MultiPatternResourceNameOneOf(OneofType.RootAItemName, rootAItemName);
+        private MultiPatternResourceName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null, string rootAId = null, string rootBId = null)
+        {
+            Type = type;
+            UnknownResource = unknownResourceName;
+            ItemId = itemId;
+            RootAId = rootAId;
+            RootBId = rootBId;
+        }
 
         /// <summary>
-        /// Constructs a new instance of <see cref="MultiPatternResourceNameOneOf"/> from the provided
-        /// <see cref="RootBItemName"/>.
+        /// Constructs a new instance of a <see cref="MultiPatternResourceName"/> class from the component parts of
+        /// pattern <c>root/{root_a_id}/items/{item_id}</c>
         /// </summary>
-        /// <param name="rootBItemName">
-        /// The <see cref="RootBItemName"/> to be contained within the returned
-        /// <see cref="MultiPatternResourceNameOneOf"/>. Must not be <c>null</c>
-        /// </param>
-        /// <returns>
-        /// A new <see cref="MultiPatternResourceNameOneOf"/>, containing <paramref name="rootBItemName"/>.
-        /// </returns>
-        public static MultiPatternResourceNameOneOf From(RootBItemName rootBItemName) =>
-            new MultiPatternResourceNameOneOf(OneofType.RootBItemName, rootBItemName);
-
-        private static bool IsValid(OneofType type, gax::IResourceName name)
+        /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
+        public MultiPatternResourceName(string rootAId, string itemId) : this(ResourceType.RootAItem, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
         {
-            switch (type)
-            {
-                case OneofType.Unknown: return true;
-                case OneofType.RootAItemName: return name is RootAItemName;
-                case OneofType.RootBItemName: return name is RootBItemName;
-                default: return false;
-            }
         }
 
-        public MultiPatternResourceNameOneOf(OneofType type, gax::IResourceName name)
-        {
-            Type = gax::GaxPreconditions.CheckEnumValue<OneofType>(type, nameof(type));
-            Name = gax::GaxPreconditions.CheckNotNull(name, nameof(name));
-            if (!IsValid(type, name))
-            {
-                throw new sys::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
-            }
-        }
+        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
+        public ResourceType Type { get; }
 
-        /// <summary>The <see cref="OneofType"/> of the Name contained in this instance.</summary>
-        public OneofType Type { get; }
+        /// <summary>
+        /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
+        /// unknown resource name.
+        /// </summary>
+        public gax::UnknownResourceName UnknownResource { get; }
 
-        /// <summary>The <see cref="gax::IResourceName"/> contained in this instance.</summary>
-        public gax::IResourceName Name { get; }
+        /// <summary>
+        /// The <c>Item</c> ID. May be <c>null</c>, depending on which resource name is contained by this instance.
+        /// </summary>
+        public string ItemId { get; }
 
-        private T CheckAndReturn<T>(OneofType type)
-        {
-            if (Type != type)
-            {
-                throw new sys::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
-            }
-            return (T)Name;
-        }
+        /// <summary>
+        /// The <c>RootA</c> ID. May be <c>null</c>, depending on which resource name is contained by this instance.
+        /// </summary>
+        public string RootAId { get; }
 
-        /// <summary>Get the contained <see cref="gax::IResourceName"/> as <see cref="RootAItemName"/>.</summary>
-        /// <remarks>
-        /// An <see cref="sys::InvalidOperationException"/> will be thrown is this does not contain an instance of
-        /// <see cref="RootAItemName"/>.
-        /// </remarks>
-        public RootAItemName RootAItemName => CheckAndReturn<RootAItemName>(OneofType.RootAItemName);
-
-        /// <summary>Get the contained <see cref="gax::IResourceName"/> as <see cref="RootBItemName"/>.</summary>
-        /// <remarks>
-        /// An <see cref="sys::InvalidOperationException"/> will be thrown is this does not contain an instance of
-        /// <see cref="RootBItemName"/>.
-        /// </remarks>
-        public RootBItemName RootBItemName => CheckAndReturn<RootBItemName>(OneofType.RootBItemName);
+        /// <summary>
+        /// The <c>RootB</c> ID. May be <c>null</c>, depending on which resource name is contained by this instance.
+        /// </summary>
+        public string RootBId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Oneof;
+        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Oneof;
 
         /// <inheritdoc/>
-        public override string ToString() => this.Name.ToString();
+        public override string ToString()
+        {
+            switch (Type)
+            {
+                case ResourceType.Unknown: return UnknownResource.ToString();
+                case ResourceType.RootAItem: return s_rootAItem.Expand(RootAId, ItemId);
+                case ResourceType.RootBItem: return s_rootBItem.Expand(RootBId, ItemId);
+                default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
+            }
+        }
 
         /// <inheritdoc/>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as MultiPatternResourceNameOneOf);
+        public override bool Equals(object obj) => Equals(obj as MultiPatternResourceName);
 
         /// <inheritdoc/>
-        public bool Equals(MultiPatternResourceNameOneOf other) => ToString() == other?.ToString();
+        public bool Equals(MultiPatternResourceName other) => ToString() == other?.ToString();
 
         /// <inheritdoc/>
-        public static bool operator ==(MultiPatternResourceNameOneOf a, MultiPatternResourceNameOneOf b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+        public static bool operator ==(MultiPatternResourceName a, MultiPatternResourceName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
 
         /// <inheritdoc/>
-        public static bool operator !=(MultiPatternResourceNameOneOf a, MultiPatternResourceNameOneOf b) => !(a == b);
+        public static bool operator !=(MultiPatternResourceName a, MultiPatternResourceName b) => !(a == b);
     }
 
     public partial class AResource
@@ -533,12 +522,11 @@ namespace Testing.UnitTests
     public partial class MultiPatternResource
     {
         /// <summary>
-        /// <see cref="tu::MultiPatternResourceNameOneOf"/>-typed view over the <see cref="Name"/> resource name
-        /// property.
+        /// <see cref="tu::MultiPatternResourceName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public tu::MultiPatternResourceNameOneOf MultiPatternResourceNameOneOf
+        public tu::MultiPatternResourceName MultiPatternResourceName
         {
-            get => string.IsNullOrEmpty(Name) ? null : tu::MultiPatternResourceNameOneOf.Parse(Name, true);
+            get => string.IsNullOrEmpty(Name) ? null : tu::MultiPatternResourceName.Parse(Name);
             set => Name = value?.ToString() ?? "";
         }
     }
@@ -557,7 +545,10 @@ namespace Testing.UnitTests
         /// <summary>
         /// <see cref="AResourceName"/>-typed view over the <see cref="RepeatedResourceName"/> resource name property.
         /// </summary>
-        public gax::ResourceNameList<AResourceName> RepeatedResourceNameAsAResourceNames => new gax::ResourceNameList<AResourceName>(RepeatedResourceName, s => AResourceName.Parse(s));
+        public gax::ResourceNameList<AResourceName> RepeatedResourceNameAsAResourceNames
+        {
+            get => new gax::ResourceNameList<AResourceName>(RepeatedResourceName, s => AResourceName.Parse(s));
+        }
 
         /// <summary>
         /// <see cref="gax::IResourceName"/>-typed view over the <see cref="SingleWildcardResource"/> resource name
@@ -573,22 +564,28 @@ namespace Testing.UnitTests
         /// <see cref="gax::IResourceName"/>-typed view over the <see cref="RepeatedWildcardResource"/> resource name
         /// property.
         /// </summary>
-        public gax::ResourceNameList<gax::IResourceName> RepeatedWildcardResourceAsResourceNames => new gax::ResourceNameList<gax::IResourceName>(RepeatedWildcardResource, s => gax::UnknownResourceName.Parse(s));
+        public gax::ResourceNameList<gax::IResourceName> RepeatedWildcardResourceAsResourceNames
+        {
+            get => new gax::ResourceNameList<gax::IResourceName>(RepeatedWildcardResource, s => gax::UnknownResourceName.Parse(s));
+        }
 
         /// <summary>
-        /// <see cref="MultiPatternResourceNameOneOf"/>-typed view over the <see cref="MultiPatternResourceName"/>
+        /// <see cref="tu::MultiPatternResourceName"/>-typed view over the <see cref="MultiPatternResourceName"/>
         /// resource name property.
         /// </summary>
-        public MultiPatternResourceNameOneOf MultiPatternResourceNameAsMultiPatternResourceNameOneOf
+        public tu::MultiPatternResourceName MultiPatternResourceNameAsMultiPatternResourceName
         {
-            get => string.IsNullOrEmpty(MultiPatternResourceName) ? null : MultiPatternResourceNameOneOf.Parse(MultiPatternResourceName, true);
+            get => string.IsNullOrEmpty(MultiPatternResourceName) ? null : tu::MultiPatternResourceName.Parse(MultiPatternResourceName);
             set => MultiPatternResourceName = value?.ToString() ?? "";
         }
 
         /// <summary>
-        /// <see cref="MultiPatternResourceNameOneOf"/>-typed view over the
+        /// <see cref="tu::MultiPatternResourceName"/>-typed view over the
         /// <see cref="RepeatedMultiPatternResourceName"/> resource name property.
         /// </summary>
-        public gax::ResourceNameList<MultiPatternResourceNameOneOf> RepeatedMultiPatternResourceNameAsMultiPatternResourceNameOneOfs => new gax::ResourceNameList<MultiPatternResourceNameOneOf>(RepeatedMultiPatternResourceName, s => MultiPatternResourceNameOneOf.Parse(s, true));
+        public gax::ResourceNameList<tu::MultiPatternResourceName> RepeatedMultiPatternResourceNameAsMultiPatternResourceNames
+        {
+            get => new gax::ResourceNameList<tu::MultiPatternResourceName>(RepeatedMultiPatternResourceName, s => tu::MultiPatternResourceName.Parse(s));
+        }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/UnitTests/Testing.UnitTests/UnitTestsResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/UnitTests/Testing.UnitTests/UnitTestsResourceNames.g.cs
@@ -24,12 +24,12 @@ namespace Testing.UnitTests
     public sealed partial class AResourceName : gax::IResourceName, sys::IEquatable<AResourceName>
     {
         /// <summary>The possible contents of <see cref="AResourceName"/>.</summary>
-        public enum ResourceType
+        public enum ResourceNameType
         {
             /// <summary>A resource of an unknown type.</summary>
             Unknown = 0,
 
-            /// <summary>A resource of type 'item'.</summary>
+            /// <summary>A resource name with pattern <c>items/{item_id}/parts/{part_id}</c>.</summary>
             ItemPart = 1
         }
 
@@ -41,8 +41,8 @@ namespace Testing.UnitTests
         /// A new instance of <see cref="AResourceName"/> containing the provided <paramref name="unknownResourceName"/>
         /// .
         /// </returns>
-        public static AResourceName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
-            new AResourceName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+        public static AResourceName FromUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new AResourceName(ResourceNameType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
 
         /// <summary>
         /// Creates a <see cref="AResourceName"/> with the pattern <c>items/{item_id}/parts/{part_id}</c>.
@@ -50,8 +50,8 @@ namespace Testing.UnitTests
         /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
         /// <param name="partId">The <c>Part</c> ID. Must not be <c>null</c> or empty.</param>
         /// <returns>A new instance of <see cref="AResourceName"/> constructed from the provided ids.</returns>
-        public static AResourceName CreateItemPart(string itemId, string partId) =>
-            new AResourceName(ResourceType.ItemPart, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)), partId: gax::GaxPreconditions.CheckNotNullOrEmpty(partId, nameof(partId)));
+        public static AResourceName FromItemPart(string itemId, string partId) =>
+            new AResourceName(ResourceNameType.ItemPart, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)), partId: gax::GaxPreconditions.CheckNotNullOrEmpty(partId, nameof(partId)));
 
         /// <summary>
         /// Formats the IDs into the string representation of this <see cref="AResourceName"/> with pattern
@@ -145,14 +145,14 @@ namespace Testing.UnitTests
             gax::TemplatedResourceName resourceName;
             if (s_itemPart.TryParseName(aResourceName, out resourceName))
             {
-                result = CreateItemPart(resourceName[0], resourceName[1]);
+                result = FromItemPart(resourceName[0], resourceName[1]);
                 return true;
             }
             if (allowUnknown)
             {
                 if (gax::UnknownResourceName.TryParse(aResourceName, out gax::UnknownResourceName unknownResourceName))
                 {
-                    result = CreateUnknown(unknownResourceName);
+                    result = FromUnknown(unknownResourceName);
                     return true;
                 }
             }
@@ -160,7 +160,7 @@ namespace Testing.UnitTests
             return false;
         }
 
-        private AResourceName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null, string partId = null)
+        private AResourceName(ResourceNameType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null, string partId = null)
         {
             Type = type;
             UnknownResource = unknownResourceName;
@@ -174,12 +174,12 @@ namespace Testing.UnitTests
         /// </summary>
         /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
         /// <param name="partId">The <c>Part</c> ID. Must not be <c>null</c> or empty.</param>
-        public AResourceName(string itemId, string partId) : this(ResourceType.ItemPart, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)), partId: gax::GaxPreconditions.CheckNotNullOrEmpty(partId, nameof(partId)))
+        public AResourceName(string itemId, string partId) : this(ResourceNameType.ItemPart, itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)), partId: gax::GaxPreconditions.CheckNotNullOrEmpty(partId, nameof(partId)))
         {
         }
 
-        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
-        public ResourceType Type { get; }
+        /// <summary>The <see cref="ResourceNameType"/> of the contained resource name.</summary>
+        public ResourceNameType Type { get; }
 
         /// <summary>
         /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
@@ -198,15 +198,15 @@ namespace Testing.UnitTests
         public string PartId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
+        public gax::ResourceNameKind Kind => Type == ResourceNameType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Simple;
 
         /// <inheritdoc/>
         public override string ToString()
         {
             switch (Type)
             {
-                case ResourceType.Unknown: return UnknownResource.ToString();
-                case ResourceType.ItemPart: return s_itemPart.Expand(ItemId, PartId);
+                case ResourceNameType.Unknown: return UnknownResource.ToString();
+                case ResourceNameType.ItemPart: return s_itemPart.Expand(ItemId, PartId);
                 default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
             }
         }
@@ -231,15 +231,15 @@ namespace Testing.UnitTests
     public sealed partial class MultiPatternResourceName : gax::IResourceName, sys::IEquatable<MultiPatternResourceName>
     {
         /// <summary>The possible contents of <see cref="MultiPatternResourceName"/>.</summary>
-        public enum ResourceType
+        public enum ResourceNameType
         {
             /// <summary>A resource of an unknown type.</summary>
             Unknown = 0,
 
-            /// <summary>A resource of type 'root_a'.</summary>
+            /// <summary>A resource name with pattern <c>root/{root_a_id}/items/{item_id}</c>.</summary>
             RootAItem = 1,
 
-            /// <summary>A resource of type 'root_b'.</summary>
+            /// <summary>A resource name with pattern <c>root/{root_b_id}/items/{item_id}</c>.</summary>
             RootBItem = 2
         }
 
@@ -253,8 +253,8 @@ namespace Testing.UnitTests
         /// A new instance of <see cref="MultiPatternResourceName"/> containing the provided
         /// <paramref name="unknownResourceName"/>.
         /// </returns>
-        public static MultiPatternResourceName CreateUnknown(gax::UnknownResourceName unknownResourceName) =>
-            new MultiPatternResourceName(ResourceType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
+        public static MultiPatternResourceName FromUnknown(gax::UnknownResourceName unknownResourceName) =>
+            new MultiPatternResourceName(ResourceNameType.Unknown, gax::GaxPreconditions.CheckNotNull(unknownResourceName, nameof(unknownResourceName)));
 
         /// <summary>
         /// Creates a <see cref="MultiPatternResourceName"/> with the pattern <c>root/{root_a_id}/items/{item_id}</c>.
@@ -264,8 +264,8 @@ namespace Testing.UnitTests
         /// <returns>
         /// A new instance of <see cref="MultiPatternResourceName"/> constructed from the provided ids.
         /// </returns>
-        public static MultiPatternResourceName CreateRootAItem(string rootAId, string itemId) =>
-            new MultiPatternResourceName(ResourceType.RootAItem, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+        public static MultiPatternResourceName FromRootAItem(string rootAId, string itemId) =>
+            new MultiPatternResourceName(ResourceNameType.RootAItem, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
 
         /// <summary>
         /// Creates a <see cref="MultiPatternResourceName"/> with the pattern <c>root/{root_b_id}/items/{item_id}</c>.
@@ -275,8 +275,8 @@ namespace Testing.UnitTests
         /// <returns>
         /// A new instance of <see cref="MultiPatternResourceName"/> constructed from the provided ids.
         /// </returns>
-        public static MultiPatternResourceName CreateRootBItem(string rootBId, string itemId) =>
-            new MultiPatternResourceName(ResourceType.RootBItem, rootBId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootBId, nameof(rootBId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
+        public static MultiPatternResourceName FromRootBItem(string rootBId, string itemId) =>
+            new MultiPatternResourceName(ResourceNameType.RootBItem, rootBId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootBId, nameof(rootBId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)));
 
         /// <summary>
         /// Formats the IDs into the string representation of this <see cref="MultiPatternResourceName"/> with pattern
@@ -401,19 +401,19 @@ namespace Testing.UnitTests
             gax::TemplatedResourceName resourceName;
             if (s_rootAItem.TryParseName(multiPatternResourceName, out resourceName))
             {
-                result = CreateRootAItem(resourceName[0], resourceName[1]);
+                result = FromRootAItem(resourceName[0], resourceName[1]);
                 return true;
             }
             if (s_rootBItem.TryParseName(multiPatternResourceName, out resourceName))
             {
-                result = CreateRootBItem(resourceName[0], resourceName[1]);
+                result = FromRootBItem(resourceName[0], resourceName[1]);
                 return true;
             }
             if (allowUnknown)
             {
                 if (gax::UnknownResourceName.TryParse(multiPatternResourceName, out gax::UnknownResourceName unknownResourceName))
                 {
-                    result = CreateUnknown(unknownResourceName);
+                    result = FromUnknown(unknownResourceName);
                     return true;
                 }
             }
@@ -421,7 +421,7 @@ namespace Testing.UnitTests
             return false;
         }
 
-        private MultiPatternResourceName(ResourceType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null, string rootAId = null, string rootBId = null)
+        private MultiPatternResourceName(ResourceNameType type, gax::UnknownResourceName unknownResourceName = null, string itemId = null, string rootAId = null, string rootBId = null)
         {
             Type = type;
             UnknownResource = unknownResourceName;
@@ -436,12 +436,12 @@ namespace Testing.UnitTests
         /// </summary>
         /// <param name="rootAId">The <c>RootA</c> ID. Must not be <c>null</c> or empty.</param>
         /// <param name="itemId">The <c>Item</c> ID. Must not be <c>null</c> or empty.</param>
-        public MultiPatternResourceName(string rootAId, string itemId) : this(ResourceType.RootAItem, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
+        public MultiPatternResourceName(string rootAId, string itemId) : this(ResourceNameType.RootAItem, rootAId: gax::GaxPreconditions.CheckNotNullOrEmpty(rootAId, nameof(rootAId)), itemId: gax::GaxPreconditions.CheckNotNullOrEmpty(itemId, nameof(itemId)))
         {
         }
 
-        /// <summary>The <see cref="ResourceType"/> of the contained resource name.</summary>
-        public ResourceType Type { get; }
+        /// <summary>The <see cref="ResourceNameType"/> of the contained resource name.</summary>
+        public ResourceNameType Type { get; }
 
         /// <summary>
         /// The contained <see cref="gax::UnknownResourceName"/>. Only non-<c>null</c>if this instance contains an
@@ -465,16 +465,16 @@ namespace Testing.UnitTests
         public string RootBId { get; }
 
         /// <inheritdoc/>
-        public gax::ResourceNameKind Kind => Type == ResourceType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Oneof;
+        public gax::ResourceNameKind Kind => Type == ResourceNameType.Unknown ? gax::ResourceNameKind.Unknown : gax::ResourceNameKind.Oneof;
 
         /// <inheritdoc/>
         public override string ToString()
         {
             switch (Type)
             {
-                case ResourceType.Unknown: return UnknownResource.ToString();
-                case ResourceType.RootAItem: return s_rootAItem.Expand(RootAId, ItemId);
-                case ResourceType.RootBItem: return s_rootBItem.Expand(RootBId, ItemId);
+                case ResourceNameType.Unknown: return UnknownResource.ToString();
+                case ResourceNameType.RootAItem: return s_rootAItem.Expand(RootAId, ItemId);
+                case ResourceNameType.RootBItem: return s_rootBItem.Expand(RootBId, ItemId);
                 default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
             }
         }

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.Snippets/VoidReturnClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.Snippets/VoidReturnClientSnippets.g.cs
@@ -30,7 +30,7 @@ namespace Testing.VoidReturn.Snippets
             // Initialize request argument(s)
             Request request = new Request
             {
-                ResourceName = new ResourceName("[ITEM_ID]"),
+                ResourceName = ResourceName.CreateItem("[ITEM_ID]"),
             };
             // Make the request
             voidReturnClient.VoidMethod(request);
@@ -47,7 +47,7 @@ namespace Testing.VoidReturn.Snippets
             // Initialize request argument(s)
             Request request = new Request
             {
-                ResourceName = new ResourceName("[ITEM_ID]"),
+                ResourceName = ResourceName.CreateItem("[ITEM_ID]"),
             };
             // Make the request
             await voidReturnClient.VoidMethodAsync(request);
@@ -88,7 +88,7 @@ namespace Testing.VoidReturn.Snippets
             // Create client
             VoidReturnClient voidReturnClient = VoidReturnClient.Create();
             // Initialize request argument(s)
-            ResourceName name = new ResourceName("[ITEM_ID]");
+            ResourceName name = ResourceName.CreateItem("[ITEM_ID]");
             // Make the request
             voidReturnClient.VoidMethod(name);
             // End snippet
@@ -102,7 +102,7 @@ namespace Testing.VoidReturn.Snippets
             // Create client
             VoidReturnClient voidReturnClient = await VoidReturnClient.CreateAsync();
             // Initialize request argument(s)
-            ResourceName name = new ResourceName("[ITEM_ID]");
+            ResourceName name = ResourceName.CreateItem("[ITEM_ID]");
             // Make the request
             await voidReturnClient.VoidMethodAsync(name);
             // End snippet

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.Snippets/VoidReturnClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.Snippets/VoidReturnClientSnippets.g.cs
@@ -30,7 +30,7 @@ namespace Testing.VoidReturn.Snippets
             // Initialize request argument(s)
             Request request = new Request
             {
-                ResourceName = ResourceName.CreateItem("[ITEM_ID]"),
+                ResourceName = ResourceName.FromItem("[ITEM_ID]"),
             };
             // Make the request
             voidReturnClient.VoidMethod(request);
@@ -47,7 +47,7 @@ namespace Testing.VoidReturn.Snippets
             // Initialize request argument(s)
             Request request = new Request
             {
-                ResourceName = ResourceName.CreateItem("[ITEM_ID]"),
+                ResourceName = ResourceName.FromItem("[ITEM_ID]"),
             };
             // Make the request
             await voidReturnClient.VoidMethodAsync(request);
@@ -88,7 +88,7 @@ namespace Testing.VoidReturn.Snippets
             // Create client
             VoidReturnClient voidReturnClient = VoidReturnClient.Create();
             // Initialize request argument(s)
-            ResourceName name = ResourceName.CreateItem("[ITEM_ID]");
+            ResourceName name = ResourceName.FromItem("[ITEM_ID]");
             // Make the request
             voidReturnClient.VoidMethod(name);
             // End snippet
@@ -102,7 +102,7 @@ namespace Testing.VoidReturn.Snippets
             // Create client
             VoidReturnClient voidReturnClient = await VoidReturnClient.CreateAsync();
             // Initialize request argument(s)
-            ResourceName name = ResourceName.CreateItem("[ITEM_ID]");
+            ResourceName name = ResourceName.FromItem("[ITEM_ID]");
             // Make the request
             await voidReturnClient.VoidMethodAsync(name);
             // End snippet

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.Tests/VoidReturnClientTest.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.Tests/VoidReturnClientTest.g.cs
@@ -36,7 +36,7 @@ namespace Testing.VoidReturn.Tests
             moq::Mock<VoidReturn.VoidReturnClient> mockGrpcClient = new moq::Mock<VoidReturn.VoidReturnClient>(moq::MockBehavior.Strict);
             Request request = new Request
             {
-                ResourceName = ResourceName.CreateItem("[ITEM_ID]"),
+                ResourceName = ResourceName.FromItem("[ITEM_ID]"),
             };
             wkt::Empty expectedResponse = new wkt::Empty { };
             mockGrpcClient.Setup(x => x.VoidMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
@@ -52,7 +52,7 @@ namespace Testing.VoidReturn.Tests
             moq::Mock<VoidReturn.VoidReturnClient> mockGrpcClient = new moq::Mock<VoidReturn.VoidReturnClient>(moq::MockBehavior.Strict);
             Request request = new Request
             {
-                ResourceName = ResourceName.CreateItem("[ITEM_ID]"),
+                ResourceName = ResourceName.FromItem("[ITEM_ID]"),
             };
             wkt::Empty expectedResponse = new wkt::Empty { };
             mockGrpcClient.Setup(x => x.VoidMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<wkt::Empty>(stt::Task.FromResult(expectedResponse), null, null, null, null));
@@ -69,7 +69,7 @@ namespace Testing.VoidReturn.Tests
             moq::Mock<VoidReturn.VoidReturnClient> mockGrpcClient = new moq::Mock<VoidReturn.VoidReturnClient>(moq::MockBehavior.Strict);
             Request request = new Request
             {
-                ResourceName = ResourceName.CreateItem("[ITEM_ID]"),
+                ResourceName = ResourceName.FromItem("[ITEM_ID]"),
             };
             wkt::Empty expectedResponse = new wkt::Empty { };
             mockGrpcClient.Setup(x => x.VoidMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
@@ -85,7 +85,7 @@ namespace Testing.VoidReturn.Tests
             moq::Mock<VoidReturn.VoidReturnClient> mockGrpcClient = new moq::Mock<VoidReturn.VoidReturnClient>(moq::MockBehavior.Strict);
             Request request = new Request
             {
-                ResourceName = ResourceName.CreateItem("[ITEM_ID]"),
+                ResourceName = ResourceName.FromItem("[ITEM_ID]"),
             };
             wkt::Empty expectedResponse = new wkt::Empty { };
             mockGrpcClient.Setup(x => x.VoidMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<wkt::Empty>(stt::Task.FromResult(expectedResponse), null, null, null, null));
@@ -102,7 +102,7 @@ namespace Testing.VoidReturn.Tests
             moq::Mock<VoidReturn.VoidReturnClient> mockGrpcClient = new moq::Mock<VoidReturn.VoidReturnClient>(moq::MockBehavior.Strict);
             Request request = new Request
             {
-                ResourceName = ResourceName.CreateItem("[ITEM_ID]"),
+                ResourceName = ResourceName.FromItem("[ITEM_ID]"),
             };
             wkt::Empty expectedResponse = new wkt::Empty { };
             mockGrpcClient.Setup(x => x.VoidMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
@@ -118,7 +118,7 @@ namespace Testing.VoidReturn.Tests
             moq::Mock<VoidReturn.VoidReturnClient> mockGrpcClient = new moq::Mock<VoidReturn.VoidReturnClient>(moq::MockBehavior.Strict);
             Request request = new Request
             {
-                ResourceName = ResourceName.CreateItem("[ITEM_ID]"),
+                ResourceName = ResourceName.FromItem("[ITEM_ID]"),
             };
             wkt::Empty expectedResponse = new wkt::Empty { };
             mockGrpcClient.Setup(x => x.VoidMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<wkt::Empty>(stt::Task.FromResult(expectedResponse), null, null, null, null));

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.Tests/VoidReturnClientTest.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.Tests/VoidReturnClientTest.g.cs
@@ -36,7 +36,7 @@ namespace Testing.VoidReturn.Tests
             moq::Mock<VoidReturn.VoidReturnClient> mockGrpcClient = new moq::Mock<VoidReturn.VoidReturnClient>(moq::MockBehavior.Strict);
             Request request = new Request
             {
-                ResourceName = new ResourceName("[ITEM_ID]"),
+                ResourceName = ResourceName.CreateItem("[ITEM_ID]"),
             };
             wkt::Empty expectedResponse = new wkt::Empty { };
             mockGrpcClient.Setup(x => x.VoidMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
@@ -52,7 +52,7 @@ namespace Testing.VoidReturn.Tests
             moq::Mock<VoidReturn.VoidReturnClient> mockGrpcClient = new moq::Mock<VoidReturn.VoidReturnClient>(moq::MockBehavior.Strict);
             Request request = new Request
             {
-                ResourceName = new ResourceName("[ITEM_ID]"),
+                ResourceName = ResourceName.CreateItem("[ITEM_ID]"),
             };
             wkt::Empty expectedResponse = new wkt::Empty { };
             mockGrpcClient.Setup(x => x.VoidMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<wkt::Empty>(stt::Task.FromResult(expectedResponse), null, null, null, null));
@@ -69,7 +69,7 @@ namespace Testing.VoidReturn.Tests
             moq::Mock<VoidReturn.VoidReturnClient> mockGrpcClient = new moq::Mock<VoidReturn.VoidReturnClient>(moq::MockBehavior.Strict);
             Request request = new Request
             {
-                ResourceName = new ResourceName("[ITEM_ID]"),
+                ResourceName = ResourceName.CreateItem("[ITEM_ID]"),
             };
             wkt::Empty expectedResponse = new wkt::Empty { };
             mockGrpcClient.Setup(x => x.VoidMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
@@ -85,7 +85,7 @@ namespace Testing.VoidReturn.Tests
             moq::Mock<VoidReturn.VoidReturnClient> mockGrpcClient = new moq::Mock<VoidReturn.VoidReturnClient>(moq::MockBehavior.Strict);
             Request request = new Request
             {
-                ResourceName = new ResourceName("[ITEM_ID]"),
+                ResourceName = ResourceName.CreateItem("[ITEM_ID]"),
             };
             wkt::Empty expectedResponse = new wkt::Empty { };
             mockGrpcClient.Setup(x => x.VoidMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<wkt::Empty>(stt::Task.FromResult(expectedResponse), null, null, null, null));
@@ -102,7 +102,7 @@ namespace Testing.VoidReturn.Tests
             moq::Mock<VoidReturn.VoidReturnClient> mockGrpcClient = new moq::Mock<VoidReturn.VoidReturnClient>(moq::MockBehavior.Strict);
             Request request = new Request
             {
-                ResourceName = new ResourceName("[ITEM_ID]"),
+                ResourceName = ResourceName.CreateItem("[ITEM_ID]"),
             };
             wkt::Empty expectedResponse = new wkt::Empty { };
             mockGrpcClient.Setup(x => x.VoidMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
@@ -118,7 +118,7 @@ namespace Testing.VoidReturn.Tests
             moq::Mock<VoidReturn.VoidReturnClient> mockGrpcClient = new moq::Mock<VoidReturn.VoidReturnClient>(moq::MockBehavior.Strict);
             Request request = new Request
             {
-                ResourceName = new ResourceName("[ITEM_ID]"),
+                ResourceName = ResourceName.CreateItem("[ITEM_ID]"),
             };
             wkt::Empty expectedResponse = new wkt::Empty { };
             mockGrpcClient.Setup(x => x.VoidMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<wkt::Empty>(stt::Task.FromResult(expectedResponse), null, null, null, null));

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/VoidReturnFakes.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/VoidReturnFakes.cs
@@ -26,7 +26,7 @@ namespace Testing.VoidReturn
 
     public class ResourceName
     {
-        public static ResourceName CreateItem(string item) => throw new NotImplementedException();
+        public static ResourceName FromItem(string item) => throw new NotImplementedException();
     }
 
     // gRPC fake

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/VoidReturnFakes.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/VoidReturnFakes.cs
@@ -26,7 +26,7 @@ namespace Testing.VoidReturn
 
     public class ResourceName
     {
-        public ResourceName(string name) => throw new NotImplementedException();
+        public static ResourceName CreateItem(string item) => throw new NotImplementedException();
     }
 
     // gRPC fake

--- a/Google.Api.Generator/Generation/MethodDetails.cs
+++ b/Google.Api.Generator/Generation/MethodDetails.cs
@@ -57,28 +57,16 @@ namespace Google.Api.Generator.Generation
             public Paginated(ServiceDetails svc, MethodDescriptor desc,
                 FieldDescriptor responseResourceField, int pageSizeFieldNumber, int pageTokenFieldNumber) : base(svc, desc)
             {
-                var resourceDetails = svc.Catalog.GetResourceDetailsByField(responseResourceField);
-                if (resourceDetails is null)
-                {
-                    ResourceTyp = Typ.Of(responseResourceField, forceRepeated: false);
-                }
-                else
-                {
-                    var resourceDef = resourceDetails.ResourceDefinition;
-                    if (resourceDef.Single != null && resourceDef.Multi != null)
-                    {
-                        // TODO: Figure out what to do in this situation.
-                        throw new InvalidOperationException("Cannot handle pagination when the resource type is both a single and multi resource-name.");
-                    }
-                    ResourceTyp = resourceDef.Single?.ResourceNameTyp ?? resourceDef.Multi.ContainerTyp;
-                }
+                ResourcesFieldResourceName = svc.Catalog.GetResourceDetailsByField(responseResourceField);
+                ResourceTyp = ResourcesFieldResourceName is null ?
+                    Typ.Of(responseResourceField, forceRepeated: false) :
+                    ResourcesFieldResourceName.ResourceDefinition.ResourceNameTyp;
                 ApiCallTyp = Typ.Generic(typeof(ApiCall<,>), RequestTyp, ResponseTyp);
                 SyncReturnTyp = Typ.Generic(typeof(PagedEnumerable<,>), ResponseTyp, ResourceTyp);
                 AsyncReturnTyp = Typ.Generic(typeof(PagedAsyncEnumerable<,>), ResponseTyp, ResourceTyp);
                 SyncGrpcType = Typ.Generic(typeof(GrpcPagedEnumerable<,,>), RequestTyp, ResponseTyp, ResourceTyp);
                 AsyncGrpcType = Typ.Generic(typeof(GrpcPagedAsyncEnumerable<,,>), RequestTyp, ResponseTyp, ResourceTyp);
                 ResourcesFieldName = responseResourceField.CSharpPropertyName();
-                ResourcesFieldResourceName = svc.Catalog.GetResourceDetailsByField(responseResourceField);
                 PageSizeFieldNumber = pageSizeFieldNumber;
                 PageTokenFieldNumber = pageTokenFieldNumber;
             }

--- a/Google.Api.Generator/Generation/ServiceCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceCodeGenerator.cs
@@ -72,7 +72,7 @@ namespace Google.Api.Generator.Generation
                     using (ctx.InClass(cls))
                     {
                         var resourceField = method.ResourcesFieldResourceName;
-                        var propertyName = resourceField?.SingleResourcePropertyName ?? resourceField?.MultiResourcePropertyName ?? method.ResourcesFieldName;
+                        var propertyName = resourceField?.ResourcePropertyName ?? method.ResourcesFieldName;
                         var genericGetEnumerator = Method(Public, ctx.Type(Typ.Generic(typeof(IEnumerator<>), method.ResourceTyp)), "GetEnumerator")()
                             .WithBody(Property(Public, ctx.TypeDontCare, propertyName).Call(nameof(IEnumerable<int>.GetEnumerator))())
                             .WithXmlDoc(XmlDoc.Summary("Returns an enumerator that iterates through the resources in this response."));

--- a/Google.Api.Generator/Generation/ServiceMethodGenerator.Signatures.cs
+++ b/Google.Api.Generator/Generation/ServiceMethodGenerator.Signatures.cs
@@ -39,9 +39,8 @@ namespace Google.Api.Generator.Generation
                 private class ParameterInfo
                 {
                     public ParameterInfo(IReadOnlyList<FieldDescriptor> fieldDescs, ParameterSyntax parameter, object initExpr,
-                        ResourceDetails.Field resourceField, bool isMultiResource, DocumentationCommentTriviaSyntax xmlDoc) =>
-                        (FieldDescs, Parameter, InitExpr, ResourceField, IsMultiResource, XmlDoc) =
-                        (fieldDescs, parameter, initExpr, resourceField, isMultiResource, xmlDoc);
+                        ResourceDetails.Field resourceField, DocumentationCommentTriviaSyntax xmlDoc) =>
+                        (FieldDescs, Parameter, InitExpr, ResourceField, XmlDoc) = (fieldDescs, parameter, initExpr, resourceField, xmlDoc);
                     /// <summary>Nesting fields; null if none.</summary>
                     public IReadOnlyList<FieldDescriptor> FieldDescs { get; }
                     public ParameterSyntax Parameter { get; }
@@ -49,7 +48,6 @@ namespace Google.Api.Generator.Generation
                     /// <summary>Not null if a resource-name field.</summary>
                     public ResourceDetails.Field ResourceField { get; }
                     /// <summary>If a resource-name field, is this a single or multi resource.</summary>
-                    public bool IsMultiResource { get; }
                     public DocumentationCommentTriviaSyntax XmlDoc { get; }
                 }
 
@@ -61,7 +59,7 @@ namespace Google.Api.Generator.Generation
                 private SourceFileContext Ctx => _def.Ctx;
                 private MethodDetails MethodDetails => _def.MethodDetails;
 
-                private object InitExpr(MethodDetails.Signature.Field field, ParameterSyntax param, bool treatAsResource = false, bool isMultiResource = false)
+                private object InitExpr(MethodDetails.Signature.Field field, ParameterSyntax param, bool treatAsResource = false)
                 {
                     // Type                  | Single optional | Single required | Repeated optional | Repeated required
                     // ----------------------|-----------------|-----------------|-------------------|------------------
@@ -75,17 +73,10 @@ namespace Google.Api.Generator.Generation
                     {
                         if (treatAsResource)
                         {
-                            if (isMultiResource)
-                            {
-                                throw new NotImplementedException(); // TODO: Resource sets.
-                            }
-                            else
-                            {
-                                return CollectionInitializer(field.IsRequired ?
-                                    Ctx.Type(typeof(GaxPreconditions)).Call(nameof(GaxPreconditions.CheckNotNull))(param, Nameof(param)) :
-                                    param.NullCoalesce(Ctx.Type(typeof(Enumerable)).Call(
-                                        nameof(Enumerable.Empty), Ctx.Type(field.FieldResource.ResourceDefinition.Single.ResourceNameTyp))()));
-                            }
+                            return CollectionInitializer(field.IsRequired ?
+                                Ctx.Type(typeof(GaxPreconditions)).Call(nameof(GaxPreconditions.CheckNotNull))(param, Nameof(param)) :
+                                param.NullCoalesce(Ctx.Type(typeof(Enumerable)).Call(
+                                    nameof(Enumerable.Empty), Ctx.Type(field.FieldResource.ResourceDefinition.ResourceNameTyp))()));
                         }
                         else
                         {
@@ -98,18 +89,9 @@ namespace Google.Api.Generator.Generation
                     {
                         if (treatAsResource)
                         {
-                            if (isMultiResource)
-                            {
-                                return field.IsRequired ?
-                                    Ctx.Type(typeof(GaxPreconditions)).Call(nameof(GaxPreconditions.CheckNotNull))(param, Nameof(param)) :
-                                    (object)param;
-                            }
-                            else
-                            {
-                                return field.IsRequired ?
-                                    Ctx.Type(typeof(GaxPreconditions)).Call(nameof(GaxPreconditions.CheckNotNull))(param, Nameof(param)) :
-                                    (object)param;
-                            }
+                            return field.IsRequired ?
+                                Ctx.Type(typeof(GaxPreconditions)).Call(nameof(GaxPreconditions.CheckNotNull))(param, Nameof(param)) :
+                                (object)param;
                         }
                         else if (field.Typ.IsPrimitive || field.Typ.IsEnum)
                         {
@@ -149,7 +131,7 @@ namespace Google.Api.Generator.Generation
                     var parameter = Parameter(Ctx.Type(field.Typ), field.ParameterName);
                     var initExpr = InitExpr(field, parameter);
                     var xmlDoc = XmlDoc.ParamPreFormatted(parameter, field.DocLines);
-                    return new ParameterInfo(field.Descs, parameter, initExpr, null, false, xmlDoc);
+                    return new ParameterInfo(field.Descs, parameter, initExpr, null, xmlDoc);
                 });
 
                 private IEnumerable<ParameterInfo> PaginatedParameters(IEnumerable<ParameterInfo> coreParameters)
@@ -163,8 +145,8 @@ namespace Google.Api.Generator.Generation
                     var pageSizeXmlDoc = XmlDoc.Param(pageSizeParameter,
                         "The size of page to request. The response will not be larger than this, but may be smaller. A value of ", null, " or ", 0, " uses a server-defined page size.");
                     return coreParameters
-                        .Append(new ParameterInfo(null, pageTokenParameter, pageTokenInit, null, false, pageTokenXmlDoc))
-                        .Append(new ParameterInfo(null, pageSizeParameter, pageSizeInit, null, false, pageSizeXmlDoc));
+                        .Append(new ParameterInfo(null, pageTokenParameter, pageTokenInit, null, pageTokenXmlDoc))
+                        .Append(new ParameterInfo(null, pageSizeParameter, pageSizeInit, null, pageSizeXmlDoc));
                 }
 
                 private MethodDeclarationSyntax AbstractRequestMethod(bool sync, bool callSettings, IEnumerable<ParameterInfo> parameters, DocumentationCommentTriviaSyntax returnsXmlDoc = null)
@@ -194,8 +176,7 @@ namespace Google.Api.Generator.Generation
                                     foreach (var param in f.OrderBy(x => x.FieldDescs?.Last().Index ?? int.MaxValue))
                                     {
                                         yield return (param.InitExpr as ObjectInitExpr) ??
-                                            new ObjectInitExpr((param.IsMultiResource ? param.ResourceField?.MultiResourcePropertyName : param.ResourceField?.SingleResourcePropertyName) ??
-                                                param.FieldDescs.Last().CSharpPropertyName(), param.InitExpr);
+                                            new ObjectInitExpr(param.ResourceField?.ResourcePropertyName ??  param.FieldDescs.Last().CSharpPropertyName(), param.InitExpr);
                                     }
                                 }
                                 else
@@ -235,39 +216,15 @@ namespace Google.Api.Generator.Generation
                         {
                             yield break;
                         }
-                        var bothCount = fields.Count(f => f.FieldResource?.ResourceDefinition.Single != null && f.FieldResource?.ResourceDefinition.Multi != null);
-                        if (bothCount > 4)
+                        var parameters = fields.Select(field =>
                         {
-                            throw new InvalidOperationException($"Cannot generate >16 overloads for single/multi method signature: '{signature._def.MethodDetails.SyncMethodName}'");
-                        }
-                        var overloadCount = 1 << bothCount;
-                        for (int i = 0; i < overloadCount; i++)
-                        {
-                            var parameters = new List<ParameterInfo>();
-                            int mask = 1;
-                            foreach (var field in fields)
-                            {
-                                var fieldResource = field.FieldResource;
-                                var oneDef = fieldResource?.ResourceDefinition.Single;
-                                var multiDef = fieldResource?.ResourceDefinition.Multi;
-                                bool isMulti = false;
-                                if (oneDef != null && multiDef != null)
-                                {
-                                    isMulti = (i & mask) != 0;
-                                    mask <<= 1;
-                                }
-                                else
-                                {
-                                    isMulti = multiDef != null;
-                                }
-                                var parameter = Parameter(ctx.Type(MaybeRepeated(isMulti ? multiDef.ContainerTyp : oneDef?.ResourceNameTyp) ?? field.Typ), field.ParameterName);
-                                var initExpr = signature.InitExpr(field, parameter, fieldResource != null, isMulti);
-                                var xmlDoc = XmlDoc.ParamPreFormatted(parameter, field.DocLines);
-                                parameters.Add(new ParameterInfo(field.Descs, parameter, initExpr, field.FieldResource, isMulti, xmlDoc));
-                                Typ MaybeRepeated(Typ typ) => typ == null ? null : field.IsRepeated ? Typ.Generic(typeof(IEnumerable<>), typ) : typ;
-                            }
-                            yield return new ResourceName(signature, parameters);
-                        }
+                            var parameter = Parameter(ctx.Type(MaybeRepeated(field.FieldResource?.ResourceDefinition.ResourceNameTyp) ?? field.Typ), field.ParameterName);
+                            Typ MaybeRepeated(Typ typ) => typ == null ? null : field.IsRepeated ? Typ.Generic(typeof(IEnumerable<>), typ) : typ;
+                            var initExpr = signature.InitExpr(field, parameter, field.FieldResource is object);
+                            var xmlDoc = XmlDoc.ParamPreFormatted(parameter, field.DocLines);
+                            return new ParameterInfo(field.Descs, parameter, initExpr, field.FieldResource, xmlDoc);
+                        }).ToList();
+                        yield return new ResourceName(signature, parameters);
                     }
 
                     private ResourceName(Signature signature, IEnumerable<ParameterInfo> parameters)

--- a/Google.Api.Generator/Generation/SnippetCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/SnippetCodeGenerator.cs
@@ -174,7 +174,7 @@ namespace Google.Api.Generator.Generation
                     {
                         @default = def.IsWildcard ?
                             (object)New(Ctx.Type<UnknownResourceName>())("a/wildcard/resource") :
-                            Ctx.Type(def.ResourceNameTyp).Call($"Create{string.Join("", def.Patterns[0].Template.ParameterNames.Select(x => x.RemoveSuffix("_id").ToUpperCamelCase()))}")
+                            Ctx.Type(def.ResourceNameTyp).Call($"From{string.Join("", def.Patterns[0].Template.ParameterNames.Select(x => x.RemoveSuffix("_id").ToUpperCamelCase()))}")
                                 (def.Patterns[0].Template.ParameterNames.Select(x => $"[{x.ToUpperInvariant()}]"));
                     }
                     return fieldDesc.IsRepeated ? Collection(@default, resourceNameAsString ? null : def.ResourceNameTyp) : @default;

--- a/Google.Api.Generator/Generation/UnitTestCodeGeneration.cs
+++ b/Google.Api.Generator/Generation/UnitTestCodeGeneration.cs
@@ -126,7 +126,7 @@ namespace Google.Api.Generator.Generation
                     {
                         value = def.IsWildcard ?
                             (object)New(Ctx.Type<UnknownResourceName>())("a/wildcard/resource") :
-                            Ctx.Type(def.ResourceNameTyp).Call($"Create{string.Join("", def.Patterns[0].Template.ParameterNames.Select(x => x.RemoveSuffix("_id").ToUpperCamelCase()))}")
+                            Ctx.Type(def.ResourceNameTyp).Call($"From{string.Join("", def.Patterns[0].Template.ParameterNames.Select(x => x.RemoveSuffix("_id").ToUpperCamelCase()))}")
                                 (def.Patterns[0].Template.ParameterNames.Select(x => $"[{x.ToUpperInvariant()}]"));
                     }
                     return fieldDesc.IsRepeated ? CollectionInitializer(value) : value;

--- a/Google.Api.Generator/ProtoUtils/ProtoCatalog.cs
+++ b/Google.Api.Generator/ProtoUtils/ProtoCatalog.cs
@@ -43,10 +43,7 @@ namespace Google.Api.Generator.ProtoUtils
             var resourcesByUrt = _resourcesByFileName.Values.SelectMany(x => x).ToDictionary(x => x.UnifiedResourceTypeName);
             var resourcesByPatterns = _resourcesByFileName.Values.SelectMany(x => x).Select(def =>
                 {
-                    // If it's a single & multi, only use the multi. The single is legacy.
-                    var patterns = def.Multi != null ?
-                          def.Multi.Defs.Where(y => !y.IsWildcard).Select(y => y.Pattern).ToImmutableHashSet() :
-                          !def.Single.IsWildcard ? ImmutableHashSet.Create(def.Single.Pattern) : ImmutableHashSet<string>.Empty;
+                    var patterns = def.IsWildcard ? ImmutableHashSet<string>.Empty : def.Patterns.Select(x => x.PatternString).ToImmutableHashSet();
                     return (patterns, def);
                 })
                 .Where(x => !x.patterns.IsEmpty)

--- a/Google.Api.Generator/ProtoUtils/ResourceDetails.cs
+++ b/Google.Api.Generator/ProtoUtils/ResourceDetails.cs
@@ -26,57 +26,50 @@ namespace Google.Api.Generator.ProtoUtils
     {
         public class Definition
         {
-            public class SingleDef
+            public class Pattern
             {
-                public static SingleDef Local(string ns, string shortName, string pattern) =>
-                    pattern == "*" ?
-                        new SingleDef(Typ.Of<IResourceName>(), pattern, null, true, false) :
-                        new SingleDef(Typ.Manual(ns, $"{shortName}Name"), pattern, new PathTemplate(pattern), false, false);
+                public Pattern(string pattern) => (PatternString, Template) = (pattern, new PathTemplate(pattern));
 
-                public static SingleDef Common(string ns, string name, string pattern) =>
-                    new SingleDef(Typ.Manual(ns, name), pattern, new PathTemplate(pattern), false, true);
-
-                private SingleDef(Typ resourceNameTyp, string pattern, PathTemplate template, bool isWildcard, bool isCommon) =>
-                    (ResourceNameTyp, Pattern, Template, IsWildcard, IsCommon) = (resourceNameTyp, pattern, template, isWildcard, isCommon);
-                public Typ ResourceNameTyp { get; }
-                public string Pattern { get; }
+                public string PatternString { get; }
                 public PathTemplate Template { get; }
-                public bool IsWildcard { get; }
-                public bool IsCommon { get; }
             }
 
-            public class MultiDef
+            public static Definition UnknownResource { get; } = new Definition();
+
+            // Ctor for wildcard only.
+            private Definition() => ResourceNameTyp = Typ.Of<IResourceName>();
+
+            public Definition(FileDescriptor fileDesc, MessageDescriptor msgDesc, string type, string nameField, CommonResource common, IEnumerable<string> patterns)
             {
-                public MultiDef(string ns, string shortName, IEnumerable<SingleDef> oneDefs)
+                MsgDesc = msgDesc;
+                FileName = fileDesc.Name;
+                UnifiedResourceTypeName = type;
+                var typeNameParts = type.Split('/');
+                if (typeNameParts.Length != 2)
                 {
-                    ContainerTyp = Typ.Manual(ns, $"{shortName}NameOneOf");
-                    Defs = oneDefs.ToList();
+                    throw new InvalidOperationException($"Invalid unified resource name: '{type}' used in message '{msgDesc?.Name}'");
                 }
-                public Typ ContainerTyp { get; }
-                public IReadOnlyList<SingleDef> Defs { get; }
-            }
-
-            public static Definition UnknownResource { get; } = new Definition(null, null, "*", null, SingleDef.Local(null, null, "*"), null);
-
-            public Definition(MessageDescriptor msgDesc, string fileName, string type, string nameField, SingleDef single, MultiDef multi)
-            {
-                if (type != "*")
+                ShortName = typeNameParts[1];
+                FieldName = ShortName.ToLowerCamelCase();
+                NameField = string.IsNullOrEmpty(nameField) ? "name" : nameField;
+                DocName = ShortName;
+                if (!patterns.All(x => x == "*"))
                 {
-                    MsgDesc = msgDesc;
-                    FileName = fileName;
-                    UnifiedResourceTypeName = type;
-                    var typeNameParts = type.Split('/');
-                    if (typeNameParts.Length != 2)
+                    // Not a wildcard.
+                    if (patterns.Any(x => x == "*"))
                     {
-                        throw new InvalidOperationException($"Invalid unified resource name: '{type}' used in message '{msgDesc?.Name}'");
+                        throw new InvalidOperationException("A wildcard pattern must be the only pattern in a resource.");
                     }
-                    ShortName = typeNameParts[1];
-                    FieldName = ShortName.ToLowerCamelCase();
-                    NameField = string.IsNullOrEmpty(nameField) ? "name" : nameField;
-                    DocName = ShortName;
+                    Patterns = patterns.Select(x => new Pattern(x)).ToList();
+                    ResourceNameTyp = common == null ?
+                        Typ.Manual(fileDesc.CSharpNamespace(), $"{ShortName}Name") :
+                        Typ.Manual(common.CsharpNamespace, common.CsharpClassName);
                 }
-                Single = single;
-                Multi = multi;
+                else
+                {
+                    // Wildcard resource.
+                    ResourceNameTyp = Typ.Of<IResourceName>();
+                }
             }
 
             public MessageDescriptor MsgDesc { get; }
@@ -96,14 +89,13 @@ namespace Google.Api.Generator.ProtoUtils
             /// <summary>The name of this resource, as used in XmlDoc.</summary>
             public string DocName { get; }
 
-            /// <summary>Definition of resource that is not a multi. Null if only a multi.</summary>
-            public SingleDef Single { get; }
+            public bool IsCommon { get; }
 
-            /// <summary>Definition of resource that is a multi. Null if not a multi.</summary>
-            public MultiDef Multi { get; }
+            public IReadOnlyList<Pattern> Patterns { get; }
 
-            /// <summary>Is this a common definition? I.e. it's already defined elsewhere.</summary>
-            public bool IsCommon => Single?.IsCommon ?? false;
+            public bool IsWildcard => Patterns == null;
+
+            public Typ ResourceNameTyp { get; }
         }
 
         /// <summary>
@@ -115,33 +107,25 @@ namespace Google.Api.Generator.ProtoUtils
             {
                 UnderlyingPropertyName = fieldDesc.CSharpPropertyName();
                 ResourceDefinition = resourceDef;
-                SingleResourcePropertyName = resourceDef.Single is null ? null : MakePropertyName(resourceDef.Single.ResourceNameTyp.Name, resourceDef.Single.IsWildcard);
-                MultiResourcePropertyName = resourceDef.Multi is null ? null : MakePropertyName(resourceDef.Multi.ContainerTyp.Name, false);
 
-                string MakePropertyName(string typName, bool isWildcard)
-                {
-                    // This naming logic is copied directly from the Java generator.
-                    // TODO: Make sure it's correct for all combinations - I'm not sure it is!
-                    var requireIdentifier = !((fieldDesc.IsRepeated && fieldDesc.Name.ToLowerInvariant() == "names") ||
-                        (!fieldDesc.IsRepeated && fieldDesc.Name.ToLowerInvariant() == "name"));
-                    var requireAs = requireIdentifier || isWildcard;
-                    var requirePlural = fieldDesc.IsRepeated;
-                    var name = requireIdentifier ? UnderlyingPropertyName : "";
-                    name += requireAs ? "As" : "";
-                    name += isWildcard ? "ResourceName" : typName;
-                    name += requirePlural ? "s" : "";
-                    return name;
-                }
+                // This naming logic is copied directly from the Java generator.
+                // TODO: Make sure it's correct for all combinations - I'm not sure it is!
+                var requireIdentifier = !((fieldDesc.IsRepeated && fieldDesc.Name.ToLowerInvariant() == "names") ||
+                    (!fieldDesc.IsRepeated && fieldDesc.Name.ToLowerInvariant() == "name"));
+                var requireAs = requireIdentifier || resourceDef.IsWildcard;
+                var requirePlural = fieldDesc.IsRepeated;
+                var name = requireIdentifier ? UnderlyingPropertyName : "";
+                name += requireAs ? "As" : "";
+                name += resourceDef.IsWildcard ? "ResourceName" : resourceDef.ResourceNameTyp.Name;
+                name += requirePlural ? "s" : "";
+                ResourcePropertyName = name;
             }
 
             /// <summary>The C# name of the string-typed property underlying this resource.</summary>
             public string UnderlyingPropertyName { get; }
 
-            /// <summary>The C# name of the single-pattern resource property.</summary>
-            public string SingleResourcePropertyName { get; }
-
-            /// <summary>The C# name of the multi-pattern resource property.</summary>
-            public string MultiResourcePropertyName { get; }
+            /// <summary>The C# name of the resource property.</summary>
+            public string ResourcePropertyName { get; }
 
             /// <summary>The resource definition for this field.</summary>
             public Definition ResourceDefinition { get; }
@@ -151,18 +135,6 @@ namespace Google.Api.Generator.ProtoUtils
         {
             var commonsByType = commonResourcesConfigs?.SelectMany(x => x.CommonResources_).ToImmutableDictionary(x => x.Type) ??
                 ImmutableDictionary<string, CommonResource>.Empty;
-            // Singles:
-            // Compatibility problems: none
-            //
-            // Multi: If pattern already exists, use it; otherwise create new single-def.
-            //        Create name as concatenation of all ID parts, without "Id" suffixes.
-            // Compatibility problems: Adding a new resource with the same pattern as one of a multi-pattern.
-            //
-            // Child: Find all children that need parents generating.
-            //        Single/Container-name generated as "{ShortName}Parent"; unless a single already exists with same pattern.
-            //        Multi-def parts constructed as in normal multis.
-            // Compatibility problems: Adding a new resource with the same pattern as a single-pattern parent.
-            //                         Adding a new resource with the same pattern as one of a multi-pattern parent.
             // TODO: Support new (Sept 2019) `name_descriptor` way of specifying resource-names.
             var msgsFromProtoMsgs = descs
                 .SelectMany(fileDesc => fileDesc.MessageTypes.Select(msgDesc =>
@@ -175,51 +147,11 @@ namespace Google.Api.Generator.ProtoUtils
                         resDesc0 : Enumerable.Empty<ResourceDescriptor>())
                             .Select(resDesc => (fileDesc, msgDesc: (MessageDescriptor)null, resDesc, shortName: GetShortName(resDesc))));
             var msgs = msgsFromProtoMsgs.Concat(msgsFromFileAnnotation).ToImmutableList();
-            // Load Singles.
-            var singlesByType = msgs.Where(x => HasSingle(x.resDesc))
-                .ToImmutableDictionary(x => x.resDesc.Type, x =>
-                {
-                    var hasCommon = commonsByType.TryGetValue(x.resDesc.Type, out var common);
-                    var single = hasCommon ?
-                        Definition.SingleDef.Common(common.CsharpNamespace, common.CsharpClassName, x.resDesc.Pattern[0]) :
-                        Definition.SingleDef.Local(x.fileDesc.CSharpNamespace(), x.shortName, x.resDesc.Pattern[0]);
-                    return (x.resDesc, single);
-                });
-            var singlesByPattern = singlesByType.Values.ToImmutableDictionary(x => x.single.Pattern);
-            // Load Multis.
-            // TODO: Consider how common resource-names and multi-defs interact.
-            var multisByType = msgs.Where(x => HasMulti(x.resDesc)).Select(msg =>
-            {
-                var innerDefs = msg.resDesc.Pattern.Select(pattern =>
-                {
-                    if (singlesByPattern.TryGetValue(pattern, out var def))
-                    {
-                        return def.single;
-                    }
-                    var shortName = string.Join("", new PathTemplate(pattern).ParameterNames.Select(x => x.ToUpperCamelCase().RemoveSuffix("Id")));
-                    return Definition.SingleDef.Local(msg.fileDesc.CSharpNamespace(), shortName, pattern);
-                }).ToList();
-                var multi = new Definition.MultiDef(msg.fileDesc.CSharpNamespace(), msg.shortName, innerDefs);
-                return (msg.resDesc, multi);
-            }).ToImmutableDictionary(x => x.resDesc.Type);
-            // Load Parents.
-            // TODO
-
-            // Build return value.
-            var fileNamesByType = msgs.ToImmutableDictionary(x => x.resDesc.Type, x => x.fileDesc.Name);
             return msgs.Select(x =>
             {
-                var single = singlesByType.GetValueOrDefault(x.resDesc.Type).single;
-                var multi = multisByType.GetValueOrDefault(x.resDesc.Type).multi;
-                return new Definition(x.msgDesc, fileNamesByType[x.resDesc.Type], x.resDesc.Type, x.resDesc.NameField, single, multi);
+                commonsByType.TryGetValue(x.resDesc.Type, out var common);
+                return new Definition(x.fileDesc, x.msgDesc, x.resDesc.Type, x.resDesc.NameField, common, x.resDesc.Pattern);
             }).ToList();
-
-            bool HasSingle(ResourceDescriptor resDesc) =>
-                (resDesc.History & ResourceDescriptor.Types.History.FutureMultiPattern) == 0 &&
-                    (resDesc.Pattern.Count == 1 || (resDesc.History & ResourceDescriptor.Types.History.OriginallySinglePattern) != 0);
-
-            bool HasMulti(ResourceDescriptor resDesc) =>
-                resDesc.Pattern.Count > 1 || (resDesc.History & ResourceDescriptor.Types.History.FutureMultiPattern) != 0;
 
             string GetShortName(ResourceDescriptor resDesc)
             {
@@ -268,12 +200,11 @@ namespace Google.Api.Generator.ProtoUtils
                 {
                     throw new InvalidOperationException($"No resource type with child name: '{resourceRef.ChildType}' for field {msgDesc.Name}.{fieldDesc.Name}");
                 }
-                var childDefs = childDef.Multi != null ? childDef.Multi.Defs : new[] { childDef.Single };
-                if (childDefs.Any(x => x.IsWildcard))
+                if (childDef.IsWildcard)
                 {
                     throw new InvalidOperationException("Cannot refer to the child-type of a resource with a wildcard pattern");
                 }
-                var parentPatterns = childDefs.Select(x => ParentPattern(x.Pattern)).ToImmutableHashSet();
+                var parentPatterns = childDef.Patterns.Select(x => x.PatternString).ToImmutableHashSet();
                 if (resourcesByPatterns.TryGetValue(parentPatterns, out var parentDef))
                 {
                     // Return existing resource; no auto-generated required.
@@ -285,17 +216,6 @@ namespace Google.Api.Generator.ProtoUtils
                     "Cannot refer to the child-type of a resource if the child pattern is not already defined in a resource.");
             }
             throw new InvalidOperationException("type or child_type must be set.");
-
-            string ParentPattern(string pattern)
-            {
-                var lastIndex = pattern.LastIndexOf('}');
-                var last2Index = pattern.LastIndexOf('}', startIndex: Math.Max(lastIndex - 1, 0));
-                if (lastIndex < 0 || last2Index < 0)
-                {
-                    throw new InvalidOperationException("Cannot create the parent of a single-piece resource name.");
-                }
-                return pattern.Substring(0, last2Index + 1);
-            }
         }
     }
 }

--- a/Google.Api.Generator/RoslynUtils/ArgModifier.cs
+++ b/Google.Api.Generator/RoslynUtils/ArgModifier.cs
@@ -19,6 +19,7 @@ namespace Google.Api.Generator.RoslynUtils
         public enum Type
         {
             Ref,
+            Out,
         }
 
         public ArgModifier(Type type, object arg) => (ModType, Arg) = (type, arg);

--- a/Google.Api.Generator/RoslynUtils/RoslynConverters.cs
+++ b/Google.Api.Generator/RoslynUtils/RoslynConverters.cs
@@ -87,6 +87,9 @@ namespace Google.Api.Generator.RoslynUtils
                     case ArgModifier.Type.Ref:
                         kind = SyntaxKind.RefKeyword;
                         break;
+                    case ArgModifier.Type.Out:
+                        kind = SyntaxKind.OutKeyword;
+                        break;
                     default:
                         throw new InvalidOperationException($"Cannot convert modtype: {argMod.ModType}");
                 }
@@ -174,9 +177,13 @@ namespace Google.Api.Generator.RoslynUtils
                 case MethodDeclarationSyntax v:
                     name = v.Identifier;
                     break;
+                case EnumMemberDeclarationSyntax v:
+                    name = v.Identifier;
+                    break;
                 default:
                     throw new NotSupportedException($"Cannot handle ToSimpleName({o.GetType()})");
             }
+            name = name.WithoutTrivia();
             return genericArgs.Any() ?
                 GenericName(name, TypeArgumentList(SeparatedList(genericArgs))) :
                 (SimpleNameSyntax)IdentifierName(name);

--- a/Google.Api.Generator/RoslynUtils/RoslynExtensions.cs
+++ b/Google.Api.Generator/RoslynUtils/RoslynExtensions.cs
@@ -233,12 +233,14 @@ namespace Google.Api.Generator.RoslynUtils
         public static BinaryExpressionSyntax Equality(this ParameterSyntax lhs, object rhs) =>
             BinaryExpression(SyntaxKind.EqualsExpression, IdentifierName(lhs.Identifier), ToExpression(rhs));
 
+        public static ExpressionSyntax Equality(this PropertyDeclarationSyntax lhs, object rhs) =>
+            BinaryExpression(SyntaxKind.EqualsExpression, ToExpression(lhs), ToExpression(rhs));
+
         public static BinaryExpressionSyntax Or(this ExpressionSyntax lhs, object rhs) =>
             BinaryExpression(SyntaxKind.LogicalOrExpression, lhs, ToExpression(rhs));
 
         public static ParameterSyntax Ref(this ParameterSyntax parameter) => parameter.WithModifiers(TokenList(Token(SyntaxKind.RefKeyword)));
         public static ParameterSyntax Out(this ParameterSyntax parameter) => parameter.WithModifiers(TokenList(Token(SyntaxKind.OutKeyword)));
-        public static ParameterSyntax OutVar(this ParameterSyntax parameter) => parameter.WithModifiers(TokenList(Token(SyntaxKind.OutKeyword), Token(SyntaxKind.TypeVarKeyword)));
 
         public static MethodDeclarationSyntax AddGenericConstraint(this MethodDeclarationSyntax method, Typ.GenericParameter genericParam, params TypeSyntax[] constraints)
         {

--- a/Google.Api.Generator/Utils/Typ.cs
+++ b/Google.Api.Generator/Utils/Typ.cs
@@ -22,8 +22,6 @@ using System.Linq;
 
 namespace Google.Api.Generator.Utils
 {
-    // TODO: If this name causes too much confusion change it to something
-    // more descriptive, possibly "ClrType".
     /// <summary>
     /// Abstraction of a .NET type.
     /// The name "Typ" is delibrately concise as this type is used extensively


### PR DESCRIPTION
Sorry about this size of this.
Please do check at least a few of generated resource-name classes in the tests, as these are the end result of the change.

And I'm aware some of the resource-name tests are now superfluous because they're now effectively testing the same thing, I'll tidy them up in a later PR.