### PR TITLE
Fix test and snippet generation for constant patterns

### DIFF
--- a/Google.Api.Generator/Generation/SnippetCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/SnippetCodeGenerator.cs
@@ -177,7 +177,7 @@ namespace Google.Api.Generator.Generation
                     {
                         @default = pattern is null ?
                             (object)New(Ctx.Type<UnparsedResourceName>())("a/wildcard/resource") :
-                            Ctx.Type(resourceTyp).Call($"From{string.Join("", pattern.Template.ParameterNames.Select(x => x.RemoveSuffix("_id").ToUpperCamelCase()))}")
+                            Ctx.Type(resourceTyp).Call(FactoryMethodName(pattern))
                                 (pattern.Template.ParameterNames.Select(x => $"[{x.ToUpperInvariant()}]"));
                     }
                     return fieldDesc.IsRepeated ? Collection(@default, resourceTyp) : @default;
@@ -239,6 +239,17 @@ namespace Google.Api.Generator.Generation
                 object Collection(object value, Typ typ) => topLevel ?
                     NewArray(Ctx.ArrayType(Typ.ArrayOf(typ ?? ProtoTyp.Of(fieldDesc).GenericArgTyps.First())))(value) :
                     (object)CollectionInitializer(value);
+
+                string FactoryMethodName(ResourceDetails.Definition.Pattern pattern)
+                {
+                    // Use the parameter names as a suffix, or the pattern string instead if there are no parameters.
+                    string suffix = string.Join("", pattern.Template.ParameterNames.Select(x => x.RemoveSuffix("_id").ToUpperCamelCase()));
+                    if (suffix == "")
+                    {
+                        suffix = pattern.PatternString.ToUpperCamelCase();
+                    }
+                    return $"From{suffix}";
+                }
             }
 
             private IEnumerable<ObjectInitExpr> InitRequest()

--- a/Google.Api.Generator/Generation/UnitTestCodeGeneration.cs
+++ b/Google.Api.Generator/Generation/UnitTestCodeGeneration.cs
@@ -119,7 +119,7 @@ namespace Google.Api.Generator.Generation
                     var pattern = def.Patterns.FirstOrDefault(x => !x.IsWildcard);
                     object value = pattern is null ?
                         (object)New(Ctx.Type<UnparsedResourceName>())("a/wildcard/resource") :
-                        Ctx.Type(def.ResourceNameTyp).Call($"From{string.Join("", pattern.Template.ParameterNames.Select(x => x.RemoveSuffix("_id").ToUpperCamelCase()))}")
+                        Ctx.Type(def.ResourceNameTyp).Call(FactoryMethodName(pattern))
                                 (pattern.Template.ParameterNames.Select(x => $"[{x.ToUpperInvariant()}]"));
                     return fieldDesc.IsRepeated ? CollectionInitializer(value) : value;
                 }
@@ -177,6 +177,17 @@ namespace Google.Api.Generator.Generation
                 long Long() => BitConverter.ToInt64(FieldHash());
                 double Double() => ((double)Long()) / 8;
                 string String() => $"{fieldDesc.Name}{Int():x8}";
+
+                string FactoryMethodName(ResourceDetails.Definition.Pattern pattern)
+                {
+                    // Use the parameter names as a suffix, or the pattern string instead if there are no parameters.
+                    string suffix = string.Join("", pattern.Template.ParameterNames.Select(x => x.RemoveSuffix("_id").ToUpperCamelCase()));
+                    if (suffix == "")
+                    {
+                        suffix = pattern.PatternString.ToUpperCamelCase();
+                    }
+                    return $"From{suffix}";
+                }
             }
 
             private IEnumerable<ObjectInitExpr> InitMessage(MessageDescriptor msgDesc, IEnumerable<MethodDetails.Signature.Field> onlyFields)


### PR DESCRIPTION
This involves unfortunate duplication, but I suspect that can't be
avoided without a bit more disruption. (Ideally the
SnippetCodeGenerator, UnitTestCodeGenerator and
could use ResourceNamesGenerator as the one true source of
information about what would be generated, but that would be a big
change.)

No tests yet - there's no *simple* place to add a test for this.
Suggestions welcome, including "it's not worth it for this case".