### PR TITLE
Apply pagination named arguments corner case to resource name overloads

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Paginated.proto
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Paginated.proto
@@ -21,6 +21,8 @@ service Paginated {
   // in both the request and the response.
   rpc ResourcedMethod(ResourceRequest) returns(ResourceResponse) {
     option (google.api.method_signature) = "name";
+    // The same corner case as above, but where the first parameter is a resource name.
+    option (google.api.method_signature) = "name,extra_string";
   }
 }
 
@@ -51,6 +53,7 @@ message ResourceRequest {
   string name = 1 [(google.api.resource_reference).type = "paginated.example.com/Resource"];
   int32 page_size = 2;
   string page_token = 3;
+  string extra_string = 4;
 }
 
 message ResourceResponse {

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/PaginatedFakes.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/PaginatedFakes.cs
@@ -46,6 +46,7 @@ namespace Testing.Paginated
         public string Name { get; set; }
         public int PageSize { get; set; }
         public string PageToken { get; set; }
+        public string ExtraString { get; set; }
     }
 
     public partial class ResourceResponse : ProtoMsgFake<ResourceResponse>

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.Snippets/PaginatedClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.Snippets/PaginatedClientSnippets.g.cs
@@ -400,6 +400,7 @@ namespace Testing.Paginated.Snippets
             ResourceRequest request = new ResourceRequest
             {
                 ResourceName = ResourceName.FromItem("[ITEM_ID]"),
+                ExtraString = "",
             };
             // Make the request
             PagedEnumerable<ResourceResponse, ResourceName> response = paginatedClient.ResourcedMethod(request);
@@ -448,6 +449,7 @@ namespace Testing.Paginated.Snippets
             ResourceRequest request = new ResourceRequest
             {
                 ResourceName = ResourceName.FromItem("[ITEM_ID]"),
+                ExtraString = "",
             };
             // Make the request
             PagedAsyncEnumerable<ResourceResponse, ResourceName> response = paginatedClient.ResourcedMethodAsync(request);
@@ -487,7 +489,7 @@ namespace Testing.Paginated.Snippets
         }
 
         /// <summary>Snippet for ResourcedMethod</summary>
-        public void ResourcedMethod()
+        public void ResourcedMethod1()
         {
             // Snippet: ResourcedMethod(string, string, int?, CallSettings)
             // Create client
@@ -532,7 +534,7 @@ namespace Testing.Paginated.Snippets
         }
 
         /// <summary>Snippet for ResourcedMethod</summary>
-        public async Task ResourcedMethodAsync()
+        public async Task ResourcedMethod1Async()
         {
             // Snippet: ResourcedMethodAsync(string, string, int?, CallSettings)
             // Create client
@@ -577,7 +579,7 @@ namespace Testing.Paginated.Snippets
         }
 
         /// <summary>Snippet for ResourcedMethod</summary>
-        public void ResourcedMethod_ResourceNames()
+        public void ResourcedMethod1_ResourceNames()
         {
             // Snippet: ResourcedMethod(ResourceName, string, int?, CallSettings)
             // Create client
@@ -622,7 +624,7 @@ namespace Testing.Paginated.Snippets
         }
 
         /// <summary>Snippet for ResourcedMethod</summary>
-        public async Task ResourcedMethodAsync_ResourceNames()
+        public async Task ResourcedMethod1Async_ResourceNames()
         {
             // Snippet: ResourcedMethodAsync(ResourceName, string, int?, CallSettings)
             // Create client
@@ -631,6 +633,190 @@ namespace Testing.Paginated.Snippets
             ResourceName name = ResourceName.FromItem("[ITEM_ID]");
             // Make the request
             PagedAsyncEnumerable<ResourceResponse, ResourceName> response = paginatedClient.ResourcedMethodAsync(name);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((ResourceName item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((ResourceResponse page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (ResourceName item in page)
+                {
+                    // Do something with each item
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<ResourceName> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (ResourceName item in singlePage)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        /// <summary>Snippet for ResourcedMethod</summary>
+        public void ResourcedMethod2()
+        {
+            // Snippet: ResourcedMethod(string, string, string, int?, CallSettings)
+            // Create client
+            PaginatedClient paginatedClient = PaginatedClient.Create();
+            // Initialize request argument(s)
+            string name = "items/[ITEM_ID]";
+            string extraString = "";
+            // Make the request
+            PagedEnumerable<ResourceResponse, ResourceName> response = paginatedClient.ResourcedMethod(name, extraString: extraString);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (ResourceName item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (ResourceResponse page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (ResourceName item in page)
+                {
+                    // Do something with each item
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<ResourceName> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (ResourceName item in singlePage)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        /// <summary>Snippet for ResourcedMethod</summary>
+        public async Task ResourcedMethod2Async()
+        {
+            // Snippet: ResourcedMethodAsync(string, string, string, int?, CallSettings)
+            // Create client
+            PaginatedClient paginatedClient = await PaginatedClient.CreateAsync();
+            // Initialize request argument(s)
+            string name = "items/[ITEM_ID]";
+            string extraString = "";
+            // Make the request
+            PagedAsyncEnumerable<ResourceResponse, ResourceName> response = paginatedClient.ResourcedMethodAsync(name, extraString: extraString);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((ResourceName item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((ResourceResponse page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (ResourceName item in page)
+                {
+                    // Do something with each item
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<ResourceName> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (ResourceName item in singlePage)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        /// <summary>Snippet for ResourcedMethod</summary>
+        public void ResourcedMethod2_ResourceNames()
+        {
+            // Snippet: ResourcedMethod(ResourceName, string, string, int?, CallSettings)
+            // Create client
+            PaginatedClient paginatedClient = PaginatedClient.Create();
+            // Initialize request argument(s)
+            ResourceName name = ResourceName.FromItem("[ITEM_ID]");
+            string extraString = "";
+            // Make the request
+            PagedEnumerable<ResourceResponse, ResourceName> response = paginatedClient.ResourcedMethod(name, extraString: extraString);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (ResourceName item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (ResourceResponse page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (ResourceName item in page)
+                {
+                    // Do something with each item
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<ResourceName> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (ResourceName item in singlePage)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        /// <summary>Snippet for ResourcedMethod</summary>
+        public async Task ResourcedMethod2Async_ResourceNames()
+        {
+            // Snippet: ResourcedMethodAsync(ResourceName, string, string, int?, CallSettings)
+            // Create client
+            PaginatedClient paginatedClient = await PaginatedClient.CreateAsync();
+            // Initialize request argument(s)
+            ResourceName name = ResourceName.FromItem("[ITEM_ID]");
+            string extraString = "";
+            // Make the request
+            PagedAsyncEnumerable<ResourceResponse, ResourceName> response = paginatedClient.ResourcedMethodAsync(name, extraString: extraString);
 
             // Iterate over all response items, lazily performing RPCs as required
             await response.ForEachAsync((ResourceName item) =>

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated/PaginatedClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated/PaginatedClient.g.cs
@@ -300,6 +300,114 @@ namespace Testing.Paginated
                 PageToken = pageToken ?? "",
                 PageSize = pageSize ?? 0,
             }, callSettings);
+
+        /// <summary>
+        /// Test a paginated RPC with a method signature that contains resource-names
+        /// in both the request and the response.
+        /// </summary>
+        /// <param name="name">
+        /// </param>
+        /// <param name="extraString">
+        /// </param>
+        /// <param name="pageToken">
+        /// The token returned from the previous request. A value of <c>null</c> or an empty string retrieves the first
+        /// page.
+        /// </param>
+        /// <param name="pageSize">
+        /// The size of page to request. The response will not be larger than this, but may be smaller. A value of
+        /// <c>null</c> or <c>0</c> uses a server-defined page size.
+        /// </param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A pageable sequence of <see cref="ResourceName"/> resources.</returns>
+        public virtual gax::PagedEnumerable<ResourceResponse, ResourceName> ResourcedMethod(string name, string extraString, string pageToken = null, int? pageSize = null, gaxgrpc::CallSettings callSettings = null) =>
+            ResourcedMethod(new ResourceRequest
+            {
+                Name = name ?? "",
+                ExtraString = extraString ?? "",
+                PageToken = pageToken ?? "",
+                PageSize = pageSize ?? 0,
+            }, callSettings);
+
+        /// <summary>
+        /// Test a paginated RPC with a method signature that contains resource-names
+        /// in both the request and the response.
+        /// </summary>
+        /// <param name="name">
+        /// </param>
+        /// <param name="extraString">
+        /// </param>
+        /// <param name="pageToken">
+        /// The token returned from the previous request. A value of <c>null</c> or an empty string retrieves the first
+        /// page.
+        /// </param>
+        /// <param name="pageSize">
+        /// The size of page to request. The response will not be larger than this, but may be smaller. A value of
+        /// <c>null</c> or <c>0</c> uses a server-defined page size.
+        /// </param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A pageable asynchronous sequence of <see cref="ResourceName"/> resources.</returns>
+        public virtual gax::PagedAsyncEnumerable<ResourceResponse, ResourceName> ResourcedMethodAsync(string name, string extraString, string pageToken = null, int? pageSize = null, gaxgrpc::CallSettings callSettings = null) =>
+            ResourcedMethodAsync(new ResourceRequest
+            {
+                Name = name ?? "",
+                ExtraString = extraString ?? "",
+                PageToken = pageToken ?? "",
+                PageSize = pageSize ?? 0,
+            }, callSettings);
+
+        /// <summary>
+        /// Test a paginated RPC with a method signature that contains resource-names
+        /// in both the request and the response.
+        /// </summary>
+        /// <param name="name">
+        /// </param>
+        /// <param name="extraString">
+        /// </param>
+        /// <param name="pageToken">
+        /// The token returned from the previous request. A value of <c>null</c> or an empty string retrieves the first
+        /// page.
+        /// </param>
+        /// <param name="pageSize">
+        /// The size of page to request. The response will not be larger than this, but may be smaller. A value of
+        /// <c>null</c> or <c>0</c> uses a server-defined page size.
+        /// </param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A pageable sequence of <see cref="ResourceName"/> resources.</returns>
+        public virtual gax::PagedEnumerable<ResourceResponse, ResourceName> ResourcedMethod(ResourceName name, string extraString, string pageToken = null, int? pageSize = null, gaxgrpc::CallSettings callSettings = null) =>
+            ResourcedMethod(new ResourceRequest
+            {
+                ResourceName = name,
+                ExtraString = extraString ?? "",
+                PageToken = pageToken ?? "",
+                PageSize = pageSize ?? 0,
+            }, callSettings);
+
+        /// <summary>
+        /// Test a paginated RPC with a method signature that contains resource-names
+        /// in both the request and the response.
+        /// </summary>
+        /// <param name="name">
+        /// </param>
+        /// <param name="extraString">
+        /// </param>
+        /// <param name="pageToken">
+        /// The token returned from the previous request. A value of <c>null</c> or an empty string retrieves the first
+        /// page.
+        /// </param>
+        /// <param name="pageSize">
+        /// The size of page to request. The response will not be larger than this, but may be smaller. A value of
+        /// <c>null</c> or <c>0</c> uses a server-defined page size.
+        /// </param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A pageable asynchronous sequence of <see cref="ResourceName"/> resources.</returns>
+        public virtual gax::PagedAsyncEnumerable<ResourceResponse, ResourceName> ResourcedMethodAsync(ResourceName name, string extraString, string pageToken = null, int? pageSize = null, gaxgrpc::CallSettings callSettings = null) =>
+            ResourcedMethodAsync(new ResourceRequest
+            {
+                ResourceName = name,
+                ExtraString = extraString ?? "",
+                PageToken = pageToken ?? "",
+                PageSize = pageSize ?? 0,
+            }, callSettings);
         // TEST_END
     }
 

--- a/Google.Api.Generator/Generation/SnippetCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/SnippetCodeGenerator.cs
@@ -574,10 +574,10 @@ namespace Google.Api.Generator.Generation
                     InitRequestArgsNormal, _def.AsyncResponse.WithInitializer(_def.Client.Call(Method.AsyncMethodName)(PaginatedArgs(InitRequestArgsNormal).ToArray())), isSig: true);
 
                 public MethodDeclarationSyntax SyncPaginatedMethodResourceNames => _def.SyncPaginated(SyncResourceNameMethodName, SnippetCommentResourceNameArgs,
-                    InitRequestArgsResourceNames, _def.Response.WithInitializer(_def.Client.Call(Method.SyncMethodName)(InitRequestArgsResourceNames.ToArray())), isSig: true);
+                    InitRequestArgsResourceNames, _def.Response.WithInitializer(_def.Client.Call(Method.SyncMethodName)(PaginatedArgs(InitRequestArgsResourceNames).ToArray())), isSig: true);
 
                 public MethodDeclarationSyntax AsyncPaginatedMethodResourceNames => _def.AsyncPaginated(AsyncResourceNameMethodName, SnippetCommentResourceNameArgs,
-                    InitRequestArgsResourceNames, _def.AsyncResponse.WithInitializer(_def.Client.Call(Method.AsyncMethodName)(InitRequestArgsResourceNames.ToArray())), isSig: true);
+                    InitRequestArgsResourceNames, _def.AsyncResponse.WithInitializer(_def.Client.Call(Method.AsyncMethodName)(PaginatedArgs(InitRequestArgsResourceNames).ToArray())), isSig: true);
 
                 public MethodDeclarationSyntax ServerStreamingMethod => _def.ServerStreaming(SyncMethodName, _sig.Fields.Select(f => f.Typ),
                     InitRequestArgsNormal, _def.Response.WithInitializer(_def.Client.Call(Method.SyncMethodName)(InitRequestArgsNormal.ToArray())));
@@ -588,7 +588,7 @@ namespace Google.Api.Generator.Generation
 
             private bool RequireFinalNamedArg(MethodDetails.Signature sig)
             {
-                // The last argument numst be named, if there is a signature with identical types and an extra string parameter.
+                // The last argument must be named, if there is a signature with identical types and an extra string parameter.
                 var stringTyp = Typ.Of<string>();
                 var sigTyps = sig.Fields.Select(x => x.Typ).ToList();
                 return Method.Signatures.Any(s => s.Fields.Select(x => x.Typ).Append(stringTyp).SequenceEqual(sigTyps));


### PR DESCRIPTION
Fixes #198.

2 lines of production code change (+ a typo fix), hundreds of lines of test code change...