### PR TITLE
Allow partial class interception of client builder methods

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTests/Basic/Testing.Basic/BasicClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic/Testing.Basic/BasicClient.g.cs
@@ -74,16 +74,34 @@ namespace Testing.Basic
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public BasicSettings Settings { get; set; }
 
+        partial void InterceptBuild(ref BasicClient client);
+
+        partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<BasicClient> task);
+
         /// <inheritdoc/>
         public override BasicClient Build()
+        {
+            BasicClient client = null;
+            InterceptBuild(ref client);
+            return client ?? BuildImpl();
+        }
+
+        /// <inheritdoc/>
+        public override stt::Task<BasicClient> BuildAsync(st::CancellationToken cancellationToken = default)
+        {
+            stt::Task<BasicClient> task = null;
+            InterceptBuildAsync(cancellationToken, ref task);
+            return task ?? BuildAsyncImpl(cancellationToken);
+        }
+
+        private BasicClient BuildImpl()
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
             return BasicClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
-        public override async stt::Task<BasicClient> BuildAsync(st::CancellationToken cancellationToken = default)
+        private async stt::Task<BasicClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated/DeprecatedClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated/DeprecatedClient.g.cs
@@ -113,16 +113,34 @@ namespace Testing.Deprecated
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public DeprecatedSettings Settings { get; set; }
 
+        partial void InterceptBuild(ref DeprecatedClient client);
+
+        partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DeprecatedClient> task);
+
         /// <inheritdoc/>
         public override DeprecatedClient Build()
+        {
+            DeprecatedClient client = null;
+            InterceptBuild(ref client);
+            return client ?? BuildImpl();
+        }
+
+        /// <inheritdoc/>
+        public override stt::Task<DeprecatedClient> BuildAsync(st::CancellationToken cancellationToken = default)
+        {
+            stt::Task<DeprecatedClient> task = null;
+            InterceptBuildAsync(cancellationToken, ref task);
+            return task ?? BuildAsyncImpl(cancellationToken);
+        }
+
+        private DeprecatedClient BuildImpl()
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
             return DeprecatedClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
-        public override async stt::Task<DeprecatedClient> BuildAsync(st::CancellationToken cancellationToken = default)
+        private async stt::Task<DeprecatedClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords/KeywordsClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords/KeywordsClient.g.cs
@@ -87,16 +87,34 @@ namespace Testing.Keywords
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public KeywordsSettings Settings { get; set; }
 
+        partial void InterceptBuild(ref KeywordsClient client);
+
+        partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<KeywordsClient> task);
+
         /// <inheritdoc/>
         public override KeywordsClient Build()
+        {
+            KeywordsClient client = null;
+            InterceptBuild(ref client);
+            return client ?? BuildImpl();
+        }
+
+        /// <inheritdoc/>
+        public override stt::Task<KeywordsClient> BuildAsync(st::CancellationToken cancellationToken = default)
+        {
+            stt::Task<KeywordsClient> task = null;
+            InterceptBuildAsync(cancellationToken, ref task);
+            return task ?? BuildAsyncImpl(cancellationToken);
+        }
+
+        private KeywordsClient BuildImpl()
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
             return KeywordsClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
-        public override async stt::Task<KeywordsClient> BuildAsync(st::CancellationToken cancellationToken = default)
+        private async stt::Task<KeywordsClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);

--- a/Google.Api.Generator.Tests/ProtoTests/UnitTests/Testing.UnitTests/UnitTestsClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/UnitTests/Testing.UnitTests/UnitTestsClient.g.cs
@@ -108,16 +108,34 @@ namespace Testing.UnitTests
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public UnitTestsSettings Settings { get; set; }
 
+        partial void InterceptBuild(ref UnitTestsClient client);
+
+        partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<UnitTestsClient> task);
+
         /// <inheritdoc/>
         public override UnitTestsClient Build()
+        {
+            UnitTestsClient client = null;
+            InterceptBuild(ref client);
+            return client ?? BuildImpl();
+        }
+
+        /// <inheritdoc/>
+        public override stt::Task<UnitTestsClient> BuildAsync(st::CancellationToken cancellationToken = default)
+        {
+            stt::Task<UnitTestsClient> task = null;
+            InterceptBuildAsync(cancellationToken, ref task);
+            return task ?? BuildAsyncImpl(cancellationToken);
+        }
+
+        private UnitTestsClient BuildImpl()
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
             return UnitTestsClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
-        public override async stt::Task<UnitTestsClient> BuildAsync(st::CancellationToken cancellationToken = default)
+        private async stt::Task<UnitTestsClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);

--- a/Google.Api.Generator/RoslynUtils/RoslynExtensions.cs
+++ b/Google.Api.Generator/RoslynUtils/RoslynExtensions.cs
@@ -217,6 +217,9 @@ namespace Google.Api.Generator.RoslynUtils
         public static ExpressionSyntax NullCoalesce(this ParameterSyntax lhs, object rhs) =>
             BinaryExpression(SyntaxKind.CoalesceExpression, ToExpression(lhs), ToExpression(rhs));
 
+        public static ExpressionSyntax NullCoalesce(this LocalDeclarationStatementSyntax lhs, object rhs) =>
+            BinaryExpression(SyntaxKind.CoalesceExpression, ToExpression(lhs), ToExpression(rhs));
+
         public static ExpressionSyntax NotEqualTo(this LocalDeclarationStatementSyntax lhs, object rhs) =>
             BinaryExpression(SyntaxKind.NotEqualsExpression, ToExpression(lhs), ToExpression(rhs));
 


### PR DESCRIPTION
This will make implementing emulator support simpler, for example.

An alternative possibly design would be to have a partial method
"returning" (via a ref parameter) another builder of the same type.
We could then, then we could call Build or BuildAsync on that
builder (if not null). This would mean only implementing a single
partial method in partial classes - but would prohibit any
customization requiring asynchrony.

The scheme in this commit is still not massively onerous for partial
class implementers, but gives more freedom for future expansion.
Note that all of this can change in the generator later, in that
it's a breaking change for generator consumers, but not for end user
developers, as the public API surface remains the same
(Build/BuildAsync).