### PR TITLE
Don't generate common resource names

### DIFF
--- a/Google.Api.Generator/Generation/ResourceNamesGenerator.cs
+++ b/Google.Api.Generator/Generation/ResourceNamesGenerator.cs
@@ -396,7 +396,7 @@ namespace Google.Api.Generator.Generation
         {
             foreach (var def in _catalog.GetResourceDefsByFile(_fileDesc))
             {
-                if (!def.IsWildcard)
+                if (!def.IsWildcard && !def.IsCommon)
                 {
                     yield return new ResourceClassBuilder(_ctx, def).Generate();
                 }

--- a/Google.Api.Generator/ProtoUtils/ProtoCatalog.cs
+++ b/Google.Api.Generator/ProtoUtils/ProtoCatalog.cs
@@ -54,7 +54,6 @@ namespace Google.Api.Generator.ProtoUtils
                     (field, res: ResourceDetails.LoadResourceReference(msg, field, resourcesByUrt, resourcesByPatterns)))
                     .Where(x => x.res != null))
                 .ToDictionary(x => x.field.FullName, x => x.res);
-            _commonUrts = resourcesByUrt.Values.Where(x => x.IsCommon).Select(x => x.UnifiedResourceTypeName).ToImmutableHashSet();
 
             IEnumerable<MessageDescriptor> MsgPlusNested(MessageDescriptor msgDesc) => msgDesc.NestedTypes.SelectMany(MsgPlusNested).Append(msgDesc);
         }
@@ -63,7 +62,6 @@ namespace Google.Api.Generator.ProtoUtils
         private readonly IReadOnlyDictionary<string, MessageDescriptor> _msgs;
         private readonly IReadOnlyDictionary<string, ResourceDetails.Field> _resourcesByFieldName;
         private readonly IReadOnlyDictionary<string, IReadOnlyList<ResourceDetails.Definition>> _resourcesByFileName;
-        private readonly IImmutableSet<string> _commonUrts;
 
         public MessageDescriptor GetMessageByName(string name) =>
             _msgs.GetValueOrDefault($"{_defaultPackage}.{name}") ?? _msgs.GetValueOrDefault(name);
@@ -72,7 +70,5 @@ namespace Google.Api.Generator.ProtoUtils
 
         public IEnumerable<ResourceDetails.Definition> GetResourceDefsByFile(FileDescriptor fileDesc) =>
             _resourcesByFileName.GetValueOrDefault(fileDesc.Name, ImmutableList<ResourceDetails.Definition>.Empty);
-
-        public bool IsCommonResourceType(string type) => _commonUrts.Contains(type);
     }
 }

--- a/Google.Api.Generator/ProtoUtils/ResourceDetails.cs
+++ b/Google.Api.Generator/ProtoUtils/ResourceDetails.cs
@@ -70,6 +70,7 @@ namespace Google.Api.Generator.ProtoUtils
                     // Wildcard resource.
                     ResourceNameTyp = Typ.Of<IResourceName>();
                 }
+                IsCommon = common != null;
             }
 
             public MessageDescriptor MsgDesc { get; }


### PR DESCRIPTION
It looks like some of the common resource handling underwent bitrot when resource names were redesigned.
It's very possible that this "fix" isn't right, but it's a starting point...