### PR TITLE
Use explicit docs instead of inheritdoc in most places

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTests/Basic/Testing.Basic/BasicClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic/Testing.Basic/BasicClient.g.cs
@@ -78,7 +78,7 @@ namespace Testing.Basic
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<BasicClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override BasicClient Build()
         {
             BasicClient client = null;
@@ -86,7 +86,7 @@ namespace Testing.Basic
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<BasicClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<BasicClient> task = null;
@@ -108,16 +108,18 @@ namespace Testing.Basic
             return BasicClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => BasicClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => BasicClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => BasicClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/Google.Api.Generator.Tests/ProtoTests/ChildResource/Testing.ChildResource/ChildResourceResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ChildResource/Testing.ChildResource/ChildResourceResourceNames.g.cs
@@ -181,10 +181,11 @@ namespace Testing.ChildResource
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -195,7 +196,7 @@ namespace Testing.ChildResource
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -399,10 +400,11 @@ namespace Testing.ChildResource
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -413,7 +415,7 @@ namespace Testing.ChildResource
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -582,10 +584,11 @@ namespace Testing.ChildResource
         /// </summary>
         public string OrgId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -596,7 +599,7 @@ namespace Testing.ChildResource
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -772,10 +775,11 @@ namespace Testing.ChildResource
         /// </summary>
         public string DeptId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -786,7 +790,7 @@ namespace Testing.ChildResource
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -1074,10 +1078,11 @@ namespace Testing.ChildResource
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -1090,7 +1095,7 @@ namespace Testing.ChildResource
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -1378,10 +1383,11 @@ namespace Testing.ChildResource
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -1394,7 +1400,7 @@ namespace Testing.ChildResource
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -1621,10 +1627,11 @@ namespace Testing.ChildResource
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -1636,7 +1643,7 @@ namespace Testing.ChildResource
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -1861,10 +1868,11 @@ namespace Testing.ChildResource
         /// </summary>
         public string OverlapId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -1876,7 +1884,7 @@ namespace Testing.ChildResource
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -2175,10 +2183,11 @@ namespace Testing.ChildResource
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -2192,7 +2201,7 @@ namespace Testing.ChildResource
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -2522,10 +2531,11 @@ namespace Testing.ChildResource
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -2539,7 +2549,7 @@ namespace Testing.ChildResource
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated/DeprecatedClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated/DeprecatedClient.g.cs
@@ -117,7 +117,7 @@ namespace Testing.Deprecated
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DeprecatedClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override DeprecatedClient Build()
         {
             DeprecatedClient client = null;
@@ -125,7 +125,7 @@ namespace Testing.Deprecated
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<DeprecatedClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<DeprecatedClient> task = null;
@@ -147,16 +147,18 @@ namespace Testing.Deprecated
             return DeprecatedClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => DeprecatedClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => DeprecatedClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => DeprecatedClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords/KeywordsClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords/KeywordsClient.g.cs
@@ -91,7 +91,7 @@ namespace Testing.Keywords
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<KeywordsClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override KeywordsClient Build()
         {
             KeywordsClient client = null;
@@ -99,7 +99,7 @@ namespace Testing.Keywords
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<KeywordsClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<KeywordsClient> task = null;
@@ -121,16 +121,18 @@ namespace Testing.Keywords
             return KeywordsClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => KeywordsClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => KeywordsClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => KeywordsClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords/KeywordsResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords/KeywordsResourceNames.g.cs
@@ -182,10 +182,11 @@ namespace Testing.Keywords
         /// </summary>
         public string ItemId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -196,7 +197,7 @@ namespace Testing.Keywords
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro/LroResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro/LroResourceNames.g.cs
@@ -183,10 +183,11 @@ namespace Testing.Lro
         /// </summary>
         public string ItemId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -197,7 +198,7 @@ namespace Testing.Lro
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated/PaginatedResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated/PaginatedResourceNames.g.cs
@@ -183,10 +183,11 @@ namespace Testing.Paginated
         /// </summary>
         public string ItemId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -197,7 +198,7 @@ namespace Testing.Paginated
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator/ResourceNameSeparatorResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator/ResourceNameSeparatorResourceNames.g.cs
@@ -365,10 +365,11 @@ namespace Testing.ResourceNameSeparator
         /// </summary>
         public string ItemBId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -380,7 +381,7 @@ namespace Testing.ResourceNameSeparator
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames/ResourceNamesResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames/ResourceNamesResourceNames.g.cs
@@ -186,10 +186,11 @@ namespace Testing.ResourceNames
         /// </summary>
         public string ItemId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -200,7 +201,7 @@ namespace Testing.ResourceNames
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -389,10 +390,11 @@ namespace Testing.ResourceNames
         /// </summary>
         public string ItemId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -403,7 +405,7 @@ namespace Testing.ResourceNames
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -754,10 +756,11 @@ namespace Testing.ResourceNames
         /// </summary>
         public string ItemCId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -772,7 +775,7 @@ namespace Testing.ResourceNames
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/Google.Api.Generator.Tests/ProtoTests/ServerStreaming/Testing.ServerStreaming/ServerStreamingResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ServerStreaming/Testing.ServerStreaming/ServerStreamingResourceNames.g.cs
@@ -183,10 +183,11 @@ namespace Testing.ServerStreaming
         /// </summary>
         public string ItemId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -197,7 +198,7 @@ namespace Testing.ServerStreaming
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets/SnippetsResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets/SnippetsResourceNames.g.cs
@@ -197,10 +197,11 @@ namespace Testing.Snippets
         /// </summary>
         public string PartId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -211,7 +212,7 @@ namespace Testing.Snippets
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -464,10 +465,11 @@ namespace Testing.Snippets
         /// </summary>
         public string RootBId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -479,7 +481,7 @@ namespace Testing.Snippets
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -661,10 +663,11 @@ namespace Testing.Snippets
         /// </summary>
         public string ItemId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -675,7 +678,7 @@ namespace Testing.Snippets
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/Google.Api.Generator.Tests/ProtoTests/UnitTests/Testing.UnitTests/UnitTestsClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/UnitTests/Testing.UnitTests/UnitTestsClient.g.cs
@@ -112,7 +112,7 @@ namespace Testing.UnitTests
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<UnitTestsClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override UnitTestsClient Build()
         {
             UnitTestsClient client = null;
@@ -120,7 +120,7 @@ namespace Testing.UnitTests
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<UnitTestsClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<UnitTestsClient> task = null;
@@ -142,16 +142,18 @@ namespace Testing.UnitTests
             return UnitTestsClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => UnitTestsClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => UnitTestsClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => UnitTestsClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/Google.Api.Generator.Tests/ProtoTests/UnitTests/Testing.UnitTests/UnitTestsResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/UnitTests/Testing.UnitTests/UnitTestsResourceNames.g.cs
@@ -197,10 +197,11 @@ namespace Testing.UnitTests
         /// </summary>
         public string PartId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -211,7 +212,7 @@ namespace Testing.UnitTests
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -464,10 +465,11 @@ namespace Testing.UnitTests
         /// </summary>
         public string RootBId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -479,7 +481,7 @@ namespace Testing.UnitTests
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/Google.Api.Generator/Generation/ResourceNamesGenerator.cs
+++ b/Google.Api.Generator/Generation/ResourceNamesGenerator.cs
@@ -423,7 +423,7 @@ namespace Google.Api.Generator.Generation
 
             private PropertyDeclarationSyntax IsKnownPattern() => Property(Public, _ctx.Type<bool>(), nameof(IResourceName.IsKnownPattern))
                 .WithGetBody(ResourceType().NotEqualTo(_ctx.Type(ResourceNameTypeTyp).Access("Unparsed")))
-                .WithXmlDoc(XmlDoc.InheritDoc);
+                .WithXmlDoc(XmlDoc.Summary("Whether this instance contains a resource name with a known pattern."));
 
             private new MethodDeclarationSyntax ToString()
             {
@@ -435,7 +435,10 @@ namespace Google.Api.Generator.Generation
                     .WithBody(
                         Switch(ResourceType())(switchCases.ToArray()).WithDefault(
                             Throw(New(_ctx.Type<InvalidOperationException>())("Unrecognized resource-type."))))
-                    .WithXmlDoc(XmlDoc.InheritDoc);
+                    .WithXmlDoc(
+                        XmlDoc.Summary("The string representation of the resource name."),
+                        XmlDoc.Returns("The string representation of the resource name.")
+                    );
 
                 static IEnumerable<object> ExpandArgs(ResourceNamesGenerator.PatternDetails pattern)
                 {
@@ -459,7 +462,7 @@ namespace Google.Api.Generator.Generation
             {
                 return Method(Public | Override, _ctx.Type<int>(), nameof(object.GetHashCode))()
                     .WithBody(Return(This.Call(ToString())().Call(nameof(object.GetHashCode))()))
-                    .WithXmlDoc(XmlDoc.InheritDoc);
+                    .WithXmlDoc(XmlDoc.Summary("Returns a hash code for this resource name."));
             }
 
             private MethodDeclarationSyntax Equals()

--- a/Google.Api.Generator/Generation/ServiceBuilderCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceBuilderCodeGenerator.cs
@@ -82,7 +82,7 @@ namespace Google.Api.Generator.Generation
                     client.WithInitializer(Null),
                     This.Call("InterceptBuild")(Ref(client)),
                     Return(client.NullCoalesce(This.Call("BuildImpl")())))
-                .WithXmlDoc(XmlDoc.InheritDoc);
+                .WithXmlDoc(XmlDoc.Summary("Builds the resulting client."));
         }
 
         private MethodDeclarationSyntax BuildAsync()
@@ -94,7 +94,7 @@ namespace Google.Api.Generator.Generation
                     task.WithInitializer(Null),
                     This.Call("InterceptBuildAsync")(cancellationToken, Ref(task)),
                     Return(task.NullCoalesce(This.Call("BuildAsyncImpl")(cancellationToken))))
-                .WithXmlDoc(XmlDoc.InheritDoc);
+                .WithXmlDoc(XmlDoc.Summary("Builds the resulting client asynchronously."));
         }
 
         private MethodDeclarationSyntax BuildImpl()
@@ -121,21 +121,21 @@ namespace Google.Api.Generator.Generation
         private MethodDeclarationSyntax GetDefaultEndpoint() =>
             Method(Protected|Override, _ctx.Type<string>(), "GetDefaultEndpoint")()
                 .WithBody(_ctx.Type(_svc.ClientAbstractTyp).Access("DefaultEndpoint"))
-                .WithXmlDoc(XmlDoc.InheritDoc);
+                .WithXmlDoc(XmlDoc.Summary("Returns the endpoint for this builder type, used if no endpoint is otherwise specified."));
 
         private MethodDeclarationSyntax GetDefaultScopes() =>
             Method(Protected | Override, _ctx.Type<IReadOnlyList<string>>(), "GetDefaultScopes")()
                 .WithBody(_ctx.Type(_svc.ClientAbstractTyp).Access("DefaultScopes"))
-                .WithXmlDoc(XmlDoc.InheritDoc);
+                .WithXmlDoc(XmlDoc.Summary("Returns the default scopes for this builder type, used if no scopes are otherwise specified."));
 
         private MethodDeclarationSyntax GetChannelPool() =>
             Method(Protected | Override, _ctx.Type<ChannelPool>(), "GetChannelPool")()
                 .WithBody(_ctx.Type(_svc.ClientAbstractTyp).Access("ChannelPool"))
-                .WithXmlDoc(XmlDoc.InheritDoc);
+                .WithXmlDoc(XmlDoc.Summary("Returns the channel pool to use when no other options are specified."));
 
         private PropertyDeclarationSyntax DefaultGrpcAdapter() =>
             Property(Protected | Override, _ctx.Type<GrpcAdapter>(), "DefaultGrpcAdapter")
                 .WithGetBody(_ctx.Type<GrpcCoreAdapter>().Access(nameof(GrpcCoreAdapter.Instance)))
-                .WithXmlDoc(XmlDoc.InheritDoc);
+                .WithXmlDoc(XmlDoc.Summary("Returns the default ", _ctx.Type<GrpcAdapter>(), "to use if not otherwise specified."));
     }
 }


### PR DESCRIPTION
We still use inheritdoc for ==, != and Equals - those don't seem to
cause docfx issues, for whatever reason.

The documentation isn't always *exactly* what would be inherited -
I've simplified it in a couple of places - but it's close enough.

Fixes #248.