### PR TITLE
Enable snippets and unittests for resource-name tests

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTest.cs
+++ b/Google.Api.Generator.Tests/ProtoTest.cs
@@ -145,7 +145,7 @@ namespace Google.Api.Generator.Tests
         public void MethodSignatures() => ProtoTestSingle("MethodSignatures", ignoreCsProj: true, ignoreSnippets: true, ignoreUnitTests: true);
 
         [Fact]
-        public void ResourceNames() => ProtoTestSingle("ResourceNames", ignoreCsProj: true, ignoreSnippets: true, ignoreUnitTests: true);
+        public void ResourceNames() => ProtoTestSingle("ResourceNames", ignoreCsProj: true);
 
         [Fact]
         public void Paginated0() => ProtoTestSingle("Paginated", ignoreCsProj: true, ignoreUnitTests: true);

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/ResourceNamesFakes.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/ResourceNamesFakes.cs
@@ -13,39 +13,59 @@
 // limitations under the License.
 
 using Google.Protobuf.Collections;
+using Grpc.Core;
+using System;
 
 namespace Testing.ResourceNames
 {
+    public class ResourceNames
+    {
+        // Fake gRPC client, to allow generated tests to compile.
+        public class ResourceNamesClient
+        {
+            public ResourceNamesClient() { }
+            public ResourceNamesClient(CallInvoker callInvoker) { }
+            public virtual Response SinglePatternMethod(SinglePattern request, CallOptions callOptions) => throw new NotImplementedException();
+            public virtual AsyncUnaryCall<Response> SinglePatternMethodAsync(SinglePattern request, CallOptions callOptions) => throw new NotImplementedException();
+            public virtual Response WildcardOnlyPatternMethod(WildcardOnlyPattern request, CallOptions callOptions) => throw new NotImplementedException();
+            public virtual AsyncUnaryCall<Response> WildcardOnlyPatternMethodAsync(WildcardOnlyPattern request, CallOptions callOptions) => throw new NotImplementedException();
+            public virtual Response WildcardMultiPatternMethod(WildcardMultiPattern request, CallOptions callOptions) => throw new NotImplementedException();
+            public virtual AsyncUnaryCall<Response> WildcardMultiPatternMethodAsync(WildcardMultiPattern request, CallOptions callOptions) => throw new NotImplementedException();
+            public virtual Response WildcardMultiPatternMultipleMethod(WildcardMultiPatternMultiple request, CallOptions callOptions) => throw new NotImplementedException();
+            public virtual AsyncUnaryCall<Response> WildcardMultiPatternMultipleMethodAsync(WildcardMultiPatternMultiple request, CallOptions callOptions) => throw new NotImplementedException();
+        }
+    }
+
     public partial class SinglePattern : ProtoMsgFake<SinglePattern>
     {
         public string RealName { get; set; }
         public string Ref { get; set; }
-        public RepeatedField<string> RepeatedRef { get; }
+        public RepeatedField<string> RepeatedRef { get; } = new RepeatedField<string>();
         public string ValueRef { get; set; }
-        public RepeatedField<string> RepeatedValueRef { get; }
+        public RepeatedField<string> RepeatedValueRef { get; } = new RepeatedField<string>();
     }
 
     public partial class WildcardOnlyPattern : ProtoMsgFake<WildcardOnlyPattern>
     {
         public string Name { get; set; }
         public string Ref { get; set; }
-        public RepeatedField<string> RepeatedRef { get; }
+        public RepeatedField<string> RepeatedRef { get; } = new RepeatedField<string>();
         public string RefSugar { get; set; }
-        public RepeatedField<string> RepeatedRefSugar { get; }
+        public RepeatedField<string> RepeatedRefSugar { get; } = new RepeatedField<string>();
     }
 
     public partial class WildcardMultiPattern : ProtoMsgFake<WildcardMultiPattern>
     {
         public string Name { get; set; }
         public string Ref { get; set; }
-        public RepeatedField<string> RepeatedRef { get; }
+        public RepeatedField<string> RepeatedRef { get; } = new RepeatedField<string>();
     }
 
     public partial class WildcardMultiPatternMultiple : ProtoMsgFake<WildcardMultiPatternMultiple>
     {
         public string Name { get; set; }
         public string Ref { get; set; }
-        public RepeatedField<string> RepeatedRef { get; }
+        public RepeatedField<string> RepeatedRef { get; } = new RepeatedField<string>();
     }
 
     public partial class Response : ProtoMsgFake<Response> { }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.Snippets/ResourceNamesClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.Snippets/ResourceNamesClientSnippets.g.cs
@@ -1,0 +1,890 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using Google.Api.Gax;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    /// <summary>Generated snippets.</summary>
+    public sealed class GeneratedResourceNamesClientSnippets
+    {
+        /// <summary>Snippet for SinglePatternMethod</summary>
+        public void SinglePatternMethodRequestObject()
+        {
+            // Snippet: SinglePatternMethod(SinglePattern, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            SinglePattern request = new SinglePattern
+            {
+                RealNameAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RefAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsSinglePatternNames =
+                {
+                    SinglePatternName.FromItem("[ITEM_ID]"),
+                },
+                ValueRefAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RepeatedValueRefAsSinglePatternNames =
+                {
+                    SinglePatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            // Make the request
+            Response response = resourceNamesClient.SinglePatternMethod(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for SinglePatternMethodAsync</summary>
+        public async Task SinglePatternMethodRequestObjectAsync()
+        {
+            // Snippet: SinglePatternMethodAsync(SinglePattern, CallSettings)
+            // Additional: SinglePatternMethodAsync(SinglePattern, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            SinglePattern request = new SinglePattern
+            {
+                RealNameAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RefAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsSinglePatternNames =
+                {
+                    SinglePatternName.FromItem("[ITEM_ID]"),
+                },
+                ValueRefAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RepeatedValueRefAsSinglePatternNames =
+                {
+                    SinglePatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            // Make the request
+            Response response = await resourceNamesClient.SinglePatternMethodAsync(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for SinglePatternMethod</summary>
+        public void SinglePatternMethod()
+        {
+            // Snippet: SinglePatternMethod(string, string, IEnumerable<string>, string, IEnumerable<string>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            string realName = "items/[ITEM_ID]";
+            string @ref = "items/[ITEM_ID]";
+            IEnumerable<string> repeatedRef = new string[] { "items/[ITEM_ID]", };
+            string valueRef = "items/[ITEM_ID]";
+            IEnumerable<string> repeatedValueRef = new string[] { "items/[ITEM_ID]", };
+            // Make the request
+            Response response = resourceNamesClient.SinglePatternMethod(realName, @ref, repeatedRef, valueRef, repeatedValueRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for SinglePatternMethodAsync</summary>
+        public async Task SinglePatternMethodAsync()
+        {
+            // Snippet: SinglePatternMethodAsync(string, string, IEnumerable<string>, string, IEnumerable<string>, CallSettings)
+            // Additional: SinglePatternMethodAsync(string, string, IEnumerable<string>, string, IEnumerable<string>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            string realName = "items/[ITEM_ID]";
+            string @ref = "items/[ITEM_ID]";
+            IEnumerable<string> repeatedRef = new string[] { "items/[ITEM_ID]", };
+            string valueRef = "items/[ITEM_ID]";
+            IEnumerable<string> repeatedValueRef = new string[] { "items/[ITEM_ID]", };
+            // Make the request
+            Response response = await resourceNamesClient.SinglePatternMethodAsync(realName, @ref, repeatedRef, valueRef, repeatedValueRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for SinglePatternMethod</summary>
+        public void SinglePatternMethodResourceNames()
+        {
+            // Snippet: SinglePatternMethod(SinglePatternName, SinglePatternName, IEnumerable<SinglePatternName>, SinglePatternName, IEnumerable<SinglePatternName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            SinglePatternName realName = SinglePatternName.FromItem("[ITEM_ID]");
+            SinglePatternName @ref = SinglePatternName.FromItem("[ITEM_ID]");
+            IEnumerable<SinglePatternName> repeatedRef = new SinglePatternName[]
+            {
+                SinglePatternName.FromItem("[ITEM_ID]"),
+            };
+            SinglePatternName valueRef = SinglePatternName.FromItem("[ITEM_ID]");
+            IEnumerable<SinglePatternName> repeatedValueRef = new SinglePatternName[]
+            {
+                SinglePatternName.FromItem("[ITEM_ID]"),
+            };
+            // Make the request
+            Response response = resourceNamesClient.SinglePatternMethod(realName, @ref, repeatedRef, valueRef, repeatedValueRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for SinglePatternMethodAsync</summary>
+        public async Task SinglePatternMethodResourceNamesAsync()
+        {
+            // Snippet: SinglePatternMethodAsync(SinglePatternName, SinglePatternName, IEnumerable<SinglePatternName>, SinglePatternName, IEnumerable<SinglePatternName>, CallSettings)
+            // Additional: SinglePatternMethodAsync(SinglePatternName, SinglePatternName, IEnumerable<SinglePatternName>, SinglePatternName, IEnumerable<SinglePatternName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            SinglePatternName realName = SinglePatternName.FromItem("[ITEM_ID]");
+            SinglePatternName @ref = SinglePatternName.FromItem("[ITEM_ID]");
+            IEnumerable<SinglePatternName> repeatedRef = new SinglePatternName[]
+            {
+                SinglePatternName.FromItem("[ITEM_ID]"),
+            };
+            SinglePatternName valueRef = SinglePatternName.FromItem("[ITEM_ID]");
+            IEnumerable<SinglePatternName> repeatedValueRef = new SinglePatternName[]
+            {
+                SinglePatternName.FromItem("[ITEM_ID]"),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.SinglePatternMethodAsync(realName, @ref, repeatedRef, valueRef, repeatedValueRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardOnlyPatternMethod</summary>
+        public void WildcardOnlyPatternMethodRequestObject()
+        {
+            // Snippet: WildcardOnlyPatternMethod(WildcardOnlyPattern, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            WildcardOnlyPattern request = new WildcardOnlyPattern
+            {
+                ResourceName = new UnparsedResourceName("a/wildcard/resource"),
+                RefAsResourceName = new UnparsedResourceName("a/wildcard/resource"),
+                RepeatedRefAsResourceNames =
+                {
+                    new UnparsedResourceName("a/wildcard/resource"),
+                },
+                RefSugarAsResourceName = new UnparsedResourceName("a/wildcard/resource"),
+                RepeatedRefSugarAsResourceNames =
+                {
+                    new UnparsedResourceName("a/wildcard/resource"),
+                },
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardOnlyPatternMethod(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardOnlyPatternMethodAsync</summary>
+        public async Task WildcardOnlyPatternMethodRequestObjectAsync()
+        {
+            // Snippet: WildcardOnlyPatternMethodAsync(WildcardOnlyPattern, CallSettings)
+            // Additional: WildcardOnlyPatternMethodAsync(WildcardOnlyPattern, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            WildcardOnlyPattern request = new WildcardOnlyPattern
+            {
+                ResourceName = new UnparsedResourceName("a/wildcard/resource"),
+                RefAsResourceName = new UnparsedResourceName("a/wildcard/resource"),
+                RepeatedRefAsResourceNames =
+                {
+                    new UnparsedResourceName("a/wildcard/resource"),
+                },
+                RefSugarAsResourceName = new UnparsedResourceName("a/wildcard/resource"),
+                RepeatedRefSugarAsResourceNames =
+                {
+                    new UnparsedResourceName("a/wildcard/resource"),
+                },
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardOnlyPatternMethodAsync(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardOnlyPatternMethod</summary>
+        public void WildcardOnlyPatternMethod()
+        {
+            // Snippet: WildcardOnlyPatternMethod(string, string, IEnumerable<string>, string, IEnumerable<string>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            string name = "a/wildcard/resource";
+            string @ref = "a/wildcard/resource";
+            IEnumerable<string> repeatedRef = new string[]
+            {
+                "a/wildcard/resource",
+            };
+            string refSugar = "a/wildcard/resource";
+            IEnumerable<string> repeatedRefSugar = new string[]
+            {
+                "a/wildcard/resource",
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardOnlyPatternMethod(name, @ref, repeatedRef, refSugar, repeatedRefSugar);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardOnlyPatternMethodAsync</summary>
+        public async Task WildcardOnlyPatternMethodAsync()
+        {
+            // Snippet: WildcardOnlyPatternMethodAsync(string, string, IEnumerable<string>, string, IEnumerable<string>, CallSettings)
+            // Additional: WildcardOnlyPatternMethodAsync(string, string, IEnumerable<string>, string, IEnumerable<string>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            string name = "a/wildcard/resource";
+            string @ref = "a/wildcard/resource";
+            IEnumerable<string> repeatedRef = new string[]
+            {
+                "a/wildcard/resource",
+            };
+            string refSugar = "a/wildcard/resource";
+            IEnumerable<string> repeatedRefSugar = new string[]
+            {
+                "a/wildcard/resource",
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardOnlyPatternMethodAsync(name, @ref, repeatedRef, refSugar, repeatedRefSugar);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardOnlyPatternMethod</summary>
+        public void WildcardOnlyPatternMethodResourceNames()
+        {
+            // Snippet: WildcardOnlyPatternMethod(IResourceName, IResourceName, IEnumerable<IResourceName>, IResourceName, IEnumerable<IResourceName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            IResourceName name = new UnparsedResourceName("a/wildcard/resource");
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            IResourceName refSugar = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<IResourceName> repeatedRefSugar = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardOnlyPatternMethod(name, @ref, repeatedRef, refSugar, repeatedRefSugar);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardOnlyPatternMethodAsync</summary>
+        public async Task WildcardOnlyPatternMethodResourceNamesAsync()
+        {
+            // Snippet: WildcardOnlyPatternMethodAsync(IResourceName, IResourceName, IEnumerable<IResourceName>, IResourceName, IEnumerable<IResourceName>, CallSettings)
+            // Additional: WildcardOnlyPatternMethodAsync(IResourceName, IResourceName, IEnumerable<IResourceName>, IResourceName, IEnumerable<IResourceName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            IResourceName name = new UnparsedResourceName("a/wildcard/resource");
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            IResourceName refSugar = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<IResourceName> repeatedRefSugar = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardOnlyPatternMethodAsync(name, @ref, repeatedRef, refSugar, repeatedRefSugar);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        public void WildcardMultiPatternMethodRequestObject()
+        {
+            // Snippet: WildcardMultiPatternMethod(WildcardMultiPattern, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            WildcardMultiPattern request = new WildcardMultiPattern
+            {
+                WildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RefAsWildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsWildcardMultiPatternNames =
+                {
+                    WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMethod(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        public async Task WildcardMultiPatternMethodRequestObjectAsync()
+        {
+            // Snippet: WildcardMultiPatternMethodAsync(WildcardMultiPattern, CallSettings)
+            // Additional: WildcardMultiPatternMethodAsync(WildcardMultiPattern, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            WildcardMultiPattern request = new WildcardMultiPattern
+            {
+                WildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RefAsWildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsWildcardMultiPatternNames =
+                {
+                    WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        public void WildcardMultiPatternMethod()
+        {
+            // Snippet: WildcardMultiPatternMethod(string, string, IEnumerable<string>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            string name = "items/[ITEM_ID]";
+            string @ref = "items/[ITEM_ID]";
+            IEnumerable<string> repeatedRef = new string[] { "items/[ITEM_ID]", };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        public async Task WildcardMultiPatternMethodAsync()
+        {
+            // Snippet: WildcardMultiPatternMethodAsync(string, string, IEnumerable<string>, CallSettings)
+            // Additional: WildcardMultiPatternMethodAsync(string, string, IEnumerable<string>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            string name = "items/[ITEM_ID]";
+            string @ref = "items/[ITEM_ID]";
+            IEnumerable<string> repeatedRef = new string[] { "items/[ITEM_ID]", };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        public void WildcardMultiPatternMethodResourceNames1()
+        {
+            // Snippet: WildcardMultiPatternMethod(WildcardMultiPatternName, WildcardMultiPatternName, IEnumerable<WildcardMultiPatternName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            WildcardMultiPatternName name = WildcardMultiPatternName.FromItem("[ITEM_ID]");
+            WildcardMultiPatternName @ref = WildcardMultiPatternName.FromItem("[ITEM_ID]");
+            IEnumerable<WildcardMultiPatternName> repeatedRef = new WildcardMultiPatternName[]
+            {
+                WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        public async Task WildcardMultiPatternMethodResourceNames1Async()
+        {
+            // Snippet: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, WildcardMultiPatternName, IEnumerable<WildcardMultiPatternName>, CallSettings)
+            // Additional: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, WildcardMultiPatternName, IEnumerable<WildcardMultiPatternName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            WildcardMultiPatternName name = WildcardMultiPatternName.FromItem("[ITEM_ID]");
+            WildcardMultiPatternName @ref = WildcardMultiPatternName.FromItem("[ITEM_ID]");
+            IEnumerable<WildcardMultiPatternName> repeatedRef = new WildcardMultiPatternName[]
+            {
+                WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        public void WildcardMultiPatternMethodResourceNames2()
+        {
+            // Snippet: WildcardMultiPatternMethod(WildcardMultiPatternName, WildcardMultiPatternName, IEnumerable<IResourceName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            WildcardMultiPatternName name = WildcardMultiPatternName.FromItem("[ITEM_ID]");
+            WildcardMultiPatternName @ref = WildcardMultiPatternName.FromItem("[ITEM_ID]");
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        public async Task WildcardMultiPatternMethodResourceNames2Async()
+        {
+            // Snippet: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, WildcardMultiPatternName, IEnumerable<IResourceName>, CallSettings)
+            // Additional: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, WildcardMultiPatternName, IEnumerable<IResourceName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            WildcardMultiPatternName name = WildcardMultiPatternName.FromItem("[ITEM_ID]");
+            WildcardMultiPatternName @ref = WildcardMultiPatternName.FromItem("[ITEM_ID]");
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        public void WildcardMultiPatternMethodResourceNames3()
+        {
+            // Snippet: WildcardMultiPatternMethod(WildcardMultiPatternName, IResourceName, IEnumerable<WildcardMultiPatternName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            WildcardMultiPatternName name = WildcardMultiPatternName.FromItem("[ITEM_ID]");
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<WildcardMultiPatternName> repeatedRef = new WildcardMultiPatternName[]
+            {
+                WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        public async Task WildcardMultiPatternMethodResourceNames3Async()
+        {
+            // Snippet: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, IResourceName, IEnumerable<WildcardMultiPatternName>, CallSettings)
+            // Additional: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, IResourceName, IEnumerable<WildcardMultiPatternName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            WildcardMultiPatternName name = WildcardMultiPatternName.FromItem("[ITEM_ID]");
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<WildcardMultiPatternName> repeatedRef = new WildcardMultiPatternName[]
+            {
+                WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        public void WildcardMultiPatternMethodResourceNames4()
+        {
+            // Snippet: WildcardMultiPatternMethod(WildcardMultiPatternName, IResourceName, IEnumerable<IResourceName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            WildcardMultiPatternName name = WildcardMultiPatternName.FromItem("[ITEM_ID]");
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        public async Task WildcardMultiPatternMethodResourceNames4Async()
+        {
+            // Snippet: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, IResourceName, IEnumerable<IResourceName>, CallSettings)
+            // Additional: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, IResourceName, IEnumerable<IResourceName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            WildcardMultiPatternName name = WildcardMultiPatternName.FromItem("[ITEM_ID]");
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        public void WildcardMultiPatternMethodResourceNames5()
+        {
+            // Snippet: WildcardMultiPatternMethod(IResourceName, WildcardMultiPatternName, IEnumerable<WildcardMultiPatternName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            IResourceName name = new UnparsedResourceName("a/wildcard/resource");
+            WildcardMultiPatternName @ref = WildcardMultiPatternName.FromItem("[ITEM_ID]");
+            IEnumerable<WildcardMultiPatternName> repeatedRef = new WildcardMultiPatternName[]
+            {
+                WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        public async Task WildcardMultiPatternMethodResourceNames5Async()
+        {
+            // Snippet: WildcardMultiPatternMethodAsync(IResourceName, WildcardMultiPatternName, IEnumerable<WildcardMultiPatternName>, CallSettings)
+            // Additional: WildcardMultiPatternMethodAsync(IResourceName, WildcardMultiPatternName, IEnumerable<WildcardMultiPatternName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            IResourceName name = new UnparsedResourceName("a/wildcard/resource");
+            WildcardMultiPatternName @ref = WildcardMultiPatternName.FromItem("[ITEM_ID]");
+            IEnumerable<WildcardMultiPatternName> repeatedRef = new WildcardMultiPatternName[]
+            {
+                WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        public void WildcardMultiPatternMethodResourceNames6()
+        {
+            // Snippet: WildcardMultiPatternMethod(IResourceName, WildcardMultiPatternName, IEnumerable<IResourceName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            IResourceName name = new UnparsedResourceName("a/wildcard/resource");
+            WildcardMultiPatternName @ref = WildcardMultiPatternName.FromItem("[ITEM_ID]");
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        public async Task WildcardMultiPatternMethodResourceNames6Async()
+        {
+            // Snippet: WildcardMultiPatternMethodAsync(IResourceName, WildcardMultiPatternName, IEnumerable<IResourceName>, CallSettings)
+            // Additional: WildcardMultiPatternMethodAsync(IResourceName, WildcardMultiPatternName, IEnumerable<IResourceName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            IResourceName name = new UnparsedResourceName("a/wildcard/resource");
+            WildcardMultiPatternName @ref = WildcardMultiPatternName.FromItem("[ITEM_ID]");
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        public void WildcardMultiPatternMethodResourceNames7()
+        {
+            // Snippet: WildcardMultiPatternMethod(IResourceName, IResourceName, IEnumerable<WildcardMultiPatternName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            IResourceName name = new UnparsedResourceName("a/wildcard/resource");
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<WildcardMultiPatternName> repeatedRef = new WildcardMultiPatternName[]
+            {
+                WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        public async Task WildcardMultiPatternMethodResourceNames7Async()
+        {
+            // Snippet: WildcardMultiPatternMethodAsync(IResourceName, IResourceName, IEnumerable<WildcardMultiPatternName>, CallSettings)
+            // Additional: WildcardMultiPatternMethodAsync(IResourceName, IResourceName, IEnumerable<WildcardMultiPatternName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            IResourceName name = new UnparsedResourceName("a/wildcard/resource");
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<WildcardMultiPatternName> repeatedRef = new WildcardMultiPatternName[]
+            {
+                WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        public void WildcardMultiPatternMethodResourceNames8()
+        {
+            // Snippet: WildcardMultiPatternMethod(IResourceName, IResourceName, IEnumerable<IResourceName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            IResourceName name = new UnparsedResourceName("a/wildcard/resource");
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        public async Task WildcardMultiPatternMethodResourceNames8Async()
+        {
+            // Snippet: WildcardMultiPatternMethodAsync(IResourceName, IResourceName, IEnumerable<IResourceName>, CallSettings)
+            // Additional: WildcardMultiPatternMethodAsync(IResourceName, IResourceName, IEnumerable<IResourceName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            IResourceName name = new UnparsedResourceName("a/wildcard/resource");
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMultipleMethod</summary>
+        public void WildcardMultiPatternMultipleMethodRequestObject()
+        {
+            // Snippet: WildcardMultiPatternMultipleMethod(WildcardMultiPatternMultiple, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            WildcardMultiPatternMultiple request = new WildcardMultiPatternMultiple
+            {
+                WildcardMultiPatternMultipleName = WildcardMultiPatternMultipleName.FromConstPattern(),
+                RefAsWildcardMultiPatternMultipleName = WildcardMultiPatternMultipleName.FromConstPattern(),
+                RepeatedRefAsWildcardMultiPatternMultipleNames =
+                {
+                    WildcardMultiPatternMultipleName.FromConstPattern(),
+                },
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMultipleMethod(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMultipleMethodAsync</summary>
+        public async Task WildcardMultiPatternMultipleMethodRequestObjectAsync()
+        {
+            // Snippet: WildcardMultiPatternMultipleMethodAsync(WildcardMultiPatternMultiple, CallSettings)
+            // Additional: WildcardMultiPatternMultipleMethodAsync(WildcardMultiPatternMultiple, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            WildcardMultiPatternMultiple request = new WildcardMultiPatternMultiple
+            {
+                WildcardMultiPatternMultipleName = WildcardMultiPatternMultipleName.FromConstPattern(),
+                RefAsWildcardMultiPatternMultipleName = WildcardMultiPatternMultipleName.FromConstPattern(),
+                RepeatedRefAsWildcardMultiPatternMultipleNames =
+                {
+                    WildcardMultiPatternMultipleName.FromConstPattern(),
+                },
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMultipleMethodAsync(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMultipleMethod</summary>
+        public void WildcardMultiPatternMultipleMethod()
+        {
+            // Snippet: WildcardMultiPatternMultipleMethod(string, IEnumerable<string>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            string @ref = "constPattern";
+            IEnumerable<string> repeatedRef = new string[] { "constPattern", };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMultipleMethod(@ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMultipleMethodAsync</summary>
+        public async Task WildcardMultiPatternMultipleMethodAsync()
+        {
+            // Snippet: WildcardMultiPatternMultipleMethodAsync(string, IEnumerable<string>, CallSettings)
+            // Additional: WildcardMultiPatternMultipleMethodAsync(string, IEnumerable<string>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            string @ref = "constPattern";
+            IEnumerable<string> repeatedRef = new string[] { "constPattern", };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMultipleMethodAsync(@ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMultipleMethod</summary>
+        public void WildcardMultiPatternMultipleMethodResourceNames1()
+        {
+            // Snippet: WildcardMultiPatternMultipleMethod(WildcardMultiPatternMultipleName, IEnumerable<WildcardMultiPatternMultipleName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            WildcardMultiPatternMultipleName @ref = WildcardMultiPatternMultipleName.FromConstPattern();
+            IEnumerable<WildcardMultiPatternMultipleName> repeatedRef = new WildcardMultiPatternMultipleName[]
+            {
+                WildcardMultiPatternMultipleName.FromConstPattern(),
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMultipleMethod(@ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMultipleMethodAsync</summary>
+        public async Task WildcardMultiPatternMultipleMethodResourceNames1Async()
+        {
+            // Snippet: WildcardMultiPatternMultipleMethodAsync(WildcardMultiPatternMultipleName, IEnumerable<WildcardMultiPatternMultipleName>, CallSettings)
+            // Additional: WildcardMultiPatternMultipleMethodAsync(WildcardMultiPatternMultipleName, IEnumerable<WildcardMultiPatternMultipleName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            WildcardMultiPatternMultipleName @ref = WildcardMultiPatternMultipleName.FromConstPattern();
+            IEnumerable<WildcardMultiPatternMultipleName> repeatedRef = new WildcardMultiPatternMultipleName[]
+            {
+                WildcardMultiPatternMultipleName.FromConstPattern(),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMultipleMethodAsync(@ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMultipleMethod</summary>
+        public void WildcardMultiPatternMultipleMethodResourceNames2()
+        {
+            // Snippet: WildcardMultiPatternMultipleMethod(WildcardMultiPatternMultipleName, IEnumerable<IResourceName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            WildcardMultiPatternMultipleName @ref = WildcardMultiPatternMultipleName.FromConstPattern();
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMultipleMethod(@ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMultipleMethodAsync</summary>
+        public async Task WildcardMultiPatternMultipleMethodResourceNames2Async()
+        {
+            // Snippet: WildcardMultiPatternMultipleMethodAsync(WildcardMultiPatternMultipleName, IEnumerable<IResourceName>, CallSettings)
+            // Additional: WildcardMultiPatternMultipleMethodAsync(WildcardMultiPatternMultipleName, IEnumerable<IResourceName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            WildcardMultiPatternMultipleName @ref = WildcardMultiPatternMultipleName.FromConstPattern();
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMultipleMethodAsync(@ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMultipleMethod</summary>
+        public void WildcardMultiPatternMultipleMethodResourceNames3()
+        {
+            // Snippet: WildcardMultiPatternMultipleMethod(IResourceName, IEnumerable<WildcardMultiPatternMultipleName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<WildcardMultiPatternMultipleName> repeatedRef = new WildcardMultiPatternMultipleName[]
+            {
+                WildcardMultiPatternMultipleName.FromConstPattern(),
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMultipleMethod(@ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMultipleMethodAsync</summary>
+        public async Task WildcardMultiPatternMultipleMethodResourceNames3Async()
+        {
+            // Snippet: WildcardMultiPatternMultipleMethodAsync(IResourceName, IEnumerable<WildcardMultiPatternMultipleName>, CallSettings)
+            // Additional: WildcardMultiPatternMultipleMethodAsync(IResourceName, IEnumerable<WildcardMultiPatternMultipleName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<WildcardMultiPatternMultipleName> repeatedRef = new WildcardMultiPatternMultipleName[]
+            {
+                WildcardMultiPatternMultipleName.FromConstPattern(),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMultipleMethodAsync(@ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMultipleMethod</summary>
+        public void WildcardMultiPatternMultipleMethodResourceNames4()
+        {
+            // Snippet: WildcardMultiPatternMultipleMethod(IResourceName, IEnumerable<IResourceName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMultipleMethod(@ref, repeatedRef);
+            // End snippet
+        }
+
+        /// <summary>Snippet for WildcardMultiPatternMultipleMethodAsync</summary>
+        public async Task WildcardMultiPatternMultipleMethodResourceNames4Async()
+        {
+            // Snippet: WildcardMultiPatternMultipleMethodAsync(IResourceName, IEnumerable<IResourceName>, CallSettings)
+            // Additional: WildcardMultiPatternMultipleMethodAsync(IResourceName, IEnumerable<IResourceName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMultipleMethodAsync(@ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.Tests/ResourceNamesClientTest.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.Tests/ResourceNamesClientTest.g.cs
@@ -1,0 +1,1048 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+using gax = Google.Api.Gax;
+using gaxgrpc = Google.Api.Gax.Grpc;
+using grpccore = Grpc.Core;
+using moq = Moq;
+using st = System.Threading;
+using stt = System.Threading.Tasks;
+using xunit = Xunit;
+
+namespace Testing.ResourceNames.Tests
+{
+    /// <summary>Generated unit tests.</summary>
+    public sealed class GeneratedResourceNamesClientTest
+    {
+        [xunit::FactAttribute]
+        public void SinglePatternMethodRequestObject()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            SinglePattern request = new SinglePattern
+            {
+                RealNameAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RefAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsSinglePatternNames =
+                {
+                    SinglePatternName.FromItem("[ITEM_ID]"),
+                },
+                ValueRefAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RepeatedValueRefAsSinglePatternNames =
+                {
+                    SinglePatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.SinglePatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response response = client.SinglePatternMethod(request);
+            xunit::Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public async stt::Task SinglePatternMethodRequestObjectAsync()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            SinglePattern request = new SinglePattern
+            {
+                RealNameAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RefAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsSinglePatternNames =
+                {
+                    SinglePatternName.FromItem("[ITEM_ID]"),
+                },
+                ValueRefAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RepeatedValueRefAsSinglePatternNames =
+                {
+                    SinglePatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.SinglePatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response responseCallSettings = await client.SinglePatternMethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
+            xunit::Assert.Same(expectedResponse, responseCallSettings);
+            Response responseCancellationToken = await client.SinglePatternMethodAsync(request, st::CancellationToken.None);
+            xunit::Assert.Same(expectedResponse, responseCancellationToken);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public void SinglePatternMethod()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            SinglePattern request = new SinglePattern
+            {
+                RealNameAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RefAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsSinglePatternNames =
+                {
+                    SinglePatternName.FromItem("[ITEM_ID]"),
+                },
+                ValueRefAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RepeatedValueRefAsSinglePatternNames =
+                {
+                    SinglePatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.SinglePatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response response = client.SinglePatternMethod(request.RealName, request.Ref, request.RepeatedRef, request.ValueRef, request.RepeatedValueRef);
+            xunit::Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public async stt::Task SinglePatternMethodAsync()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            SinglePattern request = new SinglePattern
+            {
+                RealNameAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RefAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsSinglePatternNames =
+                {
+                    SinglePatternName.FromItem("[ITEM_ID]"),
+                },
+                ValueRefAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RepeatedValueRefAsSinglePatternNames =
+                {
+                    SinglePatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.SinglePatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response responseCallSettings = await client.SinglePatternMethodAsync(request.RealName, request.Ref, request.RepeatedRef, request.ValueRef, request.RepeatedValueRef, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
+            xunit::Assert.Same(expectedResponse, responseCallSettings);
+            Response responseCancellationToken = await client.SinglePatternMethodAsync(request.RealName, request.Ref, request.RepeatedRef, request.ValueRef, request.RepeatedValueRef, st::CancellationToken.None);
+            xunit::Assert.Same(expectedResponse, responseCancellationToken);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public void SinglePatternMethodResourceNames()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            SinglePattern request = new SinglePattern
+            {
+                RealNameAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RefAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsSinglePatternNames =
+                {
+                    SinglePatternName.FromItem("[ITEM_ID]"),
+                },
+                ValueRefAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RepeatedValueRefAsSinglePatternNames =
+                {
+                    SinglePatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.SinglePatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response response = client.SinglePatternMethod(request.RealNameAsSinglePatternName, request.RefAsSinglePatternName, request.RepeatedRefAsSinglePatternNames, request.ValueRefAsSinglePatternName, request.RepeatedValueRefAsSinglePatternNames);
+            xunit::Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public async stt::Task SinglePatternMethodResourceNamesAsync()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            SinglePattern request = new SinglePattern
+            {
+                RealNameAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RefAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsSinglePatternNames =
+                {
+                    SinglePatternName.FromItem("[ITEM_ID]"),
+                },
+                ValueRefAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RepeatedValueRefAsSinglePatternNames =
+                {
+                    SinglePatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.SinglePatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response responseCallSettings = await client.SinglePatternMethodAsync(request.RealNameAsSinglePatternName, request.RefAsSinglePatternName, request.RepeatedRefAsSinglePatternNames, request.ValueRefAsSinglePatternName, request.RepeatedValueRefAsSinglePatternNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
+            xunit::Assert.Same(expectedResponse, responseCallSettings);
+            Response responseCancellationToken = await client.SinglePatternMethodAsync(request.RealNameAsSinglePatternName, request.RefAsSinglePatternName, request.RepeatedRefAsSinglePatternNames, request.ValueRefAsSinglePatternName, request.RepeatedValueRefAsSinglePatternNames, st::CancellationToken.None);
+            xunit::Assert.Same(expectedResponse, responseCancellationToken);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public void WildcardOnlyPatternMethodRequestObject()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardOnlyPattern request = new WildcardOnlyPattern
+            {
+                ResourceName = new gax::UnparsedResourceName("a/wildcard/resource"),
+                RefAsResourceName = new gax::UnparsedResourceName("a/wildcard/resource"),
+                RepeatedRefAsResourceNames =
+                {
+                    new gax::UnparsedResourceName("a/wildcard/resource"),
+                },
+                RefSugarAsResourceName = new gax::UnparsedResourceName("a/wildcard/resource"),
+                RepeatedRefSugarAsResourceNames =
+                {
+                    new gax::UnparsedResourceName("a/wildcard/resource"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardOnlyPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response response = client.WildcardOnlyPatternMethod(request);
+            xunit::Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public async stt::Task WildcardOnlyPatternMethodRequestObjectAsync()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardOnlyPattern request = new WildcardOnlyPattern
+            {
+                ResourceName = new gax::UnparsedResourceName("a/wildcard/resource"),
+                RefAsResourceName = new gax::UnparsedResourceName("a/wildcard/resource"),
+                RepeatedRefAsResourceNames =
+                {
+                    new gax::UnparsedResourceName("a/wildcard/resource"),
+                },
+                RefSugarAsResourceName = new gax::UnparsedResourceName("a/wildcard/resource"),
+                RepeatedRefSugarAsResourceNames =
+                {
+                    new gax::UnparsedResourceName("a/wildcard/resource"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardOnlyPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response responseCallSettings = await client.WildcardOnlyPatternMethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
+            xunit::Assert.Same(expectedResponse, responseCallSettings);
+            Response responseCancellationToken = await client.WildcardOnlyPatternMethodAsync(request, st::CancellationToken.None);
+            xunit::Assert.Same(expectedResponse, responseCancellationToken);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public void WildcardOnlyPatternMethod()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardOnlyPattern request = new WildcardOnlyPattern
+            {
+                ResourceName = new gax::UnparsedResourceName("a/wildcard/resource"),
+                RefAsResourceName = new gax::UnparsedResourceName("a/wildcard/resource"),
+                RepeatedRefAsResourceNames =
+                {
+                    new gax::UnparsedResourceName("a/wildcard/resource"),
+                },
+                RefSugarAsResourceName = new gax::UnparsedResourceName("a/wildcard/resource"),
+                RepeatedRefSugarAsResourceNames =
+                {
+                    new gax::UnparsedResourceName("a/wildcard/resource"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardOnlyPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response response = client.WildcardOnlyPatternMethod(request.Name, request.Ref, request.RepeatedRef, request.RefSugar, request.RepeatedRefSugar);
+            xunit::Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public async stt::Task WildcardOnlyPatternMethodAsync()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardOnlyPattern request = new WildcardOnlyPattern
+            {
+                ResourceName = new gax::UnparsedResourceName("a/wildcard/resource"),
+                RefAsResourceName = new gax::UnparsedResourceName("a/wildcard/resource"),
+                RepeatedRefAsResourceNames =
+                {
+                    new gax::UnparsedResourceName("a/wildcard/resource"),
+                },
+                RefSugarAsResourceName = new gax::UnparsedResourceName("a/wildcard/resource"),
+                RepeatedRefSugarAsResourceNames =
+                {
+                    new gax::UnparsedResourceName("a/wildcard/resource"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardOnlyPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response responseCallSettings = await client.WildcardOnlyPatternMethodAsync(request.Name, request.Ref, request.RepeatedRef, request.RefSugar, request.RepeatedRefSugar, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
+            xunit::Assert.Same(expectedResponse, responseCallSettings);
+            Response responseCancellationToken = await client.WildcardOnlyPatternMethodAsync(request.Name, request.Ref, request.RepeatedRef, request.RefSugar, request.RepeatedRefSugar, st::CancellationToken.None);
+            xunit::Assert.Same(expectedResponse, responseCancellationToken);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public void WildcardOnlyPatternMethodResourceNames()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardOnlyPattern request = new WildcardOnlyPattern
+            {
+                ResourceName = new gax::UnparsedResourceName("a/wildcard/resource"),
+                RefAsResourceName = new gax::UnparsedResourceName("a/wildcard/resource"),
+                RepeatedRefAsResourceNames =
+                {
+                    new gax::UnparsedResourceName("a/wildcard/resource"),
+                },
+                RefSugarAsResourceName = new gax::UnparsedResourceName("a/wildcard/resource"),
+                RepeatedRefSugarAsResourceNames =
+                {
+                    new gax::UnparsedResourceName("a/wildcard/resource"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardOnlyPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response response = client.WildcardOnlyPatternMethod(request.ResourceName, request.RefAsResourceName, request.RepeatedRefAsResourceNames, request.RefSugarAsResourceName, request.RepeatedRefSugarAsResourceNames);
+            xunit::Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public async stt::Task WildcardOnlyPatternMethodResourceNamesAsync()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardOnlyPattern request = new WildcardOnlyPattern
+            {
+                ResourceName = new gax::UnparsedResourceName("a/wildcard/resource"),
+                RefAsResourceName = new gax::UnparsedResourceName("a/wildcard/resource"),
+                RepeatedRefAsResourceNames =
+                {
+                    new gax::UnparsedResourceName("a/wildcard/resource"),
+                },
+                RefSugarAsResourceName = new gax::UnparsedResourceName("a/wildcard/resource"),
+                RepeatedRefSugarAsResourceNames =
+                {
+                    new gax::UnparsedResourceName("a/wildcard/resource"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardOnlyPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response responseCallSettings = await client.WildcardOnlyPatternMethodAsync(request.ResourceName, request.RefAsResourceName, request.RepeatedRefAsResourceNames, request.RefSugarAsResourceName, request.RepeatedRefSugarAsResourceNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
+            xunit::Assert.Same(expectedResponse, responseCallSettings);
+            Response responseCancellationToken = await client.WildcardOnlyPatternMethodAsync(request.ResourceName, request.RefAsResourceName, request.RepeatedRefAsResourceNames, request.RefSugarAsResourceName, request.RepeatedRefSugarAsResourceNames, st::CancellationToken.None);
+            xunit::Assert.Same(expectedResponse, responseCancellationToken);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public void WildcardMultiPatternMethodRequestObject()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPattern request = new WildcardMultiPattern
+            {
+                WildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RefAsWildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsWildcardMultiPatternNames =
+                {
+                    WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response response = client.WildcardMultiPatternMethod(request);
+            xunit::Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public async stt::Task WildcardMultiPatternMethodRequestObjectAsync()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPattern request = new WildcardMultiPattern
+            {
+                WildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RefAsWildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsWildcardMultiPatternNames =
+                {
+                    WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response responseCallSettings = await client.WildcardMultiPatternMethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
+            xunit::Assert.Same(expectedResponse, responseCallSettings);
+            Response responseCancellationToken = await client.WildcardMultiPatternMethodAsync(request, st::CancellationToken.None);
+            xunit::Assert.Same(expectedResponse, responseCancellationToken);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public void WildcardMultiPatternMethod()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPattern request = new WildcardMultiPattern
+            {
+                WildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RefAsWildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsWildcardMultiPatternNames =
+                {
+                    WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response response = client.WildcardMultiPatternMethod(request.Name, request.Ref, request.RepeatedRef);
+            xunit::Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public async stt::Task WildcardMultiPatternMethodAsync()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPattern request = new WildcardMultiPattern
+            {
+                WildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RefAsWildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsWildcardMultiPatternNames =
+                {
+                    WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response responseCallSettings = await client.WildcardMultiPatternMethodAsync(request.Name, request.Ref, request.RepeatedRef, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
+            xunit::Assert.Same(expectedResponse, responseCallSettings);
+            Response responseCancellationToken = await client.WildcardMultiPatternMethodAsync(request.Name, request.Ref, request.RepeatedRef, st::CancellationToken.None);
+            xunit::Assert.Same(expectedResponse, responseCancellationToken);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public void WildcardMultiPatternMethodResourceNames1()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPattern request = new WildcardMultiPattern
+            {
+                WildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RefAsWildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsWildcardMultiPatternNames =
+                {
+                    WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response response = client.WildcardMultiPatternMethod(request.WildcardMultiPatternName, request.RefAsWildcardMultiPatternName, request.RepeatedRefAsWildcardMultiPatternNames);
+            xunit::Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public async stt::Task WildcardMultiPatternMethodResourceNames1Async()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPattern request = new WildcardMultiPattern
+            {
+                WildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RefAsWildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsWildcardMultiPatternNames =
+                {
+                    WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response responseCallSettings = await client.WildcardMultiPatternMethodAsync(request.WildcardMultiPatternName, request.RefAsWildcardMultiPatternName, request.RepeatedRefAsWildcardMultiPatternNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
+            xunit::Assert.Same(expectedResponse, responseCallSettings);
+            Response responseCancellationToken = await client.WildcardMultiPatternMethodAsync(request.WildcardMultiPatternName, request.RefAsWildcardMultiPatternName, request.RepeatedRefAsWildcardMultiPatternNames, st::CancellationToken.None);
+            xunit::Assert.Same(expectedResponse, responseCancellationToken);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public void WildcardMultiPatternMethodResourceNames2()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPattern request = new WildcardMultiPattern
+            {
+                WildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RefAsWildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsWildcardMultiPatternNames =
+                {
+                    WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response response = client.WildcardMultiPatternMethod(request.WildcardMultiPatternName, request.RefAsWildcardMultiPatternName, request.RepeatedRefAsResourceNames);
+            xunit::Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public async stt::Task WildcardMultiPatternMethodResourceNames2Async()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPattern request = new WildcardMultiPattern
+            {
+                WildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RefAsWildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsWildcardMultiPatternNames =
+                {
+                    WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response responseCallSettings = await client.WildcardMultiPatternMethodAsync(request.WildcardMultiPatternName, request.RefAsWildcardMultiPatternName, request.RepeatedRefAsResourceNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
+            xunit::Assert.Same(expectedResponse, responseCallSettings);
+            Response responseCancellationToken = await client.WildcardMultiPatternMethodAsync(request.WildcardMultiPatternName, request.RefAsWildcardMultiPatternName, request.RepeatedRefAsResourceNames, st::CancellationToken.None);
+            xunit::Assert.Same(expectedResponse, responseCancellationToken);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public void WildcardMultiPatternMethodResourceNames3()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPattern request = new WildcardMultiPattern
+            {
+                WildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RefAsWildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsWildcardMultiPatternNames =
+                {
+                    WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response response = client.WildcardMultiPatternMethod(request.WildcardMultiPatternName, request.RefAsResourceName, request.RepeatedRefAsWildcardMultiPatternNames);
+            xunit::Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public async stt::Task WildcardMultiPatternMethodResourceNames3Async()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPattern request = new WildcardMultiPattern
+            {
+                WildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RefAsWildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsWildcardMultiPatternNames =
+                {
+                    WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response responseCallSettings = await client.WildcardMultiPatternMethodAsync(request.WildcardMultiPatternName, request.RefAsResourceName, request.RepeatedRefAsWildcardMultiPatternNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
+            xunit::Assert.Same(expectedResponse, responseCallSettings);
+            Response responseCancellationToken = await client.WildcardMultiPatternMethodAsync(request.WildcardMultiPatternName, request.RefAsResourceName, request.RepeatedRefAsWildcardMultiPatternNames, st::CancellationToken.None);
+            xunit::Assert.Same(expectedResponse, responseCancellationToken);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public void WildcardMultiPatternMethodResourceNames4()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPattern request = new WildcardMultiPattern
+            {
+                WildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RefAsWildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsWildcardMultiPatternNames =
+                {
+                    WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response response = client.WildcardMultiPatternMethod(request.WildcardMultiPatternName, request.RefAsResourceName, request.RepeatedRefAsResourceNames);
+            xunit::Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public async stt::Task WildcardMultiPatternMethodResourceNames4Async()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPattern request = new WildcardMultiPattern
+            {
+                WildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RefAsWildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsWildcardMultiPatternNames =
+                {
+                    WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response responseCallSettings = await client.WildcardMultiPatternMethodAsync(request.WildcardMultiPatternName, request.RefAsResourceName, request.RepeatedRefAsResourceNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
+            xunit::Assert.Same(expectedResponse, responseCallSettings);
+            Response responseCancellationToken = await client.WildcardMultiPatternMethodAsync(request.WildcardMultiPatternName, request.RefAsResourceName, request.RepeatedRefAsResourceNames, st::CancellationToken.None);
+            xunit::Assert.Same(expectedResponse, responseCancellationToken);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public void WildcardMultiPatternMethodResourceNames5()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPattern request = new WildcardMultiPattern
+            {
+                WildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RefAsWildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsWildcardMultiPatternNames =
+                {
+                    WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response response = client.WildcardMultiPatternMethod(request.ResourceName, request.RefAsWildcardMultiPatternName, request.RepeatedRefAsWildcardMultiPatternNames);
+            xunit::Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public async stt::Task WildcardMultiPatternMethodResourceNames5Async()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPattern request = new WildcardMultiPattern
+            {
+                WildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RefAsWildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsWildcardMultiPatternNames =
+                {
+                    WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response responseCallSettings = await client.WildcardMultiPatternMethodAsync(request.ResourceName, request.RefAsWildcardMultiPatternName, request.RepeatedRefAsWildcardMultiPatternNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
+            xunit::Assert.Same(expectedResponse, responseCallSettings);
+            Response responseCancellationToken = await client.WildcardMultiPatternMethodAsync(request.ResourceName, request.RefAsWildcardMultiPatternName, request.RepeatedRefAsWildcardMultiPatternNames, st::CancellationToken.None);
+            xunit::Assert.Same(expectedResponse, responseCancellationToken);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public void WildcardMultiPatternMethodResourceNames6()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPattern request = new WildcardMultiPattern
+            {
+                WildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RefAsWildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsWildcardMultiPatternNames =
+                {
+                    WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response response = client.WildcardMultiPatternMethod(request.ResourceName, request.RefAsWildcardMultiPatternName, request.RepeatedRefAsResourceNames);
+            xunit::Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public async stt::Task WildcardMultiPatternMethodResourceNames6Async()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPattern request = new WildcardMultiPattern
+            {
+                WildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RefAsWildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsWildcardMultiPatternNames =
+                {
+                    WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response responseCallSettings = await client.WildcardMultiPatternMethodAsync(request.ResourceName, request.RefAsWildcardMultiPatternName, request.RepeatedRefAsResourceNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
+            xunit::Assert.Same(expectedResponse, responseCallSettings);
+            Response responseCancellationToken = await client.WildcardMultiPatternMethodAsync(request.ResourceName, request.RefAsWildcardMultiPatternName, request.RepeatedRefAsResourceNames, st::CancellationToken.None);
+            xunit::Assert.Same(expectedResponse, responseCancellationToken);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public void WildcardMultiPatternMethodResourceNames7()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPattern request = new WildcardMultiPattern
+            {
+                WildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RefAsWildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsWildcardMultiPatternNames =
+                {
+                    WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response response = client.WildcardMultiPatternMethod(request.ResourceName, request.RefAsResourceName, request.RepeatedRefAsWildcardMultiPatternNames);
+            xunit::Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public async stt::Task WildcardMultiPatternMethodResourceNames7Async()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPattern request = new WildcardMultiPattern
+            {
+                WildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RefAsWildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsWildcardMultiPatternNames =
+                {
+                    WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response responseCallSettings = await client.WildcardMultiPatternMethodAsync(request.ResourceName, request.RefAsResourceName, request.RepeatedRefAsWildcardMultiPatternNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
+            xunit::Assert.Same(expectedResponse, responseCallSettings);
+            Response responseCancellationToken = await client.WildcardMultiPatternMethodAsync(request.ResourceName, request.RefAsResourceName, request.RepeatedRefAsWildcardMultiPatternNames, st::CancellationToken.None);
+            xunit::Assert.Same(expectedResponse, responseCancellationToken);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public void WildcardMultiPatternMethodResourceNames8()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPattern request = new WildcardMultiPattern
+            {
+                WildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RefAsWildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsWildcardMultiPatternNames =
+                {
+                    WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response response = client.WildcardMultiPatternMethod(request.ResourceName, request.RefAsResourceName, request.RepeatedRefAsResourceNames);
+            xunit::Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public async stt::Task WildcardMultiPatternMethodResourceNames8Async()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPattern request = new WildcardMultiPattern
+            {
+                WildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RefAsWildcardMultiPatternName = WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsWildcardMultiPatternNames =
+                {
+                    WildcardMultiPatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response responseCallSettings = await client.WildcardMultiPatternMethodAsync(request.ResourceName, request.RefAsResourceName, request.RepeatedRefAsResourceNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
+            xunit::Assert.Same(expectedResponse, responseCallSettings);
+            Response responseCancellationToken = await client.WildcardMultiPatternMethodAsync(request.ResourceName, request.RefAsResourceName, request.RepeatedRefAsResourceNames, st::CancellationToken.None);
+            xunit::Assert.Same(expectedResponse, responseCancellationToken);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public void WildcardMultiPatternMultipleMethodRequestObject()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPatternMultiple request = new WildcardMultiPatternMultiple
+            {
+                WildcardMultiPatternMultipleName = WildcardMultiPatternMultipleName.FromConstPattern(),
+                RefAsWildcardMultiPatternMultipleName = WildcardMultiPatternMultipleName.FromConstPattern(),
+                RepeatedRefAsWildcardMultiPatternMultipleNames =
+                {
+                    WildcardMultiPatternMultipleName.FromConstPattern(),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMultipleMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response response = client.WildcardMultiPatternMultipleMethod(request);
+            xunit::Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public async stt::Task WildcardMultiPatternMultipleMethodRequestObjectAsync()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPatternMultiple request = new WildcardMultiPatternMultiple
+            {
+                WildcardMultiPatternMultipleName = WildcardMultiPatternMultipleName.FromConstPattern(),
+                RefAsWildcardMultiPatternMultipleName = WildcardMultiPatternMultipleName.FromConstPattern(),
+                RepeatedRefAsWildcardMultiPatternMultipleNames =
+                {
+                    WildcardMultiPatternMultipleName.FromConstPattern(),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMultipleMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response responseCallSettings = await client.WildcardMultiPatternMultipleMethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
+            xunit::Assert.Same(expectedResponse, responseCallSettings);
+            Response responseCancellationToken = await client.WildcardMultiPatternMultipleMethodAsync(request, st::CancellationToken.None);
+            xunit::Assert.Same(expectedResponse, responseCancellationToken);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public void WildcardMultiPatternMultipleMethod()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPatternMultiple request = new WildcardMultiPatternMultiple
+            {
+                RefAsWildcardMultiPatternMultipleName = WildcardMultiPatternMultipleName.FromConstPattern(),
+                RepeatedRefAsWildcardMultiPatternMultipleNames =
+                {
+                    WildcardMultiPatternMultipleName.FromConstPattern(),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMultipleMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response response = client.WildcardMultiPatternMultipleMethod(request.Ref, request.RepeatedRef);
+            xunit::Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public async stt::Task WildcardMultiPatternMultipleMethodAsync()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPatternMultiple request = new WildcardMultiPatternMultiple
+            {
+                RefAsWildcardMultiPatternMultipleName = WildcardMultiPatternMultipleName.FromConstPattern(),
+                RepeatedRefAsWildcardMultiPatternMultipleNames =
+                {
+                    WildcardMultiPatternMultipleName.FromConstPattern(),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMultipleMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response responseCallSettings = await client.WildcardMultiPatternMultipleMethodAsync(request.Ref, request.RepeatedRef, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
+            xunit::Assert.Same(expectedResponse, responseCallSettings);
+            Response responseCancellationToken = await client.WildcardMultiPatternMultipleMethodAsync(request.Ref, request.RepeatedRef, st::CancellationToken.None);
+            xunit::Assert.Same(expectedResponse, responseCancellationToken);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public void WildcardMultiPatternMultipleMethodResourceNames1()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPatternMultiple request = new WildcardMultiPatternMultiple
+            {
+                RefAsWildcardMultiPatternMultipleName = WildcardMultiPatternMultipleName.FromConstPattern(),
+                RepeatedRefAsWildcardMultiPatternMultipleNames =
+                {
+                    WildcardMultiPatternMultipleName.FromConstPattern(),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMultipleMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response response = client.WildcardMultiPatternMultipleMethod(request.RefAsWildcardMultiPatternMultipleName, request.RepeatedRefAsWildcardMultiPatternMultipleNames);
+            xunit::Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public async stt::Task WildcardMultiPatternMultipleMethodResourceNames1Async()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPatternMultiple request = new WildcardMultiPatternMultiple
+            {
+                RefAsWildcardMultiPatternMultipleName = WildcardMultiPatternMultipleName.FromConstPattern(),
+                RepeatedRefAsWildcardMultiPatternMultipleNames =
+                {
+                    WildcardMultiPatternMultipleName.FromConstPattern(),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMultipleMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response responseCallSettings = await client.WildcardMultiPatternMultipleMethodAsync(request.RefAsWildcardMultiPatternMultipleName, request.RepeatedRefAsWildcardMultiPatternMultipleNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
+            xunit::Assert.Same(expectedResponse, responseCallSettings);
+            Response responseCancellationToken = await client.WildcardMultiPatternMultipleMethodAsync(request.RefAsWildcardMultiPatternMultipleName, request.RepeatedRefAsWildcardMultiPatternMultipleNames, st::CancellationToken.None);
+            xunit::Assert.Same(expectedResponse, responseCancellationToken);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public void WildcardMultiPatternMultipleMethodResourceNames2()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPatternMultiple request = new WildcardMultiPatternMultiple
+            {
+                RefAsWildcardMultiPatternMultipleName = WildcardMultiPatternMultipleName.FromConstPattern(),
+                RepeatedRefAsWildcardMultiPatternMultipleNames =
+                {
+                    WildcardMultiPatternMultipleName.FromConstPattern(),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMultipleMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response response = client.WildcardMultiPatternMultipleMethod(request.RefAsWildcardMultiPatternMultipleName, request.RepeatedRefAsResourceNames);
+            xunit::Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public async stt::Task WildcardMultiPatternMultipleMethodResourceNames2Async()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPatternMultiple request = new WildcardMultiPatternMultiple
+            {
+                RefAsWildcardMultiPatternMultipleName = WildcardMultiPatternMultipleName.FromConstPattern(),
+                RepeatedRefAsWildcardMultiPatternMultipleNames =
+                {
+                    WildcardMultiPatternMultipleName.FromConstPattern(),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMultipleMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response responseCallSettings = await client.WildcardMultiPatternMultipleMethodAsync(request.RefAsWildcardMultiPatternMultipleName, request.RepeatedRefAsResourceNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
+            xunit::Assert.Same(expectedResponse, responseCallSettings);
+            Response responseCancellationToken = await client.WildcardMultiPatternMultipleMethodAsync(request.RefAsWildcardMultiPatternMultipleName, request.RepeatedRefAsResourceNames, st::CancellationToken.None);
+            xunit::Assert.Same(expectedResponse, responseCancellationToken);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public void WildcardMultiPatternMultipleMethodResourceNames3()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPatternMultiple request = new WildcardMultiPatternMultiple
+            {
+                RefAsWildcardMultiPatternMultipleName = WildcardMultiPatternMultipleName.FromConstPattern(),
+                RepeatedRefAsWildcardMultiPatternMultipleNames =
+                {
+                    WildcardMultiPatternMultipleName.FromConstPattern(),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMultipleMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response response = client.WildcardMultiPatternMultipleMethod(request.RefAsResourceName, request.RepeatedRefAsWildcardMultiPatternMultipleNames);
+            xunit::Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public async stt::Task WildcardMultiPatternMultipleMethodResourceNames3Async()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPatternMultiple request = new WildcardMultiPatternMultiple
+            {
+                RefAsWildcardMultiPatternMultipleName = WildcardMultiPatternMultipleName.FromConstPattern(),
+                RepeatedRefAsWildcardMultiPatternMultipleNames =
+                {
+                    WildcardMultiPatternMultipleName.FromConstPattern(),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMultipleMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response responseCallSettings = await client.WildcardMultiPatternMultipleMethodAsync(request.RefAsResourceName, request.RepeatedRefAsWildcardMultiPatternMultipleNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
+            xunit::Assert.Same(expectedResponse, responseCallSettings);
+            Response responseCancellationToken = await client.WildcardMultiPatternMultipleMethodAsync(request.RefAsResourceName, request.RepeatedRefAsWildcardMultiPatternMultipleNames, st::CancellationToken.None);
+            xunit::Assert.Same(expectedResponse, responseCancellationToken);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public void WildcardMultiPatternMultipleMethodResourceNames4()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPatternMultiple request = new WildcardMultiPatternMultiple
+            {
+                RefAsWildcardMultiPatternMultipleName = WildcardMultiPatternMultipleName.FromConstPattern(),
+                RepeatedRefAsWildcardMultiPatternMultipleNames =
+                {
+                    WildcardMultiPatternMultipleName.FromConstPattern(),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMultipleMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response response = client.WildcardMultiPatternMultipleMethod(request.RefAsResourceName, request.RepeatedRefAsResourceNames);
+            xunit::Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public async stt::Task WildcardMultiPatternMultipleMethodResourceNames4Async()
+        {
+            moq::Mock<ResourceNames.ResourceNamesClient> mockGrpcClient = new moq::Mock<ResourceNames.ResourceNamesClient>(moq::MockBehavior.Strict);
+            WildcardMultiPatternMultiple request = new WildcardMultiPatternMultiple
+            {
+                RefAsWildcardMultiPatternMultipleName = WildcardMultiPatternMultipleName.FromConstPattern(),
+                RepeatedRefAsWildcardMultiPatternMultipleNames =
+                {
+                    WildcardMultiPatternMultipleName.FromConstPattern(),
+                },
+            };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.WildcardMultiPatternMultipleMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            Response responseCallSettings = await client.WildcardMultiPatternMultipleMethodAsync(request.RefAsResourceName, request.RepeatedRefAsResourceNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
+            xunit::Assert.Same(expectedResponse, responseCallSettings);
+            Response responseCancellationToken = await client.WildcardMultiPatternMultipleMethodAsync(request.RefAsResourceName, request.RepeatedRefAsResourceNames, st::CancellationToken.None);
+            xunit::Assert.Same(expectedResponse, responseCancellationToken);
+            mockGrpcClient.VerifyAll();
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames/ResourceNamesClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames/ResourceNamesClient.g.cs
@@ -14,22 +14,253 @@
 
 // Generated code. DO NOT EDIT!
 
-using gaxgrpc = Google.Api.Gax.Grpc;
 using gax = Google.Api.Gax;
-using linq = System.Linq;
+using gaxgrpc = Google.Api.Gax.Grpc;
+using gaxgrpccore = Google.Api.Gax.Grpc.GrpcCore;
+using proto = Google.Protobuf;
+using grpccore = Grpc.Core;
+using grpcinter = Grpc.Core.Interceptors;
+using sys = System;
 using scg = System.Collections.Generic;
+using sco = System.Collections.ObjectModel;
+using linq = System.Linq;
 using st = System.Threading;
 using stt = System.Threading.Tasks;
-using sys = System;
 
 namespace Testing.ResourceNames
 {
-    public abstract class ResourceNamesClient
+    /// <summary>Settings for <see cref="ResourceNamesClient"/> instances.</summary>
+    public sealed partial class ResourceNamesSettings : gaxgrpc::ServiceSettingsBase
     {
-        public Response SinglePatternMethod(SinglePattern request, gaxgrpc::CallSettings callSettings) => throw new sys::NotImplementedException();
-        public stt::Task<Response> SinglePatternMethodAsync(SinglePattern request, gaxgrpc::CallSettings callSettings) => throw new sys::NotImplementedException();
+        /// <summary>Get a new instance of the default <see cref="ResourceNamesSettings"/>.</summary>
+        /// <returns>A new instance of the default <see cref="ResourceNamesSettings"/>.</returns>
+        public static ResourceNamesSettings GetDefault() => new ResourceNamesSettings();
 
-        // TEST_START
+        /// <summary>Constructs a new <see cref="ResourceNamesSettings"/> object with default settings.</summary>
+        public ResourceNamesSettings()
+        {
+        }
+
+        private ResourceNamesSettings(ResourceNamesSettings existing) : base(existing)
+        {
+            gax::GaxPreconditions.CheckNotNull(existing, nameof(existing));
+            SinglePatternMethodSettings = existing.SinglePatternMethodSettings;
+            WildcardOnlyPatternMethodSettings = existing.WildcardOnlyPatternMethodSettings;
+            WildcardMultiPatternMethodSettings = existing.WildcardMultiPatternMethodSettings;
+            WildcardMultiPatternMultipleMethodSettings = existing.WildcardMultiPatternMultipleMethodSettings;
+            OnCopy(existing);
+        }
+
+        partial void OnCopy(ResourceNamesSettings existing);
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>ResourceNamesClient.SinglePatternMethod</c> and <c>ResourceNamesClient.SinglePatternMethodAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// <list type="bullet">
+        /// <item><description>This call will not be retried.</description></item>
+        /// <item><description>No timeout is applied.</description></item>
+        /// </list>
+        /// </remarks>
+        public gaxgrpc::CallSettings SinglePatternMethodSettings { get; set; } = gaxgrpc::CallSettings.FromExpiration(gax::Expiration.None);
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>ResourceNamesClient.WildcardOnlyPatternMethod</c> and
+        /// <c>ResourceNamesClient.WildcardOnlyPatternMethodAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// <list type="bullet">
+        /// <item><description>This call will not be retried.</description></item>
+        /// <item><description>No timeout is applied.</description></item>
+        /// </list>
+        /// </remarks>
+        public gaxgrpc::CallSettings WildcardOnlyPatternMethodSettings { get; set; } = gaxgrpc::CallSettings.FromExpiration(gax::Expiration.None);
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>ResourceNamesClient.WildcardMultiPatternMethod</c> and
+        /// <c>ResourceNamesClient.WildcardMultiPatternMethodAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// <list type="bullet">
+        /// <item><description>This call will not be retried.</description></item>
+        /// <item><description>No timeout is applied.</description></item>
+        /// </list>
+        /// </remarks>
+        public gaxgrpc::CallSettings WildcardMultiPatternMethodSettings { get; set; } = gaxgrpc::CallSettings.FromExpiration(gax::Expiration.None);
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>ResourceNamesClient.WildcardMultiPatternMultipleMethod</c> and
+        /// <c>ResourceNamesClient.WildcardMultiPatternMultipleMethodAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// <list type="bullet">
+        /// <item><description>This call will not be retried.</description></item>
+        /// <item><description>No timeout is applied.</description></item>
+        /// </list>
+        /// </remarks>
+        public gaxgrpc::CallSettings WildcardMultiPatternMultipleMethodSettings { get; set; } = gaxgrpc::CallSettings.FromExpiration(gax::Expiration.None);
+
+        /// <summary>Creates a deep clone of this object, with all the same property values.</summary>
+        /// <returns>A deep clone of this <see cref="ResourceNamesSettings"/> object.</returns>
+        public ResourceNamesSettings Clone() => new ResourceNamesSettings(this);
+    }
+
+    /// <summary>
+    /// Builder class for <see cref="ResourceNamesClient"/> to provide simple configuration of credentials, endpoint
+    /// etc.
+    /// </summary>
+    public sealed partial class ResourceNamesClientBuilder : gaxgrpc::ClientBuilderBase<ResourceNamesClient>
+    {
+        /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
+        public ResourceNamesSettings Settings { get; set; }
+
+        partial void InterceptBuild(ref ResourceNamesClient client);
+
+        partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ResourceNamesClient> task);
+
+        /// <summary>Builds the resulting client.</summary>
+        public override ResourceNamesClient Build()
+        {
+            ResourceNamesClient client = null;
+            InterceptBuild(ref client);
+            return client ?? BuildImpl();
+        }
+
+        /// <summary>Builds the resulting client asynchronously.</summary>
+        public override stt::Task<ResourceNamesClient> BuildAsync(st::CancellationToken cancellationToken = default)
+        {
+            stt::Task<ResourceNamesClient> task = null;
+            InterceptBuildAsync(cancellationToken, ref task);
+            return task ?? BuildAsyncImpl(cancellationToken);
+        }
+
+        private ResourceNamesClient BuildImpl()
+        {
+            Validate();
+            grpccore::CallInvoker callInvoker = CreateCallInvoker();
+            return ResourceNamesClient.Create(callInvoker, Settings);
+        }
+
+        private async stt::Task<ResourceNamesClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
+        {
+            Validate();
+            grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
+            return ResourceNamesClient.Create(callInvoker, Settings);
+        }
+
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
+        protected override string GetDefaultEndpoint() => ResourceNamesClient.DefaultEndpoint;
+
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
+        protected override scg::IReadOnlyList<string> GetDefaultScopes() => ResourceNamesClient.DefaultScopes;
+
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
+        protected override gaxgrpc::ChannelPool GetChannelPool() => ResourceNamesClient.ChannelPool;
+
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
+        protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
+    }
+
+    /// <summary>ResourceNames client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// </remarks>
+    public abstract partial class ResourceNamesClient
+    {
+        /// <summary>
+        /// The default endpoint for the ResourceNames service, which is a host of "" and a port of 443.
+        /// </summary>
+        public static string DefaultEndpoint { get; } = ":443";
+
+        /// <summary>The default ResourceNames scopes.</summary>
+        /// <remarks>The default ResourceNames scopes are:<list type="bullet"></list></remarks>
+        public static scg::IReadOnlyList<string> DefaultScopes { get; } = new sco::ReadOnlyCollection<string>(new string[] { });
+
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+
+        /// <summary>
+        /// Asynchronously creates a <see cref="ResourceNamesClient"/> using the default credentials, endpoint and
+        /// settings. To specify custom credentials or other settings, use <see cref="ResourceNamesClientBuilder"/>.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// The <see cref="st::CancellationToken"/> to use while creating the client.
+        /// </param>
+        /// <returns>The task representing the created <see cref="ResourceNamesClient"/>.</returns>
+        public static stt::Task<ResourceNamesClient> CreateAsync(st::CancellationToken cancellationToken = default) =>
+            new ResourceNamesClientBuilder().BuildAsync(cancellationToken);
+
+        /// <summary>
+        /// Synchronously creates a <see cref="ResourceNamesClient"/> using the default credentials, endpoint and
+        /// settings. To specify custom credentials or other settings, use <see cref="ResourceNamesClientBuilder"/>.
+        /// </summary>
+        /// <returns>The created <see cref="ResourceNamesClient"/>.</returns>
+        public static ResourceNamesClient Create() => new ResourceNamesClientBuilder().Build();
+
+        /// <summary>
+        /// Creates a <see cref="ResourceNamesClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">
+        /// The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.
+        /// </param>
+        /// <param name="settings">Optional <see cref="ResourceNamesSettings"/>.</param>
+        /// <returns>The created <see cref="ResourceNamesClient"/>.</returns>
+        internal static ResourceNamesClient Create(grpccore::CallInvoker callInvoker, ResourceNamesSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            grpcinter::Interceptor interceptor = settings?.Interceptor;
+            if (interceptor != null)
+            {
+                callInvoker = grpcinter::CallInvokerExtensions.Intercept(callInvoker, interceptor);
+            }
+            ResourceNames.ResourceNamesClient grpcClient = new ResourceNames.ResourceNamesClient(callInvoker);
+            return new ResourceNamesClientImpl(grpcClient, settings);
+        }
+
+        /// <summary>
+        /// Shuts down any channels automatically created by <see cref="Create()"/> and
+        /// <see cref="CreateAsync(st::CancellationToken)"/>. Channels which weren't automatically created are not
+        /// affected.
+        /// </summary>
+        /// <remarks>
+        /// After calling this method, further calls to <see cref="Create()"/> and
+        /// <see cref="CreateAsync(st::CancellationToken)"/> will create new channels, which could in turn be shut down
+        /// by another call to this method.
+        /// </remarks>
+        /// <returns>A task representing the asynchronous shutdown operation.</returns>
+        public static stt::Task ShutdownDefaultChannelsAsync() => ChannelPool.ShutdownChannelsAsync();
+
+        /// <summary>The underlying gRPC ResourceNames client</summary>
+        public virtual ResourceNames.ResourceNamesClient GrpcClient => throw new sys::NotImplementedException();
+
+        /// <summary>
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The RPC response.</returns>
+        public virtual Response SinglePatternMethod(SinglePattern request, gaxgrpc::CallSettings callSettings = null) =>
+            throw new sys::NotImplementedException();
+
+        /// <summary>
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual stt::Task<Response> SinglePatternMethodAsync(SinglePattern request, gaxgrpc::CallSettings callSettings = null) =>
+            throw new sys::NotImplementedException();
+
+        /// <summary>
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="cancellationToken">A <see cref="st::CancellationToken"/> to use for this RPC.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual stt::Task<Response> SinglePatternMethodAsync(SinglePattern request, st::CancellationToken cancellationToken) =>
+            SinglePatternMethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
         /// <summary>
         /// </summary>
         /// <param name="realName">
@@ -183,12 +414,31 @@ namespace Testing.ResourceNames
         /// <returns>A Task containing the RPC response.</returns>
         public virtual stt::Task<Response> SinglePatternMethodAsync(SinglePatternName realName, SinglePatternName @ref, scg::IEnumerable<SinglePatternName> repeatedRef, SinglePatternName valueRef, scg::IEnumerable<SinglePatternName> repeatedValueRef, st::CancellationToken cancellationToken) =>
             SinglePatternMethodAsync(realName, @ref, repeatedRef, valueRef, repeatedValueRef, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
-        // TEST_END
 
-        public Response WildcardOnlyPatternMethod(WildcardOnlyPattern request, gaxgrpc::CallSettings callSettings = null) => throw new sys::NotImplementedException();
-        public stt::Task<Response> WildcardOnlyPatternMethodAsync(WildcardOnlyPattern request, gaxgrpc::CallSettings callSettings = null) => throw new sys::NotImplementedException();
+        /// <summary>
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The RPC response.</returns>
+        public virtual Response WildcardOnlyPatternMethod(WildcardOnlyPattern request, gaxgrpc::CallSettings callSettings = null) =>
+            throw new sys::NotImplementedException();
 
-        // TEST_START
+        /// <summary>
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual stt::Task<Response> WildcardOnlyPatternMethodAsync(WildcardOnlyPattern request, gaxgrpc::CallSettings callSettings = null) =>
+            throw new sys::NotImplementedException();
+
+        /// <summary>
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="cancellationToken">A <see cref="st::CancellationToken"/> to use for this RPC.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual stt::Task<Response> WildcardOnlyPatternMethodAsync(WildcardOnlyPattern request, st::CancellationToken cancellationToken) =>
+            WildcardOnlyPatternMethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
         /// <summary>
         /// </summary>
         /// <param name="name">
@@ -342,12 +592,31 @@ namespace Testing.ResourceNames
         /// <returns>A Task containing the RPC response.</returns>
         public virtual stt::Task<Response> WildcardOnlyPatternMethodAsync(gax::IResourceName name, gax::IResourceName @ref, scg::IEnumerable<gax::IResourceName> repeatedRef, gax::IResourceName refSugar, scg::IEnumerable<gax::IResourceName> repeatedRefSugar, st::CancellationToken cancellationToken) =>
             WildcardOnlyPatternMethodAsync(name, @ref, repeatedRef, refSugar, repeatedRefSugar, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
-        // TEST_END
 
-        public Response WildcardMultiPatternMethod(WildcardMultiPattern request, gaxgrpc::CallSettings callSettings = null) => throw new sys::NotImplementedException();
-        public stt::Task<Response> WildcardMultiPatternMethodAsync(WildcardMultiPattern request, gaxgrpc::CallSettings callSettings = null) => throw new sys::NotImplementedException();
+        /// <summary>
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The RPC response.</returns>
+        public virtual Response WildcardMultiPatternMethod(WildcardMultiPattern request, gaxgrpc::CallSettings callSettings = null) =>
+            throw new sys::NotImplementedException();
 
-        // TEST_START
+        /// <summary>
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual stt::Task<Response> WildcardMultiPatternMethodAsync(WildcardMultiPattern request, gaxgrpc::CallSettings callSettings = null) =>
+            throw new sys::NotImplementedException();
+
+        /// <summary>
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="cancellationToken">A <see cref="st::CancellationToken"/> to use for this RPC.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual stt::Task<Response> WildcardMultiPatternMethodAsync(WildcardMultiPattern request, st::CancellationToken cancellationToken) =>
+            WildcardMultiPatternMethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
         /// <summary>
         /// </summary>
         /// <param name="name">
@@ -842,12 +1111,31 @@ namespace Testing.ResourceNames
         /// <returns>A Task containing the RPC response.</returns>
         public virtual stt::Task<Response> WildcardMultiPatternMethodAsync(gax::IResourceName name, gax::IResourceName @ref, scg::IEnumerable<gax::IResourceName> repeatedRef, st::CancellationToken cancellationToken) =>
             WildcardMultiPatternMethodAsync(name, @ref, repeatedRef, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
-        // TEST_END
 
-        public Response WildcardMultiPatternMultipleMethod(WildcardMultiPatternMultiple request, gaxgrpc::CallSettings callSettings = null) => throw new sys::NotImplementedException();
-        public stt::Task<Response> WildcardMultiPatternMultipleMethodAsync(WildcardMultiPatternMultiple request, gaxgrpc::CallSettings callSettings = null) => throw new sys::NotImplementedException();
+        /// <summary>
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The RPC response.</returns>
+        public virtual Response WildcardMultiPatternMultipleMethod(WildcardMultiPatternMultiple request, gaxgrpc::CallSettings callSettings = null) =>
+            throw new sys::NotImplementedException();
 
-        // TEST_START
+        /// <summary>
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual stt::Task<Response> WildcardMultiPatternMultipleMethodAsync(WildcardMultiPatternMultiple request, gaxgrpc::CallSettings callSettings = null) =>
+            throw new sys::NotImplementedException();
+
+        /// <summary>
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="cancellationToken">A <see cref="st::CancellationToken"/> to use for this RPC.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual stt::Task<Response> WildcardMultiPatternMultipleMethodAsync(WildcardMultiPatternMultiple request, st::CancellationToken cancellationToken) =>
+            WildcardMultiPatternMultipleMethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
         /// <summary>
         /// </summary>
         /// <param name="ref">
@@ -1082,6 +1370,155 @@ namespace Testing.ResourceNames
         /// <returns>A Task containing the RPC response.</returns>
         public virtual stt::Task<Response> WildcardMultiPatternMultipleMethodAsync(gax::IResourceName @ref, scg::IEnumerable<gax::IResourceName> repeatedRef, st::CancellationToken cancellationToken) =>
             WildcardMultiPatternMultipleMethodAsync(@ref, repeatedRef, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
-        // TEST_END
+    }
+
+    /// <summary>ResourceNames client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// </remarks>
+    public sealed partial class ResourceNamesClientImpl : ResourceNamesClient
+    {
+        private readonly gaxgrpc::ApiCall<SinglePattern, Response> _callSinglePatternMethod;
+
+        private readonly gaxgrpc::ApiCall<WildcardOnlyPattern, Response> _callWildcardOnlyPatternMethod;
+
+        private readonly gaxgrpc::ApiCall<WildcardMultiPattern, Response> _callWildcardMultiPatternMethod;
+
+        private readonly gaxgrpc::ApiCall<WildcardMultiPatternMultiple, Response> _callWildcardMultiPatternMultipleMethod;
+
+        /// <summary>
+        /// Constructs a client wrapper for the ResourceNames service, with the specified gRPC client and settings.
+        /// </summary>
+        /// <param name="grpcClient">The underlying gRPC client.</param>
+        /// <param name="settings">The base <see cref="ResourceNamesSettings"/> used within this client.</param>
+        public ResourceNamesClientImpl(ResourceNames.ResourceNamesClient grpcClient, ResourceNamesSettings settings)
+        {
+            GrpcClient = grpcClient;
+            ResourceNamesSettings effectiveSettings = settings ?? ResourceNamesSettings.GetDefault();
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings);
+            _callSinglePatternMethod = clientHelper.BuildApiCall<SinglePattern, Response>(grpcClient.SinglePatternMethodAsync, grpcClient.SinglePatternMethod, effectiveSettings.SinglePatternMethodSettings);
+            Modify_ApiCall(ref _callSinglePatternMethod);
+            Modify_SinglePatternMethodApiCall(ref _callSinglePatternMethod);
+            _callWildcardOnlyPatternMethod = clientHelper.BuildApiCall<WildcardOnlyPattern, Response>(grpcClient.WildcardOnlyPatternMethodAsync, grpcClient.WildcardOnlyPatternMethod, effectiveSettings.WildcardOnlyPatternMethodSettings);
+            Modify_ApiCall(ref _callWildcardOnlyPatternMethod);
+            Modify_WildcardOnlyPatternMethodApiCall(ref _callWildcardOnlyPatternMethod);
+            _callWildcardMultiPatternMethod = clientHelper.BuildApiCall<WildcardMultiPattern, Response>(grpcClient.WildcardMultiPatternMethodAsync, grpcClient.WildcardMultiPatternMethod, effectiveSettings.WildcardMultiPatternMethodSettings);
+            Modify_ApiCall(ref _callWildcardMultiPatternMethod);
+            Modify_WildcardMultiPatternMethodApiCall(ref _callWildcardMultiPatternMethod);
+            _callWildcardMultiPatternMultipleMethod = clientHelper.BuildApiCall<WildcardMultiPatternMultiple, Response>(grpcClient.WildcardMultiPatternMultipleMethodAsync, grpcClient.WildcardMultiPatternMultipleMethod, effectiveSettings.WildcardMultiPatternMultipleMethodSettings);
+            Modify_ApiCall(ref _callWildcardMultiPatternMultipleMethod);
+            Modify_WildcardMultiPatternMultipleMethodApiCall(ref _callWildcardMultiPatternMultipleMethod);
+            OnConstruction(grpcClient, effectiveSettings, clientHelper);
+        }
+
+        partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call) where TRequest : class, proto::IMessage<TRequest> where TResponse : class, proto::IMessage<TResponse>;
+
+        partial void Modify_SinglePatternMethodApiCall(ref gaxgrpc::ApiCall<SinglePattern, Response> call);
+
+        partial void Modify_WildcardOnlyPatternMethodApiCall(ref gaxgrpc::ApiCall<WildcardOnlyPattern, Response> call);
+
+        partial void Modify_WildcardMultiPatternMethodApiCall(ref gaxgrpc::ApiCall<WildcardMultiPattern, Response> call);
+
+        partial void Modify_WildcardMultiPatternMultipleMethodApiCall(ref gaxgrpc::ApiCall<WildcardMultiPatternMultiple, Response> call);
+
+        partial void OnConstruction(ResourceNames.ResourceNamesClient grpcClient, ResourceNamesSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);
+
+        /// <summary>The underlying gRPC ResourceNames client</summary>
+        public override ResourceNames.ResourceNamesClient GrpcClient { get; }
+
+        partial void Modify_SinglePattern(ref SinglePattern request, ref gaxgrpc::CallSettings settings);
+
+        partial void Modify_WildcardOnlyPattern(ref WildcardOnlyPattern request, ref gaxgrpc::CallSettings settings);
+
+        partial void Modify_WildcardMultiPattern(ref WildcardMultiPattern request, ref gaxgrpc::CallSettings settings);
+
+        partial void Modify_WildcardMultiPatternMultiple(ref WildcardMultiPatternMultiple request, ref gaxgrpc::CallSettings settings);
+
+        /// <summary>
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The RPC response.</returns>
+        public override Response SinglePatternMethod(SinglePattern request, gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_SinglePattern(ref request, ref callSettings);
+            return _callSinglePatternMethod.Sync(request, callSettings);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public override stt::Task<Response> SinglePatternMethodAsync(SinglePattern request, gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_SinglePattern(ref request, ref callSettings);
+            return _callSinglePatternMethod.Async(request, callSettings);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The RPC response.</returns>
+        public override Response WildcardOnlyPatternMethod(WildcardOnlyPattern request, gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_WildcardOnlyPattern(ref request, ref callSettings);
+            return _callWildcardOnlyPatternMethod.Sync(request, callSettings);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public override stt::Task<Response> WildcardOnlyPatternMethodAsync(WildcardOnlyPattern request, gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_WildcardOnlyPattern(ref request, ref callSettings);
+            return _callWildcardOnlyPatternMethod.Async(request, callSettings);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The RPC response.</returns>
+        public override Response WildcardMultiPatternMethod(WildcardMultiPattern request, gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_WildcardMultiPattern(ref request, ref callSettings);
+            return _callWildcardMultiPatternMethod.Sync(request, callSettings);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public override stt::Task<Response> WildcardMultiPatternMethodAsync(WildcardMultiPattern request, gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_WildcardMultiPattern(ref request, ref callSettings);
+            return _callWildcardMultiPatternMethod.Async(request, callSettings);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The RPC response.</returns>
+        public override Response WildcardMultiPatternMultipleMethod(WildcardMultiPatternMultiple request, gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_WildcardMultiPatternMultiple(ref request, ref callSettings);
+            return _callWildcardMultiPatternMultipleMethod.Sync(request, callSettings);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public override stt::Task<Response> WildcardMultiPatternMultipleMethodAsync(WildcardMultiPatternMultiple request, gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_WildcardMultiPatternMultiple(ref request, ref callSettings);
+            return _callWildcardMultiPatternMultipleMethod.Async(request, callSettings);
+        }
     }
 }


### PR DESCRIPTION
This does not yet test the new 'parameterless pattern' code; that change will be in a follow-up PR