### PR TITLE
Fix pagination partial generation

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Paginated.proto
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Paginated.proto
@@ -17,6 +17,9 @@ service Paginated {
     option (google.api.method_signature) = "";
   }
 
+  // Test rpc with duplicate response message, to make sure partial LRO response class is only generated once.
+  rpc SignatureMethod2(Request) returns(Response);
+
   // Test a paginated RPC with a method signature that contains resource-names
   // in both the request and the response.
   rpc ResourcedMethod(ResourceRequest) returns(ResourceResponse) {

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.Snippets/PaginatedClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.Snippets/PaginatedClientSnippets.g.cs
@@ -390,6 +390,104 @@ namespace Testing.Paginated.Snippets
             // End snippet
         }
 
+        /// <summary>Snippet for SignatureMethod2</summary>
+        public void SignatureMethod2_RequestObject()
+        {
+            // Snippet: SignatureMethod2(Request, CallSettings)
+            // Create client
+            PaginatedClient paginatedClient = PaginatedClient.Create();
+            // Initialize request argument(s)
+            Request request = new Request
+            {
+                AString = "",
+                ANumber = 0,
+            };
+            // Make the request
+            PagedEnumerable<Response, Response.Types.NestedResult> response = paginatedClient.SignatureMethod2(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (Response.Types.NestedResult item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (Response page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (Response.Types.NestedResult item in page)
+                {
+                    // Do something with each item
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<Response.Types.NestedResult> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (Response.Types.NestedResult item in singlePage)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
+        /// <summary>Snippet for SignatureMethod2</summary>
+        public async Task SignatureMethod2Async_RequestObject()
+        {
+            // Snippet: SignatureMethod2Async(Request, CallSettings)
+            // Create client
+            PaginatedClient paginatedClient = await PaginatedClient.CreateAsync();
+            // Initialize request argument(s)
+            Request request = new Request
+            {
+                AString = "",
+                ANumber = 0,
+            };
+            // Make the request
+            PagedAsyncEnumerable<Response, Response.Types.NestedResult> response = paginatedClient.SignatureMethod2Async(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((Response.Types.NestedResult item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((Response page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (Response.Types.NestedResult item in page)
+                {
+                    // Do something with each item
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<Response.Types.NestedResult> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (Response.Types.NestedResult item in singlePage)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+
         /// <summary>Snippet for ResourcedMethod</summary>
         public void ResourcedMethod_RequestObject()
         {

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated/PaginatedClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated/PaginatedClient.g.cs
@@ -186,6 +186,24 @@ namespace Testing.Paginated
             }, callSettings);
 
         /// <summary>
+        /// Test rpc with duplicate response message, to make sure partial LRO response class is only generated once.
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A pageable sequence of <see cref="Response.Types.NestedResult"/> resources.</returns>
+        public virtual gax::PagedEnumerable<Response, Response.Types.NestedResult> SignatureMethod2(Request request, gaxgrpc::CallSettings callSettings = null) =>
+            throw new sys::NotImplementedException();
+
+        /// <summary>
+        /// Test rpc with duplicate response message, to make sure partial LRO response class is only generated once.
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A pageable asynchronous sequence of <see cref="Response.Types.NestedResult"/> resources.</returns>
+        public virtual gax::PagedAsyncEnumerable<Response, Response.Types.NestedResult> SignatureMethod2Async(Request request, gaxgrpc::CallSettings callSettings = null) =>
+            throw new sys::NotImplementedException();
+
+        /// <summary>
         /// Test a paginated RPC with a method signature that contains resource-names
         /// in both the request and the response.
         /// </summary>
@@ -414,6 +432,7 @@ namespace Testing.Paginated
     public sealed partial class PaginatedClientImpl : PaginatedClient
     {
         private readonly gaxgrpc::ApiCall<Request, Response> _callSignatureMethod = null;
+        private readonly gaxgrpc::ApiCall<Request, Response> _callSignatureMethod2 = null;
         private readonly gaxgrpc::ApiCall<ResourceRequest, ResourceResponse> _callResourcedMethod = null;
 
         partial void Modify_Request(ref Request request, ref gaxgrpc::CallSettings callSettings);
@@ -442,6 +461,30 @@ namespace Testing.Paginated
         {
             Modify_Request(ref request, ref callSettings);
             return new gaxgrpc::GrpcPagedAsyncEnumerable<Request, Response, Response.Types.NestedResult>(_callSignatureMethod, request, callSettings);
+        }
+
+        /// <summary>
+        /// Test rpc with duplicate response message, to make sure partial LRO response class is only generated once.
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A pageable sequence of <see cref="Response.Types.NestedResult"/> resources.</returns>
+        public override gax::PagedEnumerable<Response, Response.Types.NestedResult> SignatureMethod2(Request request, gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_Request(ref request, ref callSettings);
+            return new gaxgrpc::GrpcPagedEnumerable<Request, Response, Response.Types.NestedResult>(_callSignatureMethod2, request, callSettings);
+        }
+
+        /// <summary>
+        /// Test rpc with duplicate response message, to make sure partial LRO response class is only generated once.
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A pageable asynchronous sequence of <see cref="Response.Types.NestedResult"/> resources.</returns>
+        public override gax::PagedAsyncEnumerable<Response, Response.Types.NestedResult> SignatureMethod2Async(Request request, gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_Request(ref request, ref callSettings);
+            return new gaxgrpc::GrpcPagedAsyncEnumerable<Request, Response, Response.Types.NestedResult>(_callSignatureMethod2, request, callSettings);
         }
 
         /// <summary>

--- a/Google.Api.Generator/Generation/ServiceCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceCodeGenerator.cs
@@ -56,17 +56,10 @@ namespace Google.Api.Generator.Generation
             {
                 yield return Class(Public | Partial, typ, baseTypes: ctx.Type<IPageRequest>());
             }
-            var seen = new Dictionary<string, Typ>();
+            var seenResponseTyps = new HashSet<Typ>();
             foreach (var method in paginatedMethods)
             {
-                if (seen.TryGetValue(method.SyncMethodName, out var seenTyp))
-                {
-                    if (seenTyp != method.ResourceTyp)
-                    {
-                        throw new InvalidOperationException($"Incompatible resource-types in paginated method: {method.SyncMethodName}");
-                    }
-                }
-                else
+                if (seenResponseTyps.Add(method.ResponseTyp))
                 {
                     var cls = Class(Public | Partial, method.ResponseTyp, baseTypes: ctx.Type(Typ.Generic(typeof(IPageResponse<>), method.ResourceTyp)));
                     using (ctx.InClass(cls))


### PR DESCRIPTION
Fixes #203 

Prevents multiple identical partial classes being generate when more than one method returns the same paginated response type.