### PR TITLE
Fix field naming when the same name as the enclosing message

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Keywords.proto
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Keywords.proto
@@ -9,7 +9,7 @@ import "google/api/resource.proto";
 
 service Keywords {
   rpc Method1(Request) returns(Response) {
-    option (google.api.method_signature) = "event, switch, void";
+    option (google.api.method_signature) = "event, switch, void, request";
   }
 
   rpc Method2(Resource) returns(Response) {
@@ -37,6 +37,7 @@ message Request {
   string event = 1 [(google.api.resource_reference).type = "keywords.example.com/Resource"];
   int32 switch = 2;
   Enum void = 3;
+  string request = 4; // Also check a field named the same as the enclosing message.
 }
 
 message Response{

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/KeywordsFakes.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/KeywordsFakes.cs
@@ -50,6 +50,7 @@ namespace Testing.Keywords
         public string Event { get; set; }
         public int Switch { get; set; }
         public Enum Void { get; set; }
+        public string Request_ { get; set; }
     }
 
     public partial class Response : ProtoMsgFake<Response> { }

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.Snippets/KeywordsClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.Snippets/KeywordsClientSnippets.g.cs
@@ -33,6 +33,7 @@ namespace Testing.Keywords.Snippets
                 EventAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
                 Switch = 0,
                 Void = Enum.Void,
+                Request_ = "",
             };
             // Make the request
             Response response = keywordsClient.Method1(request);
@@ -52,6 +53,7 @@ namespace Testing.Keywords.Snippets
                 EventAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
                 Switch = 0,
                 Void = Enum.Void,
+                Request_ = "",
             };
             // Make the request
             Response response = await keywordsClient.Method1Async(request);
@@ -61,62 +63,66 @@ namespace Testing.Keywords.Snippets
         /// <summary>Snippet for Method1</summary>
         public void Method1()
         {
-            // Snippet: Method1(string, int, Enum, CallSettings)
+            // Snippet: Method1(string, int, Enum, string, CallSettings)
             // Create client
             KeywordsClient keywordsClient = KeywordsClient.Create();
             // Initialize request argument(s)
             string @event = "items/[ITEM_ID]";
             int @switch = 0;
             Enum @void = Enum.Void;
+            string request = "";
             // Make the request
-            Response response = keywordsClient.Method1(@event, @switch, @void);
+            Response response = keywordsClient.Method1(@event, @switch, @void, request);
             // End snippet
         }
 
         /// <summary>Snippet for Method1Async</summary>
         public async Task Method1Async()
         {
-            // Snippet: Method1Async(string, int, Enum, CallSettings)
-            // Additional: Method1Async(string, int, Enum, CancellationToken)
+            // Snippet: Method1Async(string, int, Enum, string, CallSettings)
+            // Additional: Method1Async(string, int, Enum, string, CancellationToken)
             // Create client
             KeywordsClient keywordsClient = await KeywordsClient.CreateAsync();
             // Initialize request argument(s)
             string @event = "items/[ITEM_ID]";
             int @switch = 0;
             Enum @void = Enum.Void;
+            string request = "";
             // Make the request
-            Response response = await keywordsClient.Method1Async(@event, @switch, @void);
+            Response response = await keywordsClient.Method1Async(@event, @switch, @void, request);
             // End snippet
         }
 
         /// <summary>Snippet for Method1</summary>
         public void Method1ResourceNames()
         {
-            // Snippet: Method1(ResourceName, int, Enum, CallSettings)
+            // Snippet: Method1(ResourceName, int, Enum, string, CallSettings)
             // Create client
             KeywordsClient keywordsClient = KeywordsClient.Create();
             // Initialize request argument(s)
             ResourceName @event = ResourceName.FromItem("[ITEM_ID]");
             int @switch = 0;
             Enum @void = Enum.Void;
+            string request = "";
             // Make the request
-            Response response = keywordsClient.Method1(@event, @switch, @void);
+            Response response = keywordsClient.Method1(@event, @switch, @void, request);
             // End snippet
         }
 
         /// <summary>Snippet for Method1Async</summary>
         public async Task Method1ResourceNamesAsync()
         {
-            // Snippet: Method1Async(ResourceName, int, Enum, CallSettings)
-            // Additional: Method1Async(ResourceName, int, Enum, CancellationToken)
+            // Snippet: Method1Async(ResourceName, int, Enum, string, CallSettings)
+            // Additional: Method1Async(ResourceName, int, Enum, string, CancellationToken)
             // Create client
             KeywordsClient keywordsClient = await KeywordsClient.CreateAsync();
             // Initialize request argument(s)
             ResourceName @event = ResourceName.FromItem("[ITEM_ID]");
             int @switch = 0;
             Enum @void = Enum.Void;
+            string request = "";
             // Make the request
-            Response response = await keywordsClient.Method1Async(@event, @switch, @void);
+            Response response = await keywordsClient.Method1Async(@event, @switch, @void, request);
             // End snippet
         }
 

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.Tests/KeywordsClientTest.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.Tests/KeywordsClientTest.g.cs
@@ -35,6 +35,7 @@ namespace Testing.Keywords.Tests
                 EventAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
                 Switch = -1514770765,
                 Void = Enum.Foreach,
+                Request_ = "request873b5710",
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.Method1(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
@@ -53,6 +54,7 @@ namespace Testing.Keywords.Tests
                 EventAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
                 Switch = -1514770765,
                 Void = Enum.Foreach,
+                Request_ = "request873b5710",
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.Method1Async(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
@@ -73,11 +75,12 @@ namespace Testing.Keywords.Tests
                 EventAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
                 Switch = -1514770765,
                 Void = Enum.Foreach,
+                Request_ = "request873b5710",
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.Method1(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
             KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null);
-            Response response = client.Method1(request.Event, request.Switch, request.Void);
+            Response response = client.Method1(request.Event, request.Switch, request.Void, request.Request_);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
         }
@@ -91,13 +94,14 @@ namespace Testing.Keywords.Tests
                 EventAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
                 Switch = -1514770765,
                 Void = Enum.Foreach,
+                Request_ = "request873b5710",
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.Method1Async(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
             KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null);
-            Response responseCallSettings = await client.Method1Async(request.Event, request.Switch, request.Void, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
+            Response responseCallSettings = await client.Method1Async(request.Event, request.Switch, request.Void, request.Request_, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
-            Response responseCancellationToken = await client.Method1Async(request.Event, request.Switch, request.Void, st::CancellationToken.None);
+            Response responseCancellationToken = await client.Method1Async(request.Event, request.Switch, request.Void, request.Request_, st::CancellationToken.None);
             xunit::Assert.Same(expectedResponse, responseCancellationToken);
             mockGrpcClient.VerifyAll();
         }
@@ -111,11 +115,12 @@ namespace Testing.Keywords.Tests
                 EventAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
                 Switch = -1514770765,
                 Void = Enum.Foreach,
+                Request_ = "request873b5710",
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.Method1(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
             KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null);
-            Response response = client.Method1(request.EventAsResourceName, request.Switch, request.Void);
+            Response response = client.Method1(request.EventAsResourceName, request.Switch, request.Void, request.Request_);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
         }
@@ -129,13 +134,14 @@ namespace Testing.Keywords.Tests
                 EventAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
                 Switch = -1514770765,
                 Void = Enum.Foreach,
+                Request_ = "request873b5710",
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.Method1Async(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
             KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null);
-            Response responseCallSettings = await client.Method1Async(request.EventAsResourceName, request.Switch, request.Void, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
+            Response responseCallSettings = await client.Method1Async(request.EventAsResourceName, request.Switch, request.Void, request.Request_, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
-            Response responseCancellationToken = await client.Method1Async(request.EventAsResourceName, request.Switch, request.Void, st::CancellationToken.None);
+            Response responseCancellationToken = await client.Method1Async(request.EventAsResourceName, request.Switch, request.Void, request.Request_, st::CancellationToken.None);
             xunit::Assert.Same(expectedResponse, responseCancellationToken);
             mockGrpcClient.VerifyAll();
         }

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords/KeywordsClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords/KeywordsClient.g.cs
@@ -232,14 +232,17 @@ namespace Testing.Keywords
         /// </param>
         /// <param name="void">
         /// </param>
+        /// <param name="request">
+        /// </param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The RPC response.</returns>
-        public virtual Response Method1(string @event, int @switch, Enum @void, gaxgrpc::CallSettings callSettings = null) =>
+        public virtual Response Method1(string @event, int @switch, Enum @void, string request, gaxgrpc::CallSettings callSettings = null) =>
             Method1(new Request
             {
                 Event = @event ?? "",
                 Switch = @switch,
                 Void = @void,
+                Request_ = request ?? "",
             }, callSettings);
 
         /// <summary>
@@ -250,14 +253,17 @@ namespace Testing.Keywords
         /// </param>
         /// <param name="void">
         /// </param>
+        /// <param name="request">
+        /// </param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A Task containing the RPC response.</returns>
-        public virtual stt::Task<Response> Method1Async(string @event, int @switch, Enum @void, gaxgrpc::CallSettings callSettings = null) =>
+        public virtual stt::Task<Response> Method1Async(string @event, int @switch, Enum @void, string request, gaxgrpc::CallSettings callSettings = null) =>
             Method1Async(new Request
             {
                 Event = @event ?? "",
                 Switch = @switch,
                 Void = @void,
+                Request_ = request ?? "",
             }, callSettings);
 
         /// <summary>
@@ -268,10 +274,12 @@ namespace Testing.Keywords
         /// </param>
         /// <param name="void">
         /// </param>
+        /// <param name="request">
+        /// </param>
         /// <param name="cancellationToken">A <see cref="st::CancellationToken"/> to use for this RPC.</param>
         /// <returns>A Task containing the RPC response.</returns>
-        public virtual stt::Task<Response> Method1Async(string @event, int @switch, Enum @void, st::CancellationToken cancellationToken) =>
-            Method1Async(@event, @switch, @void, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+        public virtual stt::Task<Response> Method1Async(string @event, int @switch, Enum @void, string request, st::CancellationToken cancellationToken) =>
+            Method1Async(@event, @switch, @void, request, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// </summary>
@@ -281,14 +289,17 @@ namespace Testing.Keywords
         /// </param>
         /// <param name="void">
         /// </param>
+        /// <param name="request">
+        /// </param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The RPC response.</returns>
-        public virtual Response Method1(ResourceName @event, int @switch, Enum @void, gaxgrpc::CallSettings callSettings = null) =>
+        public virtual Response Method1(ResourceName @event, int @switch, Enum @void, string request, gaxgrpc::CallSettings callSettings = null) =>
             Method1(new Request
             {
                 EventAsResourceName = @event,
                 Switch = @switch,
                 Void = @void,
+                Request_ = request ?? "",
             }, callSettings);
 
         /// <summary>
@@ -299,14 +310,17 @@ namespace Testing.Keywords
         /// </param>
         /// <param name="void">
         /// </param>
+        /// <param name="request">
+        /// </param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A Task containing the RPC response.</returns>
-        public virtual stt::Task<Response> Method1Async(ResourceName @event, int @switch, Enum @void, gaxgrpc::CallSettings callSettings = null) =>
+        public virtual stt::Task<Response> Method1Async(ResourceName @event, int @switch, Enum @void, string request, gaxgrpc::CallSettings callSettings = null) =>
             Method1Async(new Request
             {
                 EventAsResourceName = @event,
                 Switch = @switch,
                 Void = @void,
+                Request_ = request ?? "",
             }, callSettings);
 
         /// <summary>
@@ -317,10 +331,12 @@ namespace Testing.Keywords
         /// </param>
         /// <param name="void">
         /// </param>
+        /// <param name="request">
+        /// </param>
         /// <param name="cancellationToken">A <see cref="st::CancellationToken"/> to use for this RPC.</param>
         /// <returns>A Task containing the RPC response.</returns>
-        public virtual stt::Task<Response> Method1Async(ResourceName @event, int @switch, Enum @void, st::CancellationToken cancellationToken) =>
-            Method1Async(@event, @switch, @void, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+        public virtual stt::Task<Response> Method1Async(ResourceName @event, int @switch, Enum @void, string request, st::CancellationToken cancellationToken) =>
+            Method1Async(@event, @switch, @void, request, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
         /// </summary>

--- a/Google.Api.Generator/ProtoUtils/ProtoExtensions.cs
+++ b/Google.Api.Generator/ProtoUtils/ProtoExtensions.cs
@@ -73,7 +73,11 @@ namespace Google.Api.Generator.ProtoUtils
                 .SkipWhile(string.IsNullOrWhiteSpace).Reverse().SkipWhile(string.IsNullOrWhiteSpace).Reverse() ??
                     Enumerable.Empty<string>();
 
-        public static string CSharpPropertyName(this FieldDescriptor field) => field.Name.ToUpperCamelCase();
+        public static string CSharpPropertyName(this FieldDescriptor field)
+        {
+            var result = field.Name.ToUpperCamelCase();
+            return field.ContainingType.Name == result ? $"{result}_" : result; // Matches protoc naming
+        }
 
         public static string CSharpFieldName(this FieldDescriptor field) => field.Name.ToLowerCamelCase();
 


### PR DESCRIPTION
Fixes #234