### PR TITLE
Update parent pattern handling to cope with singleton resources

### DIFF
--- a/Google.Api.Generator.Tests/ResourceDetailsTest.cs
+++ b/Google.Api.Generator.Tests/ResourceDetailsTest.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Google.Api.Generator.ProtoUtils;
+using System;
 using Xunit;
 
 namespace Google.Api.Generator.Tests
@@ -26,7 +27,15 @@ namespace Google.Api.Generator.Tests
         [InlineData("projects/{project}/singleton", "projects/{project}")]
         [InlineData("projects/{project}/singleton/publishers/{publisher}", "projects/{project}/singleton")]
         [InlineData("projects/{project}/singleton/publishers/{publisher}/books/{book}", "projects/{project}/singleton/publishers/{publisher}")]
-        public void ParentPattern(string pattern, string expectedParent) =>
+        public void ParentPattern_Valid(string pattern, string expectedParent) =>
             Assert.Equal(expectedParent, ResourceDetails.ParentPattern(pattern));
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("projects/{project}")]
+        [InlineData("projects")]
+        [InlineData("{bizarrePattern}")]
+        public void ParentPattern_Invalid(string pattern) =>
+            Assert.Throws<ArgumentException>(() => ResourceDetails.ParentPattern(pattern));
     }
 }

--- a/Google.Api.Generator.Tests/ResourceDetailsTest.cs
+++ b/Google.Api.Generator.Tests/ResourceDetailsTest.cs
@@ -1,0 +1,32 @@
+﻿// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Generator.ProtoUtils;
+using Xunit;
+
+namespace Google.Api.Generator.Tests
+{
+    public class ResourceDetailsTest
+    {
+        [Theory]
+        [InlineData("*", "*")]
+        [InlineData("projects/{project}/publishers/{publisher}", "projects/{project}")]
+        [InlineData("projects/{project}/publishers/{publisher}/books/{book}", "projects/{project}/publishers/{publisher}")]
+        [InlineData("projects/{project}/singleton", "projects/{project}")]
+        [InlineData("projects/{project}/singleton/publishers/{publisher}", "projects/{project}/singleton")]
+        [InlineData("projects/{project}/singleton/publishers/{publisher}/books/{book}", "projects/{project}/singleton/publishers/{publisher}")]
+        public void ParentPattern(string pattern, string expectedParent) =>
+            Assert.Equal(expectedParent, ResourceDetails.ParentPattern(pattern));
+    }
+}

--- a/Google.Api.Generator/ProtoUtils/ResourceDetails.cs
+++ b/Google.Api.Generator/ProtoUtils/ResourceDetails.cs
@@ -289,22 +289,22 @@ namespace Google.Api.Generator.ProtoUtils
                     throw new InvalidOperationException("type or child_type must be set.");
                 }
             }
+        }
 
-            string ParentPattern(string pattern)
+        // Note: this could be a local method within LoadResourceReference, but making it a regular
+        // internal method allows it to be unit tested.
+        internal static string ParentPattern(string pattern)
+        {
+            if (pattern == "*")
             {
-                if (pattern == "*")
-                {
-                    // Parent of wildcard is a wildcard.
-                    return "*";
-                }
-                var lastIndex = pattern.LastIndexOf('}');
-                var last2Index = pattern.LastIndexOf('}', startIndex: Math.Max(lastIndex - 1, 0));
-                if (lastIndex < 0 || last2Index < 0)
-                {
-                    throw new InvalidOperationException("Cannot create the parent of a single-piece resource name.");
-                }
-                return pattern.Substring(0, last2Index + 1);
+                // Parent of wildcard is a wildcard.
+                return "*";
             }
+            var segments = pattern.Split('/');
+            var lastSegment = segments.Last();
+            var segmentsToConsume = lastSegment.StartsWith("{") && lastSegment.EndsWith("}") ? 2 : 1;
+            var parentSegments = segments.Take(segments.Length - segmentsToConsume);
+            return string.Join('/', parentSegments);
         }
     }
 }

--- a/Google.Api.Generator/ProtoUtils/ResourceDetails.cs
+++ b/Google.Api.Generator/ProtoUtils/ResourceDetails.cs
@@ -303,7 +303,10 @@ namespace Google.Api.Generator.ProtoUtils
             var segments = pattern.Split('/');
             var lastSegment = segments.Last();
             var segmentsToConsume = lastSegment.StartsWith("{") && lastSegment.EndsWith("}") ? 2 : 1;
-            var parentSegments = segments.Take(segments.Length - segmentsToConsume);
+            int remainingSegments = segments.Length - segmentsToConsume;
+            // We must have at least one segment afterwards. (It would be very odd to have *only* one, but valid in a theoretical way.)
+            GaxPreconditions.CheckArgument(remainingSegments > 1, nameof(pattern), "Pattern '{0}' has no parent pattern", pattern);
+            var parentSegments = segments.Take(remainingSegments);
             return string.Join('/', parentSegments);
         }
     }


### PR DESCRIPTION
This changes the logic for "parent pattern" to be broadly:

- Determine the segments of the pattern by splitting on slash
- Remove either the last two segments (if the last segment is
  a parameter, e.g. "{project}") or just the last segment otherwise
- Join the remaining segments together again with a slash separator

(Note that I'm waiting for confirmation this is all correct from multiple sources before merging.)