### PR TITLE
Fix resource property for wildcard resource fields called "name"

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets/SnippetsResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets/SnippetsResourceNames.g.cs
@@ -708,7 +708,7 @@ namespace Testing.Snippets
         /// <summary>
         /// <see cref="gax::IResourceName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public gax::IResourceName AsResourceName
+        public gax::IResourceName ResourceName
         {
             get => string.IsNullOrEmpty(Name) ? null : gax::UnparsedResourceName.Parse(Name);
             set => Name = value?.ToString() ?? "";

--- a/Google.Api.Generator.Tests/ProtoTests/UnitTests/Testing.UnitTests/UnitTestsResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/UnitTests/Testing.UnitTests/UnitTestsResourceNames.g.cs
@@ -512,7 +512,7 @@ namespace Testing.UnitTests
         /// <summary>
         /// <see cref="gax::IResourceName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public gax::IResourceName AsResourceName
+        public gax::IResourceName ResourceName
         {
             get => string.IsNullOrEmpty(Name) ? null : gax::UnparsedResourceName.Parse(Name);
             set => Name = value?.ToString() ?? "";

--- a/Google.Api.Generator/ProtoUtils/ResourceDetails.cs
+++ b/Google.Api.Generator/ProtoUtils/ResourceDetails.cs
@@ -113,7 +113,7 @@ namespace Google.Api.Generator.ProtoUtils
                 // TODO: Make sure it's correct for all combinations - I'm not sure it is!
                 var requireIdentifier = !((fieldDesc.IsRepeated && fieldDesc.Name.ToLowerInvariant() == "names") ||
                     (!fieldDesc.IsRepeated && fieldDesc.Name.ToLowerInvariant() == "name"));
-                var requireAs = requireIdentifier || resourceDef.IsWildcard;
+                var requireAs = requireIdentifier;
                 var requirePlural = fieldDesc.IsRepeated;
                 var name = requireIdentifier ? UnderlyingPropertyName : "";
                 name += requireAs ? "As" : "";


### PR DESCRIPTION
Fixes #205.

This would be a breaking change if we had any such resources, but it looks like we don't (yet).

(I have another commit to add a resource-name-accepting method test, but it looks like that's redundant.)