### PR TITLE
Failing test for snippets for repeated resource names in signatures

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Snippets.proto
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Snippets.proto
@@ -33,6 +33,10 @@ service Snippets {
     option (google.api.method_signature) = "first_name";
   }
 
+  rpc MethodRepeatedResourceSignature(RepeatedResourceSignatureRequest) returns(Response) {
+    option (google.api.method_signature) = "names";
+  }
+
   rpc MethodLroSignatures(SignatureRequest) returns(google.longrunning.Operation) {
     option (google.api.method_signature) = "a_string,an_int,a_bool";
     option (google.longrunning.operation_info) = {
@@ -171,6 +175,10 @@ message ResourceSignatureRequest {
   string first_name = 1 [(google.api.resource_reference).type = "snippets.example.com/SimpleResource"];
   string second_name = 2 [(google.api.resource_reference).type = "snippets.example.com/SimpleResource"];
   string third_name = 3 [(google.api.resource_reference).type = "snippets.example.com/SimpleResource"];
+}
+
+message RepeatedResourceSignatureRequest {
+  repeated string names = 1 [(google.api.resource_reference).type = "snippets.example.com/SimpleResource"];
 }
 
 message Task {

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/SnippetsClientFakes.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/SnippetsClientFakes.cs
@@ -73,6 +73,13 @@ namespace Testing.Snippets
         public Response MethodResourceSignature(SimpleResourceName firstName) => throw new NotImplementedException();
         public Task<Response> MethodResourceSignatureAsync(SimpleResourceName firstName) => throw new NotImplementedException();
 
+        public Response MethodRepeatedResourceSignature(RepeatedResourceSignatureRequest request) => throw new NotImplementedException();
+        public Task<Response> MethodRepeatedResourceSignatureAsync(RepeatedResourceSignatureRequest request) => throw new NotImplementedException();
+        public Response MethodRepeatedResourceSignature(IEnumerable<string> names) => throw new NotImplementedException();
+        public Response MethodRepeatedResourceSignature(IEnumerable<SimpleResourceName> names) => throw new NotImplementedException();
+        public Task<Response> MethodRepeatedResourceSignatureAsync(IEnumerable<string> names) => throw new NotImplementedException();
+        public Task<Response> MethodRepeatedResourceSignatureAsync(IEnumerable<SimpleResourceName> names) => throw new NotImplementedException();
+
         public Operation<LroResponse, LroMetadata> MethodLroSignatures(SignatureRequest request) => throw new NotImplementedException();
         public Task<Operation<LroResponse, LroMetadata>> MethodLroSignaturesAsync(SignatureRequest request) => throw new NotImplementedException();
         public Operation<LroResponse, LroMetadata> MethodLroSignatures(string aString, int anInt, bool aBool) => throw new NotImplementedException();
@@ -205,6 +212,11 @@ namespace Testing.Snippets
         public string FirstName { get; set; }
         public string SecondName { get; set; }
         public string ThirdName { get; set; }
+    }
+
+    public partial class RepeatedResourceSignatureRequest : ProtoMsgFake<ResourceSignatureRequest>
+    {
+        public RepeatedField<string> Names { get; set; }
     }
 
     public class Task : ProtoMsgFake<Task> { }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.Snippets/SnippetsClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.Snippets/SnippetsClientSnippets.g.cs
@@ -681,6 +681,99 @@ namespace Testing.Snippets.Snippets
             // End snippet
         }
 
+        /// <summary>Snippet for MethodRepeatedResourceSignature</summary>
+        public void MethodRepeatedResourceSignatureRequestObject()
+        {
+            // Snippet: MethodRepeatedResourceSignature(RepeatedResourceSignatureRequest, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            RepeatedResourceSignatureRequest request = new RepeatedResourceSignatureRequest
+            {
+                SimpleResourceNames =
+                {
+                    SimpleResourceName.FromItem("[ITEM_ID]"),
+                },
+            };
+            // Make the request
+            Response response = snippetsClient.MethodRepeatedResourceSignature(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for MethodRepeatedResourceSignatureAsync</summary>
+        public async Task MethodRepeatedResourceSignatureRequestObjectAsync()
+        {
+            // Snippet: MethodRepeatedResourceSignatureAsync(RepeatedResourceSignatureRequest, CallSettings)
+            // Additional: MethodRepeatedResourceSignatureAsync(RepeatedResourceSignatureRequest, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            RepeatedResourceSignatureRequest request = new RepeatedResourceSignatureRequest
+            {
+                SimpleResourceNames =
+                {
+                    SimpleResourceName.FromItem("[ITEM_ID]"),
+                },
+            };
+            // Make the request
+            Response response = await snippetsClient.MethodRepeatedResourceSignatureAsync(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for MethodRepeatedResourceSignature</summary>
+        public void MethodRepeatedResourceSignature()
+        {
+            // Snippet: MethodRepeatedResourceSignature(IEnumerable<string>, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            IEnumerable<string> names = new string[] { "items/[ITEM_ID]", };
+            // Make the request
+            Response response = snippetsClient.MethodRepeatedResourceSignature(names);
+            // End snippet
+        }
+
+        /// <summary>Snippet for MethodRepeatedResourceSignatureAsync</summary>
+        public async Task MethodRepeatedResourceSignatureAsync()
+        {
+            // Snippet: MethodRepeatedResourceSignatureAsync(IEnumerable<string>, CallSettings)
+            // Additional: MethodRepeatedResourceSignatureAsync(IEnumerable<string>, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            IEnumerable<string> names = new string[] { "items/[ITEM_ID]", };
+            // Make the request
+            Response response = await snippetsClient.MethodRepeatedResourceSignatureAsync(names);
+            // End snippet
+        }
+
+        /// <summary>Snippet for MethodRepeatedResourceSignature</summary>
+        public void MethodRepeatedResourceSignatureResourceNames()
+        {
+            // Snippet: MethodRepeatedResourceSignature(IEnumerable<SimpleResourceName>, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            IEnumerable<SimpleResourceName> names = new SimpleResourceName[] { SimpleResourceName.FromItem("[ITEM_ID]"), };
+            // Make the request
+            Response response = snippetsClient.MethodRepeatedResourceSignature(names);
+            // End snippet
+        }
+
+        /// <summary>Snippet for MethodRepeatedResourceSignatureAsync</summary>
+        public async Task MethodRepeatedResourceSignatureResourceNamesAsync()
+        {
+            // Snippet: MethodRepeatedResourceSignatureAsync(IEnumerable<SimpleResourceName>, CallSettings)
+            // Additional: MethodRepeatedResourceSignatureAsync(IEnumerable<SimpleResourceName>, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            IEnumerable<SimpleResourceName> names = new SimpleResourceName[] { SimpleResourceName.FromItem("[ITEM_ID]"), };
+            // Make the request
+            Response response = await snippetsClient.MethodRepeatedResourceSignatureAsync(names);
+            // End snippet
+        }
+
         /// <summary>Snippet for MethodLroSignatures</summary>
         public void MethodLroSignaturesRequestObject()
         {

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.Snippets/SnippetsClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.Snippets/SnippetsClientSnippets.g.cs
@@ -230,7 +230,7 @@ namespace Testing.Snippets.Snippets
         /// <summary>Snippet for MethodDefaultValues</summary>
         public void MethodDefaultValuesResourceNames()
         {
-            // Snippet: MethodDefaultValues(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, AResourceName, CallSettings)
+            // Snippet: MethodDefaultValues(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, IEnumerable<AResourceName>, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
@@ -251,8 +251,8 @@ namespace Testing.Snippets.Snippets
         /// <summary>Snippet for MethodDefaultValuesAsync</summary>
         public async Task MethodDefaultValuesResourceNamesAsync()
         {
-            // Snippet: MethodDefaultValuesAsync(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, AResourceName, CallSettings)
-            // Additional: MethodDefaultValuesAsync(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, AResourceName, CancellationToken)
+            // Snippet: MethodDefaultValuesAsync(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, IEnumerable<AResourceName>, CallSettings)
+            // Additional: MethodDefaultValuesAsync(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, IEnumerable<AResourceName>, CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
@@ -754,7 +754,10 @@ namespace Testing.Snippets.Snippets
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
-            IEnumerable<SimpleResourceName> names = new SimpleResourceName[] { SimpleResourceName.FromItem("[ITEM_ID]"), };
+            IEnumerable<SimpleResourceName> names = new SimpleResourceName[]
+            {
+                SimpleResourceName.FromItem("[ITEM_ID]"),
+            };
             // Make the request
             Response response = snippetsClient.MethodRepeatedResourceSignature(names);
             // End snippet
@@ -768,7 +771,10 @@ namespace Testing.Snippets.Snippets
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            IEnumerable<SimpleResourceName> names = new SimpleResourceName[] { SimpleResourceName.FromItem("[ITEM_ID]"), };
+            IEnumerable<SimpleResourceName> names = new SimpleResourceName[]
+            {
+                SimpleResourceName.FromItem("[ITEM_ID]"),
+            };
             // Make the request
             Response response = await snippetsClient.MethodRepeatedResourceSignatureAsync(names);
             // End snippet

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets/SnippetsResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets/SnippetsResourceNames.g.cs
@@ -826,4 +826,15 @@ namespace Testing.Snippets
             set => ThirdName = value?.ToString() ?? "";
         }
     }
+
+    public partial class RepeatedResourceSignatureRequest
+    {
+        /// <summary>
+        /// <see cref="SimpleResourceName"/>-typed view over the <see cref="Names"/> resource name property.
+        /// </summary>
+        public gax::ResourceNameList<SimpleResourceName> SimpleResourceNames
+        {
+            get => new gax::ResourceNameList<SimpleResourceName>(Names, s => string.IsNullOrEmpty(s) ? null : SimpleResourceName.Parse(s, allowUnparsed: true));
+        }
+    }
 }

--- a/Google.Api.Generator/Generation/SnippetCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/SnippetCodeGenerator.cs
@@ -590,27 +590,30 @@ namespace Google.Api.Generator.Generation
                             Local(Ctx.Type(f.IsRepeated && f.FieldResources is object ? Typ.Generic(typeof(IEnumerable<>), typ) : typ),
                                 f.Descs.Last().CSharpFieldName()).WithInitializer(_sig._def.DefaultValue(f.Descs.Last(), typ, topLevel: true)));
 
-                    public MethodDeclarationSyntax SyncMethod => _sig._def.Sync(SyncMethodName, _typs, InitRequestArgs, Method.SyncReturnTyp is Typ.VoidTyp ?
+                    private IEnumerable<Typ> SnippetTyps =>
+                        _sig._sig.Fields.Zip(_typs, (f, typ) => f.IsRepeated && f.FieldResources is object ? Typ.Generic(typeof(IEnumerable<>), typ) : typ);
+
+                    public MethodDeclarationSyntax SyncMethod => _sig._def.Sync(SyncMethodName, SnippetTyps, InitRequestArgs, Method.SyncReturnTyp is Typ.VoidTyp ?
                         (object)_sig._def.Client.Call(Method.SyncMethodName)(InitRequestArgs.ToArray()) :
                         _sig._def.Response.WithInitializer(_sig._def.Client.Call(Method.SyncMethodName)(InitRequestArgs.ToArray())));
 
-                    public MethodDeclarationSyntax AsyncMethod => _sig._def.Async(AsyncMethodName, _typs, InitRequestArgs, Method.SyncReturnTyp is Typ.VoidTyp ?
+                    public MethodDeclarationSyntax AsyncMethod => _sig._def.Async(AsyncMethodName, SnippetTyps, InitRequestArgs, Method.SyncReturnTyp is Typ.VoidTyp ?
                         (object)Await(_sig._def.Client.Call(Method.AsyncMethodName)(InitRequestArgs.ToArray())) :
                         _sig._def.Response.WithInitializer(Await(_sig._def.Client.Call(Method.AsyncMethodName)(InitRequestArgs.ToArray()))));
 
-                    public MethodDeclarationSyntax SyncLroMethod => _sig._def.SyncLro(SyncMethodName, _typs, InitRequestArgs,
+                    public MethodDeclarationSyntax SyncLroMethod => _sig._def.SyncLro(SyncMethodName, SnippetTyps, InitRequestArgs,
                         _sig._def.Response.WithInitializer(_sig._def.Client.Call(Method.SyncMethodName)(InitRequestArgs.ToArray())));
 
-                    public MethodDeclarationSyntax AsyncLroMethod => _sig._def.AsyncLro(AsyncMethodName, _typs, InitRequestArgs,
+                    public MethodDeclarationSyntax AsyncLroMethod => _sig._def.AsyncLro(AsyncMethodName, SnippetTyps, InitRequestArgs,
                         _sig._def.Response.WithInitializer(Await(_sig._def.Client.Call(Method.AsyncMethodName)(InitRequestArgs.ToArray()))));
 
-                    public MethodDeclarationSyntax SyncPaginatedMethod => _sig._def.SyncPaginated(SyncMethodName, _typs, InitRequestArgs,
+                    public MethodDeclarationSyntax SyncPaginatedMethod => _sig._def.SyncPaginated(SyncMethodName, SnippetTyps, InitRequestArgs,
                         _sig._def.Response.WithInitializer(_sig._def.Client.Call(Method.SyncMethodName)(_sig.PaginatedArgs(InitRequestArgs).ToArray())), true);
 
-                    public MethodDeclarationSyntax AsyncPaginatedMethod => _sig._def.AsyncPaginated(AsyncMethodName, _typs, InitRequestArgs,
+                    public MethodDeclarationSyntax AsyncPaginatedMethod => _sig._def.AsyncPaginated(AsyncMethodName, SnippetTyps, InitRequestArgs,
                         _sig._def.AsyncResponse.WithInitializer(_sig._def.Client.Call(Method.AsyncMethodName)(_sig.PaginatedArgs(InitRequestArgs).ToArray())), true);
 
-                    public MethodDeclarationSyntax ServerStreamingMethod => _sig._def.ServerStreaming(SyncMethodName, _typs, InitRequestArgs,
+                    public MethodDeclarationSyntax ServerStreamingMethod => _sig._def.ServerStreaming(SyncMethodName, SnippetTyps, InitRequestArgs,
                         _sig._def.Response.WithInitializer(_sig._def.Client.Call(Method.SyncMethodName)(InitRequestArgs.ToArray())));
                 }
 


### PR DESCRIPTION
Demonstrates #226.