### PR TITLE
Split Google.Api.Generator into two projects

### DIFF
--- a/Generator.sln
+++ b/Generator.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Api.Generator", "Goo
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Api.Generator.Tests", "Google.Api.Generator.Tests\Google.Api.Generator.Tests.csproj", "{7F2B20B6-4F23-49D7-9D12-EC767631E5D8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Api.Generator.Utils", "Google.Api.Generator.Utils\Google.Api.Generator.Utils.csproj", "{5C1198FB-4BF1-4A8A-9CCC-94FF22D57BDC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{7F2B20B6-4F23-49D7-9D12-EC767631E5D8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7F2B20B6-4F23-49D7-9D12-EC767631E5D8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7F2B20B6-4F23-49D7-9D12-EC767631E5D8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5C1198FB-4BF1-4A8A-9CCC-94FF22D57BDC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5C1198FB-4BF1-4A8A-9CCC-94FF22D57BDC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5C1198FB-4BF1-4A8A-9CCC-94FF22D57BDC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5C1198FB-4BF1-4A8A-9CCC-94FF22D57BDC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Google.Api.Generator.Tests/ResourcePatternTest.cs
+++ b/Google.Api.Generator.Tests/ResourcePatternTest.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Api.Generator.Utils;
+using Google.Api.Generator.ProtoUtils;
 using System;
 using Xunit;
 

--- a/Google.Api.Generator.Tests/WhitespaceFormatterTest.cs
+++ b/Google.Api.Generator.Tests/WhitespaceFormatterTest.cs
@@ -26,7 +26,7 @@
 // into multiple source files, and/or multiple tests.
 
 // TEST_SOURCE_START
-using Google.Api.Generator.Formatting;
+using Google.Api.Generator.Utils.Formatting;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using System;

--- a/Google.Api.Generator.Tests/XmlDocSplitterTest.cs
+++ b/Google.Api.Generator.Tests/XmlDocSplitterTest.cs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Api.Generator.Formatting;
-using Google.Api.Generator.RoslynUtils;
+using Google.Api.Generator.Utils.Formatting;
+using Google.Api.Generator.Utils.Roslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;

--- a/Google.Api.Generator.Utils/Disposable.cs
+++ b/Google.Api.Generator.Utils/Disposable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Google Inc. All Rights Reserved.
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,12 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Google.Api.Generator.RoslynUtils
-{
-    internal static class PragmaWarnings
-    {
-        public const string AnnotationKind = "pragma_warning";
+using System;
 
-        public const string Obsolete = "CS0612";
+namespace Google.Api.Generator.Utils
+{
+    /// <summary>
+    /// A general implementation of IDisposable that allows an arbitrary
+    /// action to be executed on disposal.
+    /// </summary>
+    public class Disposable : IDisposable
+    {
+        public Disposable(Action action) => _action = action;
+        private readonly Action _action;
+        public void Dispose() => _action();
     }
 }

--- a/Google.Api.Generator.Utils/Formatting/CodeFormatter.cs
+++ b/Google.Api.Generator.Utils/Formatting/CodeFormatter.cs
@@ -12,18 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace Google.Api.Generator.Utils
+namespace Google.Api.Generator.Utils.Formatting
 {
-    /// <summary>
-    /// A general implementation of IDisposable that allows an arbitrary
-    /// action to be executed on disposal.
-    /// </summary>
-    internal class Disposable : IDisposable
+    public static class CodeFormatter
     {
-        public Disposable(Action action) => _action = action;
-        private readonly Action _action;
-        public void Dispose() => _action();
+        public static CompilationUnitSyntax Format(CompilationUnitSyntax code)
+        {
+            var whitespace = new WhitespaceFormatter(maxLineLength: 120);
+            code = (CompilationUnitSyntax)whitespace.Visit(code);
+            code = PragmaWarningFormatter.Visit(code);
+            // TODO: Line length formatting
+            return code;
+        }
     }
 }

--- a/Google.Api.Generator.Utils/Formatting/PragmaWarningFormatter.cs
+++ b/Google.Api.Generator.Utils/Formatting/PragmaWarningFormatter.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Api.Generator.RoslynUtils;
+using Google.Api.Generator.Utils.Roslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -21,9 +21,9 @@ using System.Collections.Generic;
 using System.Linq;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
-namespace Google.Api.Generator.Formatting
+namespace Google.Api.Generator.Utils.Formatting
 {
-    internal static class PragmaWarningFormatter
+    public static class PragmaWarningFormatter
     {
         private class PragmaVisitor : CSharpSyntaxRewriter
         {

--- a/Google.Api.Generator.Utils/Formatting/WhitespaceFormatter.cs
+++ b/Google.Api.Generator.Utils/Formatting/WhitespaceFormatter.cs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Api.Generator.RoslynUtils;
-using Google.Api.Generator.Utils;
+using Google.Api.Generator.Utils.Roslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -22,9 +21,9 @@ using System.Collections.Generic;
 using System.Linq;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
-namespace Google.Api.Generator.Formatting
+namespace Google.Api.Generator.Utils.Formatting
 {
-    internal static class WhitespaceFormatterNewLine
+    public static class WhitespaceFormatterNewLine
     {
         public static SyntaxTrivia NewLine { get; } = SyntaxTrivia(SyntaxKind.EndOfLineTrivia, Environment.NewLine);
 
@@ -35,7 +34,7 @@ namespace Google.Api.Generator.Formatting
             token.WithTrailingTrivia(Enumerable.Repeat(NewLine, count));
     }
 
-    internal class WhitespaceFormatter : CSharpSyntaxRewriter
+    public class WhitespaceFormatter : CSharpSyntaxRewriter
     {
         private static readonly SyntaxToken s_commaSpace = Token(SyntaxKind.CommaToken).WithTrailingSpace();
         private static IEnumerable<SyntaxToken> CommaSpaces(int count) => Enumerable.Repeat(s_commaSpace, Math.Max(0, count));

--- a/Google.Api.Generator.Utils/Formatting/XmlDocSplitter.cs
+++ b/Google.Api.Generator.Utils/Formatting/XmlDocSplitter.cs
@@ -15,7 +15,7 @@
 // This is not a general-purpose C# code formatter.
 // It makes various assumptions about the Roslyn input.
 
-using Google.Api.Generator.RoslynUtils;
+using Google.Api.Generator.Utils.Roslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -24,9 +24,9 @@ using System.Collections.Generic;
 using System.Linq;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
-namespace Google.Api.Generator.Formatting
+namespace Google.Api.Generator.Utils.Formatting
 {
-    internal class XmlDocSplitter
+    public class XmlDocSplitter
     {
         private static readonly XmlElementStartTagSyntax s_missingStartTag = XmlElementStartTag(
             MissingToken(SyntaxKind.LessThanToken), XmlName(MissingToken(SyntaxKind.IdentifierToken)), List<XmlAttributeSyntax>(), MissingToken(SyntaxKind.GreaterThanToken));

--- a/Google.Api.Generator.Utils/Google.Api.Generator.Utils.csproj
+++ b/Google.Api.Generator.Utils/Google.Api.Generator.Utils.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
+  </ItemGroup>
+</Project>

--- a/Google.Api.Generator.Utils/Roslyn/ArgModifier.cs
+++ b/Google.Api.Generator.Utils/Roslyn/ArgModifier.cs
@@ -12,13 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Google.Api.Generator.RoslynUtils
+namespace Google.Api.Generator.Utils.Roslyn
 {
-    internal class ObjectInitExpr
+    public class ArgModifier
     {
-        public ObjectInitExpr(string propertyName, object code, bool isDeprecated = false) => (PropertyName, Code, IsDeprecated) = (propertyName, code, isDeprecated);
-        public string PropertyName { get; }
-        public object Code { get; }
-        public bool IsDeprecated { get; }
+        public enum Type
+        {
+            Ref,
+            Out,
+        }
+
+        public ArgModifier(Type type, object arg) => (ModType, Arg) = (type, arg);
+
+        public Type ModType { get; }
+        public object Arg { get; }
     }
 }

--- a/Google.Api.Generator.Utils/Roslyn/Keywords.cs
+++ b/Google.Api.Generator.Utils/Roslyn/Keywords.cs
@@ -1,11 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Text;
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-namespace Google.Api.Generator.RoslynUtils
+using System.Collections.Immutable;
+
+namespace Google.Api.Generator.Utils.Roslyn
 {
-    internal static class Keywords
+    public static class Keywords
     {
         // Taken from: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/
         private static IImmutableSet<string> s_keywords = ImmutableHashSet.Create(

--- a/Google.Api.Generator.Utils/Roslyn/Modifier.cs
+++ b/Google.Api.Generator.Utils/Roslyn/Modifier.cs
@@ -17,10 +17,10 @@ using Microsoft.CodeAnalysis.CSharp;
 using System;
 using System.Collections.Generic;
 
-namespace Google.Api.Generator.RoslynUtils
+namespace Google.Api.Generator.Utils.Roslyn
 {
     [Flags]
-    internal enum Modifier
+    public enum Modifier
     {
         DontCare = 0,
         None = 0,
@@ -39,7 +39,7 @@ namespace Google.Api.Generator.RoslynUtils
         Protected = 0x800,
     }
 
-    internal static class ModifierExtensions
+    public static class ModifierExtensions
     {
         private static readonly SyntaxToken s_publicToken = SyntaxFactory.Token(SyntaxKind.PublicKeyword);
         private static readonly SyntaxToken s_abstractToken = SyntaxFactory.Token(SyntaxKind.AbstractKeyword);

--- a/Google.Api.Generator.Utils/Roslyn/ObjectInitExpr.cs
+++ b/Google.Api.Generator.Utils/Roslyn/ObjectInitExpr.cs
@@ -12,19 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Google.Api.Generator.RoslynUtils
+namespace Google.Api.Generator.Utils.Roslyn
 {
-    class ArgModifier
+    public class ObjectInitExpr
     {
-        public enum Type
-        {
-            Ref,
-            Out,
-        }
-
-        public ArgModifier(Type type, object arg) => (ModType, Arg) = (type, arg);
-
-        public Type ModType { get; }
-        public object Arg { get; }
+        public ObjectInitExpr(string propertyName, object code, bool isDeprecated = false) => (PropertyName, Code, IsDeprecated) = (propertyName, code, isDeprecated);
+        public string PropertyName { get; }
+        public object Code { get; }
+        public bool IsDeprecated { get; }
     }
 }

--- a/Google.Api.Generator.Utils/Roslyn/PragmaWarnings.cs
+++ b/Google.Api.Generator.Utils/Roslyn/PragmaWarnings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 Google Inc. All Rights Reserved.
+﻿// Copyright 2020 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,19 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-
-namespace Google.Api.Generator.Formatting
+namespace Google.Api.Generator.Utils.Roslyn
 {
-    internal static class CodeFormatter
+    public static class PragmaWarnings
     {
-        public static CompilationUnitSyntax Format(CompilationUnitSyntax code)
-        {
-            var whitespace = new WhitespaceFormatter(maxLineLength: 120);
-            code = (CompilationUnitSyntax)whitespace.Visit(code);
-            code = PragmaWarningFormatter.Visit(code);
-            // TODO: Line length formatting
-            return code;
-        }
+        public const string AnnotationKind = "pragma_warning";
+
+        public const string Obsolete = "CS0612";
     }
 }

--- a/Google.Api.Generator.Utils/Roslyn/RoslynBuilder.cs
+++ b/Google.Api.Generator.Utils/Roslyn/RoslynBuilder.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Api.Generator.Utils;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -20,15 +19,15 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using static Google.Api.Generator.RoslynUtils.RoslynConverters;
+using static Google.Api.Generator.Utils.Roslyn.RoslynConverters;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
-namespace Google.Api.Generator.RoslynUtils
+namespace Google.Api.Generator.Utils.Roslyn
 {
     /// <summary>
     /// Helper methods to simplify constructing Roslyn syntax.
     /// </summary>
-    internal static class RoslynBuilder
+    public static class RoslynBuilder
     {
         private static readonly SyntaxToken s_semicolonToken = Token(SyntaxKind.SemicolonToken);
 

--- a/Google.Api.Generator.Utils/Roslyn/RoslynConverters.cs
+++ b/Google.Api.Generator.Utils/Roslyn/RoslynConverters.cs
@@ -22,12 +22,12 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
-namespace Google.Api.Generator.RoslynUtils
+namespace Google.Api.Generator.Utils.Roslyn
 {
     /// <summary>
     /// Converters between .NET objects and Roslyn types.
     /// </summary>
-    internal static class RoslynConverters
+    public static class RoslynConverters
     {
         public static IEnumerable<ExpressionSyntax> ToExpressions(object o) => o switch
         {

--- a/Google.Api.Generator.Utils/Roslyn/RoslynExtensions.cs
+++ b/Google.Api.Generator.Utils/Roslyn/RoslynExtensions.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Api.Generator.Utils;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -20,12 +19,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using static Google.Api.Generator.RoslynUtils.RoslynConverters;
+using static Google.Api.Generator.Utils.Roslyn.RoslynConverters;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
-namespace Google.Api.Generator.RoslynUtils
+namespace Google.Api.Generator.Utils.Roslyn
 {
-    internal static class RoslynExtensions
+    public static class RoslynExtensions
     {
         private static readonly SyntaxToken s_semicolonToken = Token(SyntaxKind.SemicolonToken);
 

--- a/Google.Api.Generator.Utils/Roslyn/XmlDoc.cs
+++ b/Google.Api.Generator.Utils/Roslyn/XmlDoc.cs
@@ -21,12 +21,12 @@ using System.Globalization;
 using System.Linq;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
-namespace Google.Api.Generator.RoslynUtils
+namespace Google.Api.Generator.Utils.Roslyn
 {
     /// <summary>
     /// Helper methods to assist with creating XmlDoc elements.
     /// </summary>
-    internal static class XmlDoc
+    public static class XmlDoc
     {
         public static class Annotations
         {

--- a/Google.Api.Generator.Utils/SystemExtensions.cs
+++ b/Google.Api.Generator.Utils/SystemExtensions.cs
@@ -17,7 +17,7 @@ using System.Text;
 
 namespace Google.Api.Generator.Utils
 {
-    internal static class SystemExtensions
+    public static class SystemExtensions
     {
         private static char MaybeForceCase(char c, bool? toUpper) =>
             toUpper is bool upper ? upper ? char.ToUpperInvariant(c) : char.ToLowerInvariant(c) : c;

--- a/Google.Api.Generator.Utils/Typ.cs
+++ b/Google.Api.Generator.Utils/Typ.cs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Api.Generator.ProtoUtils;
-using Google.Protobuf;
-using Google.Protobuf.Reflection;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
@@ -27,7 +24,7 @@ namespace Google.Api.Generator.Utils
     /// The name "Typ" is delibrately concise as this type is used extensively
     /// throughout the rest of the code.
     /// </summary>
-    internal abstract class Typ : IEquatable<Typ>
+    public abstract class Typ : IEquatable<Typ>
     {
         public sealed class VoidTyp : Typ
         {
@@ -109,30 +106,6 @@ namespace Google.Api.Generator.Utils
             public override string Name => null;
         }
 
-        private static readonly IReadOnlyDictionary<string, Typ> s_wrapperTypes = new Dictionary<string, Typ>
-        {
-            { "google.protobuf.BoolValue", Of<bool?>() },
-            { "google.protobuf.Int32Value", Of<int?>() },
-            { "google.protobuf.UInt32Value", Of<uint?>() },
-            { "google.protobuf.Int64Value", Of<long?>() },
-            { "google.protobuf.UInt64Value", Of<ulong?>() },
-            { "google.protobuf.FloatValue", Of<float?>() },
-            { "google.protobuf.DoubleValue", Of<double?>() },
-            { "google.protobuf.StringValue", Of<string>() },
-            { "google.protobuf.BytesValue", Of<ByteString>() },
-        };
-
-        public static bool IsWrapperType(FieldDescriptor field)
-        {
-            switch (field.FieldType)
-            {
-                case FieldType.Message:
-                    return s_wrapperTypes.ContainsKey(field.MessageType.FullName);
-                default:
-                    return false;
-            }
-        }
-
         public static Typ Void { get; } = new VoidTyp();
 
         public static Typ Of<T>() => Of(typeof(T));
@@ -144,94 +117,6 @@ namespace Google.Api.Generator.Utils
         public static Typ Generic(System.Type genericDef, params Typ[] typeArgs) => new FromGeneric(Of(genericDef), typeArgs);
         public static Typ.GenericParameter GenericParam(string name) => new Typ.GenericParameter(name);
         public static Typ.Special ClassConstraint { get; } = new Special(Special.Type.ClassConstraint);
-
-        public static Typ Of(MessageDescriptor desc)
-        {
-            if (s_wrapperTypes.TryGetValue(desc.FullName, out var wkt))
-            {
-                return wkt;
-            }
-            var ns = desc.File.CSharpNamespace();
-            var isDeprecated = desc.IsDeprecated();
-            var decls = new List<MessageDescriptor>();
-            do
-            {
-                decls.Add(desc);
-                desc = desc.ContainingType;
-            } while (desc != null);
-            decls.Reverse();
-            var typ = Manual(ns, decls[0].Name, isDeprecated: isDeprecated);
-            foreach (var decl in decls.Skip(1))
-            {
-                typ = Nested(Nested(typ, "Types"), decl.Name);
-            }
-            return typ;
-        }
-
-        public static Typ Of(EnumDescriptor desc) => desc.ContainingType == null ?
-            Manual(desc.File.CSharpNamespace(), desc.Name, isEnum: true) :
-            Nested(Nested(Of(desc.ContainingType), "Types"), desc.Name, isEnum: true);
-
-        public static Typ Of(FieldDescriptor desc, bool? forceRepeated = null)
-        {
-            if (desc.IsMap)
-            {
-                if (forceRepeated != null)
-                {
-                    throw new InvalidOperationException("Cannot force repeated on a map field.");
-                }
-                // A map is a repeated message with key and value fields.
-                var kv = desc.MessageType.Fields.InFieldNumberOrder();
-                return Generic(typeof(IDictionary<,>), Of(kv[0]), Of(kv[1]));
-            }
-            // See https://developers.google.com/protocol-buffers/docs/proto3#scalar
-            // Switch cases are ordered as in this doc. Please do not re-order.
-            if (forceRepeated ?? desc.IsRepeated)
-            {
-                switch (desc.FieldType)
-                {
-                    case FieldType.Double: return Of<IEnumerable<double>>();
-                    case FieldType.Float: return Of<IEnumerable<float>>();
-                    case FieldType.Int32: return Of<IEnumerable<int>>();
-                    case FieldType.Int64: return Of<IEnumerable<long>>();
-                    case FieldType.UInt32: return Of<IEnumerable<uint>>();
-                    case FieldType.UInt64: return Of<IEnumerable<ulong>>();
-                    case FieldType.SInt32: return Of<IEnumerable<int>>();
-                    case FieldType.SInt64: return Of<IEnumerable<long>>();
-                    case FieldType.Fixed32: return Of<IEnumerable<uint>>();
-                    case FieldType.Fixed64: return Of<IEnumerable<ulong>>();
-                    case FieldType.SFixed32: return Of<IEnumerable<int>>();
-                    case FieldType.SFixed64: return Of<IEnumerable<long>>();
-                    case FieldType.Bool: return Of<IEnumerable<bool>>();
-                    case FieldType.String: return Of<IEnumerable<string>>();
-                    case FieldType.Bytes: return Of<IEnumerable<ByteString>>();
-                    case FieldType.Message: return Generic(typeof(IEnumerable<>), Of(desc.MessageType));
-                    case FieldType.Enum: return Generic(typeof(IEnumerable<>), Of(desc.EnumType));
-                    default: throw new NotSupportedException($"Cannot get repeated Typ of: {desc.FieldType}");
-                }
-            }
-            switch (desc.FieldType)
-            {
-                case FieldType.Double: return Of<double>();
-                case FieldType.Float: return Of<float>();
-                case FieldType.Int32: return Of<int>();
-                case FieldType.Int64: return Of<long>();
-                case FieldType.UInt32: return Of<uint>();
-                case FieldType.UInt64: return Of<ulong>();
-                case FieldType.SInt32: return Of<int>();
-                case FieldType.SInt64: return Of<long>();
-                case FieldType.Fixed32: return Of<uint>();
-                case FieldType.Fixed64: return Of<ulong>();
-                case FieldType.SFixed32: return Of<int>();
-                case FieldType.SFixed64: return Of<long>();
-                case FieldType.Bool: return Of<bool>();
-                case FieldType.String: return Of<string>();
-                case FieldType.Bytes: return Of<ByteString>();
-                case FieldType.Message: return Of(desc.MessageType);
-                case FieldType.Enum: return Of(desc.EnumType);
-                default: throw new NotSupportedException($"Cannot get Typ of: {desc.FieldType}");
-            }
-        }
 
         /// <summary>The namespace of this typ.</summary>
         public abstract string Namespace { get; }

--- a/Google.Api.Generator/CodeGenerator.cs
+++ b/Google.Api.Generator/CodeGenerator.cs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 using Google.Api.Gax;
-using Google.Api.Generator.Formatting;
+using Google.Api.Generator.Utils.Formatting;
 using Google.Api.Generator.Generation;
 using Google.Api.Generator.ProtoUtils;
 using Google.Api.Generator.Utils;

--- a/Google.Api.Generator/Generation/MethodDetails.cs
+++ b/Google.Api.Generator/Generation/MethodDetails.cs
@@ -58,7 +58,7 @@ namespace Google.Api.Generator.Generation
             public Paginated(ServiceDetails svc, MethodDescriptor desc,
                 FieldDescriptor responseResourceField, int pageSizeFieldNumber, int pageTokenFieldNumber) : base(svc, desc)
             {
-                ResourceTyp = Typ.Of(responseResourceField, forceRepeated: false);
+                ResourceTyp = ProtoTyp.Of(responseResourceField, forceRepeated: false);
                 ApiCallTyp = Typ.Generic(typeof(ApiCall<,>), RequestTyp, ResponseTyp);
                 SyncReturnTyp = Typ.Generic(typeof(PagedEnumerable<,>), ResponseTyp, ResourceTyp);
                 AsyncReturnTyp = Typ.Generic(typeof(PagedAsyncEnumerable<,>), ResponseTyp, ResourceTyp);
@@ -103,8 +103,8 @@ namespace Google.Api.Generator.Generation
                     throw new InvalidOperationException(
                         $"Response-type and Metadata-type must both exist in method '{desc.FullName}': '{lroData.ResponseType}', '{lroData.MetadataType}'.");
                 }
-                OperationResponseTyp = Typ.Of(responseTypeMsg);
-                OperationMetadataTyp = Typ.Of(metadataTypeMsg);
+                OperationResponseTyp = ProtoTyp.Of(responseTypeMsg);
+                OperationMetadataTyp = ProtoTyp.Of(metadataTypeMsg);
                 SyncReturnTyp = Typ.Generic(typeof(Operation<,>), OperationResponseTyp, OperationMetadataTyp);
                 LroSettingsName = $"{desc.Name}OperationsSettings";
                 LroClientName = $"{desc.Name}OperationsClient";
@@ -182,10 +182,10 @@ namespace Google.Api.Generator.Generation
                         return (fieldDesc.FieldType == FieldType.Message ? fieldDesc.MessageType : null, acc.result.Add(fieldDesc));
                     }, acc => acc.result);
                     var lastDesc = Descs.Last();
-                    Typ = Typ.Of(lastDesc);
+                    Typ = ProtoTyp.Of(lastDesc);
                     IsMap = lastDesc.IsMap;
                     IsRepeated = lastDesc.IsRepeated;
-                    IsWrapperType = Typ.IsWrapperType(lastDesc);
+                    IsWrapperType = ProtoTyp.IsWrapperType(lastDesc);
                     IsRequired = lastDesc.SafeGetOption(FieldBehaviorExtensions.FieldBehavior).Any(x => x == FieldBehavior.Required);
                     ParameterName = lastDesc.CSharpFieldName();
                     PropertyName = lastDesc.CSharpPropertyName();
@@ -284,8 +284,8 @@ namespace Google.Api.Generator.Generation
             AsyncSnippetMethodName = $"{desc.Name}RequestObjectAsync";
             AsyncTestMethodName = $"{desc.Name}RequestObjectAsync";
             SettingsName = $"{desc.Name}Settings";
-            RequestTyp = Typ.Of(desc.InputType);
-            ResponseTyp = Typ.Of(desc.OutputType);
+            RequestTyp = ProtoTyp.Of(desc.InputType);
+            ResponseTyp = ProtoTyp.Of(desc.OutputType);
             ApiCallFieldName = $"_call{desc.Name}";
             ModifyApiCallMethodName = $"Modify_{desc.Name}ApiCall";
             ModifyRequestMethodName = $"Modify_{RequestTyp.Name}";

--- a/Google.Api.Generator/Generation/ResourceNamesGenerator.cs
+++ b/Google.Api.Generator/Generation/ResourceNamesGenerator.cs
@@ -14,7 +14,7 @@
 
 using Google.Api.Gax;
 using Google.Api.Generator.ProtoUtils;
-using Google.Api.Generator.RoslynUtils;
+using Google.Api.Generator.Utils.Roslyn;
 using Google.Api.Generator.Utils;
 using Google.Protobuf.Reflection;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -22,8 +22,8 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using static Google.Api.Generator.RoslynUtils.Modifier;
-using static Google.Api.Generator.RoslynUtils.RoslynBuilder;
+using static Google.Api.Generator.Utils.Roslyn.Modifier;
+using static Google.Api.Generator.Utils.Roslyn.RoslynBuilder;
 
 namespace Google.Api.Generator.Generation
 {
@@ -523,7 +523,7 @@ namespace Google.Api.Generator.Generation
                     .ToList();
                 if (resources.Any())
                 {
-                    var cls = Class(Public | Partial, Typ.Of(msg));
+                    var cls = Class(Public | Partial, ProtoTyp.Of(msg));
                     using (_ctx.InClass(cls))
                     {
                         _ctx.RegisterClassMemberNames(resources

--- a/Google.Api.Generator/Generation/ServiceAbstractClientClassCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceAbstractClientClassCodeGenerator.cs
@@ -14,7 +14,7 @@
 
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
-using Google.Api.Generator.RoslynUtils;
+using Google.Api.Generator.Utils.Roslyn;
 using Google.Api.Generator.Utils;
 using Grpc.Core;
 using Grpc.Core.Interceptors;
@@ -25,8 +25,8 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using static Google.Api.Generator.RoslynUtils.Modifier;
-using static Google.Api.Generator.RoslynUtils.RoslynBuilder;
+using static Google.Api.Generator.Utils.Roslyn.Modifier;
+using static Google.Api.Generator.Utils.Roslyn.RoslynBuilder;
 
 namespace Google.Api.Generator.Generation
 {

--- a/Google.Api.Generator/Generation/ServiceBuilderCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceBuilderCodeGenerator.cs
@@ -14,7 +14,7 @@
 
 using Google.Api.Gax.Grpc;
 using Google.Api.Gax.Grpc.GrpcCore;
-using Google.Api.Generator.RoslynUtils;
+using Google.Api.Generator.Utils.Roslyn;
 using Google.Api.Generator.Utils;
 using Grpc.Core;
 using Microsoft.CodeAnalysis.CSharp;
@@ -22,8 +22,8 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using static Google.Api.Generator.RoslynUtils.Modifier;
-using static Google.Api.Generator.RoslynUtils.RoslynBuilder;
+using static Google.Api.Generator.Utils.Roslyn.Modifier;
+using static Google.Api.Generator.Utils.Roslyn.RoslynBuilder;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Google.Api.Generator.Generation

--- a/Google.Api.Generator/Generation/ServiceCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceCodeGenerator.cs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 using Google.Api.Gax.Grpc;
-using Google.Api.Generator.RoslynUtils;
+using Google.Api.Generator.Utils.Roslyn;
 using Google.Api.Generator.Utils;
 using Google.LongRunning;
 using Grpc.ServiceConfig;
@@ -22,8 +22,8 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using static Google.Api.Generator.RoslynUtils.Modifier;
-using static Google.Api.Generator.RoslynUtils.RoslynBuilder;
+using static Google.Api.Generator.Utils.Roslyn.Modifier;
+using static Google.Api.Generator.Utils.Roslyn.RoslynBuilder;
 
 namespace Google.Api.Generator.Generation
 {

--- a/Google.Api.Generator/Generation/ServiceImplClientClassGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceImplClientClassGenerator.cs
@@ -14,7 +14,7 @@
 
 using Google.Api.Gax.Grpc;
 using Google.Api.Generator.ProtoUtils;
-using Google.Api.Generator.RoslynUtils;
+using Google.Api.Generator.Utils.Roslyn;
 using Google.Api.Generator.Utils;
 using Google.LongRunning;
 using Google.Protobuf;
@@ -24,8 +24,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using static Google.Api.Generator.RoslynUtils.Modifier;
-using static Google.Api.Generator.RoslynUtils.RoslynBuilder;
+using static Google.Api.Generator.Utils.Roslyn.Modifier;
+using static Google.Api.Generator.Utils.Roslyn.RoslynBuilder;
 
 namespace Google.Api.Generator.Generation
 {

--- a/Google.Api.Generator/Generation/ServiceMethodGenerator.Signatures.cs
+++ b/Google.Api.Generator/Generation/ServiceMethodGenerator.Signatures.cs
@@ -15,7 +15,7 @@
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
 using Google.Api.Generator.ProtoUtils;
-using Google.Api.Generator.RoslynUtils;
+using Google.Api.Generator.Utils.Roslyn;
 using Google.Api.Generator.Utils;
 using Google.Protobuf;
 using Google.Protobuf.Reflection;
@@ -24,8 +24,8 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using static Google.Api.Generator.RoslynUtils.Modifier;
-using static Google.Api.Generator.RoslynUtils.RoslynBuilder;
+using static Google.Api.Generator.Utils.Roslyn.Modifier;
+using static Google.Api.Generator.Utils.Roslyn.RoslynBuilder;
 
 namespace Google.Api.Generator.Generation
 {
@@ -189,7 +189,7 @@ namespace Google.Api.Generator.Generation
                                 else
                                 {
                                     // Nested field.
-                                    var code = New(Ctx.Type(Typ.Of(f.Key)))().WithInitializer(NestInit(f, ofs + 1).ToArray());
+                                    var code = New(Ctx.Type(ProtoTyp.Of(f.Key)))().WithInitializer(NestInit(f, ofs + 1).ToArray());
                                     yield return new ObjectInitExpr(f.Key.CSharpPropertyName(), code);
                                 }
                             }

--- a/Google.Api.Generator/Generation/ServiceMethodGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceMethodGenerator.cs
@@ -15,7 +15,7 @@
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
 using Google.Api.Generator.ProtoUtils;
-using Google.Api.Generator.RoslynUtils;
+using Google.Api.Generator.Utils.Roslyn;
 using Google.Api.Generator.Utils;
 using Google.LongRunning;
 using Grpc.Core;
@@ -25,8 +25,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using static Google.Api.Generator.RoslynUtils.Modifier;
-using static Google.Api.Generator.RoslynUtils.RoslynBuilder;
+using static Google.Api.Generator.Utils.Roslyn.Modifier;
+using static Google.Api.Generator.Utils.Roslyn.RoslynBuilder;
 
 namespace Google.Api.Generator.Generation
 {

--- a/Google.Api.Generator/Generation/ServiceSettingsCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceSettingsCodeGenerator.cs
@@ -14,7 +14,7 @@
 
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
-using Google.Api.Generator.RoslynUtils;
+using Google.Api.Generator.Utils.Roslyn;
 using Google.LongRunning;
 using Grpc.Core;
 using Microsoft.CodeAnalysis;
@@ -22,8 +22,8 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using static Google.Api.Generator.RoslynUtils.Modifier;
-using static Google.Api.Generator.RoslynUtils.RoslynBuilder;
+using static Google.Api.Generator.Utils.Roslyn.Modifier;
+using static Google.Api.Generator.Utils.Roslyn.RoslynBuilder;
 
 namespace Google.Api.Generator.Generation
 {

--- a/Google.Api.Generator/Generation/SnippetCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/SnippetCodeGenerator.cs
@@ -15,7 +15,7 @@
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
 using Google.Api.Generator.ProtoUtils;
-using Google.Api.Generator.RoslynUtils;
+using Google.Api.Generator.Utils.Roslyn;
 using Google.Api.Generator.Utils;
 using Google.LongRunning;
 using Google.Protobuf;
@@ -28,8 +28,8 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using static Google.Api.Generator.RoslynUtils.Modifier;
-using static Google.Api.Generator.RoslynUtils.RoslynBuilder;
+using static Google.Api.Generator.Utils.Roslyn.Modifier;
+using static Google.Api.Generator.Utils.Roslyn.RoslynBuilder;
 
 namespace Google.Api.Generator.Generation
 {
@@ -192,7 +192,7 @@ namespace Google.Api.Generator.Generation
                         var valueValue = DefaultValue(parts[1]);
                         var collectionInitializer = CollectionInitializer(ComplexElementInitializer(keyValue, valueValue));
                         return topLevel
-                            ? New(Ctx.Type(Typ.Generic(typeof(Dictionary<,>), Typ.Of(fieldDesc).GenericArgTyps.ToArray())))()
+                            ? New(Ctx.Type(Typ.Generic(typeof(Dictionary<,>), ProtoTyp.Of(fieldDesc).GenericArgTyps.ToArray())))()
                                 // We want new Dictionary<int, int> { ... } rather than new Dictionary<int, int>() { ... }
                                 .WithArgumentList(null)
                                 .WithInitializer(collectionInitializer)
@@ -228,16 +228,16 @@ namespace Google.Api.Generator.Generation
                             "google.protobuf.BoolValue" => default(bool),
                             "google.protobuf.StringValue" => "",
                             "google.protobuf.BytesValue" => Ctx.Type<ByteString>().Access(nameof(ByteString.Empty)),
-                            _ => New(Ctx.Type(Typ.Of(fieldDesc.MessageType)))()
+                            _ => New(Ctx.Type(ProtoTyp.Of(fieldDesc.MessageType)))()
                         },
-                        FieldType.Enum => Ctx.Type(Typ.Of(fieldDesc.EnumType)).Access(fieldDesc.EnumType.Values.First().CSharpName()),
+                        FieldType.Enum => Ctx.Type(ProtoTyp.Of(fieldDesc.EnumType)).Access(fieldDesc.EnumType.Values.First().CSharpName()),
                         _ => throw new InvalidOperationException($"Cannot generate default for proto type: {fieldDesc.FieldType}"),
                     };
                     return fieldDesc.IsRepeated ? Collection(@default, null) : @default;
                 }
 
                 object Collection(object value, Typ typ) => topLevel ?
-                    NewArray(Ctx.ArrayType(Typ.ArrayOf(typ ?? Typ.Of(fieldDesc).GenericArgTyps.First())))(value) :
+                    NewArray(Ctx.ArrayType(Typ.ArrayOf(typ ?? ProtoTyp.Of(fieldDesc).GenericArgTyps.First())))(value) :
                     (object)CollectionInitializer(value);
             }
 

--- a/Google.Api.Generator/Generation/SourceFileContext.cs
+++ b/Google.Api.Generator/Generation/SourceFileContext.cs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 using Google.Api.Gax;
-using Google.Api.Generator.RoslynUtils;
+using Google.Api.Generator.Utils.Roslyn;
 using Google.Api.Generator.Utils;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/Google.Api.Generator/Generation/UnitTestCodeGeneration.cs
+++ b/Google.Api.Generator/Generation/UnitTestCodeGeneration.cs
@@ -15,7 +15,7 @@
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
 using Google.Api.Generator.ProtoUtils;
-using Google.Api.Generator.RoslynUtils;
+using Google.Api.Generator.Utils.Roslyn;
 using Google.Api.Generator.Utils;
 using Google.LongRunning;
 using Google.Protobuf;
@@ -33,8 +33,8 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
-using static Google.Api.Generator.RoslynUtils.Modifier;
-using static Google.Api.Generator.RoslynUtils.RoslynBuilder;
+using static Google.Api.Generator.Utils.Roslyn.Modifier;
+using static Google.Api.Generator.Utils.Roslyn.RoslynBuilder;
 
 namespace Google.Api.Generator.Generation
 {
@@ -163,9 +163,9 @@ namespace Google.Api.Generator.Generation
                             "google.protobuf.BoolValue" => Int() >= 0,
                             "google.protobuf.StringValue" => String(),
                             "google.protobuf.BytesValue" => Ctx.Type<ByteString>().Call(nameof(ByteString.CopyFromUtf8))(String()),
-                            _ => New(Ctx.Type(Typ.Of(fieldDesc.MessageType)))(),
+                            _ => New(Ctx.Type(ProtoTyp.Of(fieldDesc.MessageType)))(),
                         },
-                        FieldType.Enum => Ctx.Type(Typ.Of(fieldDesc.EnumType)).Access(fieldDesc.EnumType.Values[Math.Abs(Int()) % fieldDesc.EnumType.Values.Count].CSharpName()),
+                        FieldType.Enum => Ctx.Type(ProtoTyp.Of(fieldDesc.EnumType)).Access(fieldDesc.EnumType.Values[Math.Abs(Int()) % fieldDesc.EnumType.Values.Count].CSharpName()),
                         _ => throw new InvalidOperationException($"Cannot generate test value for proto type: {fieldDesc.FieldType}"),
                     };
                     return fieldDesc.IsRepeated ? CollectionInitializer(value) : value;

--- a/Google.Api.Generator/Google.Api.Generator.csproj
+++ b/Google.Api.Generator/Google.Api.Generator.csproj
@@ -22,6 +22,10 @@
     <Folder Include="Google.Protobuf.Compiler\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Google.Api.Generator.Utils\Google.Api.Generator.Utils.csproj" />
+  </ItemGroup>
+
   <!-- Invariant mode reduces docker image size, and allows docker image to not have ICU support. -->
   <ItemGroup>
     <RuntimeHostConfigurationOption Include="System.Globalization.Invariant" Value="true" />

--- a/Google.Api.Generator/ProtoUtils/ProtoTyp.cs
+++ b/Google.Api.Generator/ProtoUtils/ProtoTyp.cs
@@ -1,0 +1,143 @@
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Generator.Utils;
+using Google.Protobuf;
+using Google.Protobuf.Reflection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using static Google.Api.Generator.Utils.Typ;
+
+namespace Google.Api.Generator.ProtoUtils
+{
+    /// <summary>
+    /// Factory methods for <see cref="Typ"/> based on protobuf elements.
+    /// </summary>
+    internal static class ProtoTyp
+    {
+        private static readonly IReadOnlyDictionary<string, Typ> s_wrapperTypes = new Dictionary<string, Typ>
+        {
+            { "google.protobuf.BoolValue", Of<bool?>() },
+            { "google.protobuf.Int32Value", Of<int?>() },
+            { "google.protobuf.UInt32Value", Of<uint?>() },
+            { "google.protobuf.Int64Value", Of<long?>() },
+            { "google.protobuf.UInt64Value", Of<ulong?>() },
+            { "google.protobuf.FloatValue", Of<float?>() },
+            { "google.protobuf.DoubleValue", Of<double?>() },
+            { "google.protobuf.StringValue", Of<string>() },
+            { "google.protobuf.BytesValue", Of<ByteString>() },
+        };
+
+        public static bool IsWrapperType(FieldDescriptor field)
+        {
+            switch (field.FieldType)
+            {
+                case FieldType.Message:
+                    return s_wrapperTypes.ContainsKey(field.MessageType.FullName);
+                default:
+                    return false;
+            }
+        }
+
+        public static Typ Of(MessageDescriptor desc)
+        {
+            if (s_wrapperTypes.TryGetValue(desc.FullName, out var wkt))
+            {
+                return wkt;
+            }
+            var ns = desc.File.CSharpNamespace();
+            var isDeprecated = desc.IsDeprecated();
+            var decls = new List<MessageDescriptor>();
+            do
+            {
+                decls.Add(desc);
+                desc = desc.ContainingType;
+            } while (desc != null);
+            decls.Reverse();
+            var typ = Manual(ns, decls[0].Name, isDeprecated: isDeprecated);
+            foreach (var decl in decls.Skip(1))
+            {
+                typ = Nested(Nested(typ, "Types"), decl.Name);
+            }
+            return typ;
+        }
+
+        public static Typ Of(EnumDescriptor desc) => desc.ContainingType == null ?
+            Manual(desc.File.CSharpNamespace(), desc.Name, isEnum: true) :
+            Nested(Nested(Of(desc.ContainingType), "Types"), desc.Name, isEnum: true);
+
+        public static Typ Of(FieldDescriptor desc, bool? forceRepeated = null)
+        {
+            if (desc.IsMap)
+            {
+                if (forceRepeated != null)
+                {
+                    throw new InvalidOperationException("Cannot force repeated on a map field.");
+                }
+                // A map is a repeated message with key and value fields.
+                var kv = desc.MessageType.Fields.InFieldNumberOrder();
+                return Generic(typeof(IDictionary<,>), Of(kv[0]), Of(kv[1]));
+            }
+            // See https://developers.google.com/protocol-buffers/docs/proto3#scalar
+            // Switch cases are ordered as in this doc. Please do not re-order.
+            if (forceRepeated ?? desc.IsRepeated)
+            {
+                switch (desc.FieldType)
+                {
+                    case FieldType.Double: return Of<IEnumerable<double>>();
+                    case FieldType.Float: return Of<IEnumerable<float>>();
+                    case FieldType.Int32: return Of<IEnumerable<int>>();
+                    case FieldType.Int64: return Of<IEnumerable<long>>();
+                    case FieldType.UInt32: return Of<IEnumerable<uint>>();
+                    case FieldType.UInt64: return Of<IEnumerable<ulong>>();
+                    case FieldType.SInt32: return Of<IEnumerable<int>>();
+                    case FieldType.SInt64: return Of<IEnumerable<long>>();
+                    case FieldType.Fixed32: return Of<IEnumerable<uint>>();
+                    case FieldType.Fixed64: return Of<IEnumerable<ulong>>();
+                    case FieldType.SFixed32: return Of<IEnumerable<int>>();
+                    case FieldType.SFixed64: return Of<IEnumerable<long>>();
+                    case FieldType.Bool: return Of<IEnumerable<bool>>();
+                    case FieldType.String: return Of<IEnumerable<string>>();
+                    case FieldType.Bytes: return Of<IEnumerable<ByteString>>();
+                    case FieldType.Message: return Generic(typeof(IEnumerable<>), Of(desc.MessageType));
+                    case FieldType.Enum: return Generic(typeof(IEnumerable<>), Of(desc.EnumType));
+                    default: throw new NotSupportedException($"Cannot get repeated Typ of: {desc.FieldType}");
+                }
+            }
+            switch (desc.FieldType)
+            {
+                case FieldType.Double: return Of<double>();
+                case FieldType.Float: return Of<float>();
+                case FieldType.Int32: return Of<int>();
+                case FieldType.Int64: return Of<long>();
+                case FieldType.UInt32: return Of<uint>();
+                case FieldType.UInt64: return Of<ulong>();
+                case FieldType.SInt32: return Of<int>();
+                case FieldType.SInt64: return Of<long>();
+                case FieldType.Fixed32: return Of<uint>();
+                case FieldType.Fixed64: return Of<ulong>();
+                case FieldType.SFixed32: return Of<int>();
+                case FieldType.SFixed64: return Of<long>();
+                case FieldType.Bool: return Of<bool>();
+                case FieldType.String: return Of<string>();
+                case FieldType.Bytes: return Of<ByteString>();
+                case FieldType.Message: return Of(desc.MessageType);
+                case FieldType.Enum: return Of(desc.EnumType);
+                default: throw new NotSupportedException($"Cannot get Typ of: {desc.FieldType}");
+            }
+        }
+    }
+}

--- a/Google.Api.Generator/ProtoUtils/ResourcePattern.cs
+++ b/Google.Api.Generator/ProtoUtils/ResourcePattern.cs
@@ -17,7 +17,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 
-namespace Google.Api.Generator.Utils
+namespace Google.Api.Generator.ProtoUtils
 {
     internal class ResourcePattern
     {


### PR DESCRIPTION
The new Google.Api.Generator.Utils package contains:

- Formatting utilities
- Roslyn utilities
- System extensions
- The Disposable utility type for "dispose via an action"
- The Typ type which is used widely within Google.Api.Generator

I've moved all the Typ code that's related to protobufs to a new
ProtoTyp class that's still in Google.Api.Generator, to avoid
unnecessary Protobuf dependencies in the Utils project.

While Google.Api.Generator is perhaps not the ideal executable name
now, it's not *too* bad, and it's probably not worth the widespread
inconvenience of changing it.