### PR TITLE
Generate XML comments for OneOf resource name constructors

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTests/ChildResource/Testing.ChildResource/ChildResourceResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ChildResource/Testing.ChildResource/ChildResourceResourceNames.g.cs
@@ -519,6 +519,11 @@ namespace Testing.ChildResource
             }
         }
 
+        /// <summary>
+        /// Constructs a new instance of <see cref="MultiRootItemNameOneOf"/> with an expected type and a resource name.
+        /// </summary>
+        /// <param name="type">The expected type of this oneof.</param>
+        /// <param name="name">The resource name represented by this oneof. Must not be <c>null</c>.</param>
         public MultiRootItemNameOneOf(OneofType type, gax::IResourceName name)
         {
             Type = gax::GaxPreconditions.CheckEnumValue<OneofType>(type, nameof(type));
@@ -868,6 +873,11 @@ namespace Testing.ChildResource
             }
         }
 
+        /// <summary>
+        /// Constructs a new instance of <see cref="RootsNameOneOf"/> with an expected type and a resource name.
+        /// </summary>
+        /// <param name="type">The expected type of this oneof.</param>
+        /// <param name="name">The resource name represented by this oneof. Must not be <c>null</c>.</param>
         public RootsNameOneOf(OneofType type, gax::IResourceName name)
         {
             Type = gax::GaxPreconditions.CheckEnumValue<OneofType>(type, nameof(type));

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames/ResourceNamesResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames/ResourceNamesResourceNames.g.cs
@@ -431,6 +431,11 @@ namespace Testing.ResourceNames
             }
         }
 
+        /// <summary>
+        /// Constructs a new instance of <see cref="MultiResourceNameOneOf"/> with an expected type and a resource name.
+        /// </summary>
+        /// <param name="type">The expected type of this oneof.</param>
+        /// <param name="name">The resource name represented by this oneof. Must not be <c>null</c>.</param>
         public MultiResourceNameOneOf(OneofType type, gax::IResourceName name)
         {
             Type = gax::GaxPreconditions.CheckEnumValue<OneofType>(type, nameof(type));
@@ -700,6 +705,12 @@ namespace Testing.ResourceNames
             }
         }
 
+        /// <summary>
+        /// Constructs a new instance of <see cref="FutureMultiResourceNameOneOf"/> with an expected type and a resource
+        /// name.
+        /// </summary>
+        /// <param name="type">The expected type of this oneof.</param>
+        /// <param name="name">The resource name represented by this oneof. Must not be <c>null</c>.</param>
         public FutureMultiResourceNameOneOf(OneofType type, gax::IResourceName name)
         {
             Type = gax::GaxPreconditions.CheckEnumValue<OneofType>(type, nameof(type));
@@ -1095,6 +1106,12 @@ namespace Testing.ResourceNames
             }
         }
 
+        /// <summary>
+        /// Constructs a new instance of <see cref="OriginallySingleResourceNameOneOf"/> with an expected type and a
+        /// resource name.
+        /// </summary>
+        /// <param name="type">The expected type of this oneof.</param>
+        /// <param name="name">The resource name represented by this oneof. Must not be <c>null</c>.</param>
         public OriginallySingleResourceNameOneOf(OneofType type, gax::IResourceName name)
         {
             Type = gax::GaxPreconditions.CheckEnumValue<OneofType>(type, nameof(type));

--- a/Google.Api.Generator.Tests/ProtoTests/UnitTests/Testing.UnitTests/UnitTestsResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/UnitTests/Testing.UnitTests/UnitTestsResourceNames.g.cs
@@ -445,6 +445,12 @@ namespace Testing.UnitTests
             }
         }
 
+        /// <summary>
+        /// Constructs a new instance of <see cref="MultiPatternResourceNameOneOf"/> with an expected type and a
+        /// resource name.
+        /// </summary>
+        /// <param name="type">The expected type of this oneof.</param>
+        /// <param name="name">The resource name represented by this oneof. Must not be <c>null</c>.</param>
         public MultiPatternResourceNameOneOf(OneofType type, gax::IResourceName name)
         {
             Type = gax::GaxPreconditions.CheckEnumValue<OneofType>(type, nameof(type));

--- a/Google.Api.Generator/Generation/ResourceNamesGenerator.cs
+++ b/Google.Api.Generator/Generation/ResourceNamesGenerator.cs
@@ -372,7 +372,11 @@ namespace Google.Api.Generator.Generation
                         nameProp.Assign(_ctx.Type(typeof(GaxPreconditions)).Call(nameof(GaxPreconditions.CheckNotNull))(name, Nameof(name))),
                         If(Not(This.Call(isValid)(type, name))).Then(
                             Throw(New(_ctx.Type<ArgumentException>())(Dollar($"Mismatched OneofType '{type}' and resource name '{name}'")))))
-                    .WithXmlDoc();
+                    .WithXmlDoc(
+                        XmlDoc.Summary("Constructs a new instance of ", _ctx.Type(_def.ContainerTyp), " with an expected type and a resource name."),
+                        XmlDoc.Param(type, "The expected type of this oneof."),
+                        XmlDoc.Param(name, "The resource name represented by this oneof. Must not be ", null, "."));
+
             }
 
             private PropertyDeclarationSyntax TypeProperty() => AutoProperty(Public, _ctx.Type(OneOfTypeEnumTyp), "Type")


### PR DESCRIPTION
Fixes #216.

I don't think we should agonize too much on the precise wording, as oneofs don't exist in the next major version.