### PR TITLE
Don't generate tests/snippets for IResourceName overloads

### DIFF
--- a/Google.Api.Generator/Generation/SnippetCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/SnippetCodeGenerator.cs
@@ -568,7 +568,8 @@ namespace Google.Api.Generator.Generation
                         }
                         var allOverloads = sig._sig.Fields.Aggregate(ImmutableList.Create(ImmutableList<Typ>.Empty), (overloads, f) =>
                         {
-                            var typs = f.FieldResources is null ? new[] { f.Typ } : f.FieldResources.Select(x => x.ResourceDefinition.ResourceNameTyp);
+                            var typs = f.FieldResources is null ? new[] { f.Typ }
+                                : f.FieldResources.Where(resDetails => resDetails.ContainsWildcard != false).Select(x => x.ResourceDefinition.ResourceNameTyp);
                             return overloads.SelectMany(overload => typs.Select(typ => overload.Add(typ))).ToImmutableList();
                         }).ToList();
                         return allOverloads.Select((typs, index) => new ResourceName(sig, typs, allOverloads.Count > 1 ? (int?)(index + 1) : null));

--- a/Google.Api.Generator/Generation/UnitTestCodeGeneration.cs
+++ b/Google.Api.Generator/Generation/UnitTestCodeGeneration.cs
@@ -294,7 +294,8 @@ namespace Google.Api.Generator.Generation
                         }
                         var allOverloads = sig._sig.Fields.Aggregate(ImmutableList.Create(ImmutableList<string>.Empty), (overloads, f) =>
                         {
-                            var names = f.FieldResources is null ? new[] { f.PropertyName } : f.FieldResources.Select(x => x.ResourcePropertyName);
+                            var names = f.FieldResources is null ? new[] { f.PropertyName }
+                                : f.FieldResources.Where(resDetails => resDetails.ContainsWildcard != false).Select(x => x.ResourcePropertyName);
                             return overloads.SelectMany(overload => names.Select(typ => overload.Add(typ))).ToImmutableList();
                         }).ToList();
                         return allOverloads.Select((typs, index) => new ResourceName(sig, typs, allOverloads.Count > 1 ? (int?)(index + 1) : null));


### PR DESCRIPTION
This is effectively left over work from https://github.com/googleapis/gapic-generator-csharp/commit/99f02340d3d9000d16a516c84ffd5317145da672

It's slightly worrying that no tests have changed here.