### PR TITLE
Update deps in generated csproj files

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTests/Basic/Testing.Basic/Testing.Basic.csproj
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic/Testing.Basic/Testing.Basic.csproj
@@ -40,8 +40,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="3.0.0-beta01" />
-    <PackageReference Include="Grpc.Core" Version="2.27.0" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="3.1.0" />
+    <PackageReference Include="Grpc.Core" Version="2.32.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.13.0" />
   </ItemGroup>
 
 </Project>

--- a/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro/Testing.Lro.csproj
+++ b/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro/Testing.Lro.csproj
@@ -40,9 +40,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="3.0.0-beta01" />
-    <PackageReference Include="Grpc.Core" Version="2.27.0" />
-    <PackageReference Include="Google.LongRunning" Version="2.0.0-beta01" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="3.1.0" />
+    <PackageReference Include="Grpc.Core" Version="2.32.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.13.0" />
+    <PackageReference Include="Google.LongRunning" Version="2.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Google.Api.Generator/Generation/CsProjGenerator.cs
+++ b/Google.Api.Generator/Generation/CsProjGenerator.cs
@@ -20,9 +20,10 @@ namespace Google.Api.Generator.Generation
 {
     internal static class CsProjGenerator
     {
-        private const string GaxGrpcCoreVersion = "3.0.0-beta01";
-        private const string GrpcCoreVersion = "2.27.0";
-        private const string LroVersion = "2.0.0-beta01";
+        private const string GaxGrpcCoreVersion = "3.1.0";
+        private const string GrpcCoreVersion = "2.32.0";
+        private const string LroVersion = "2.0.0";
+        private const string ProtobufVersion = "3.13.0"; // Required due to incompatibility between GAX and the protoc version used by the bazel rules.
 
         public static string GenerateClient(bool hasLro)
         {
@@ -72,7 +73,8 @@ namespace Google.Api.Generator.Generation
 
   <ItemGroup>
     <PackageReference Include=""Google.Api.Gax.Grpc.GrpcCore"" Version=""{GaxGrpcCoreVersion}"" />
-    <PackageReference Include=""Grpc.Core"" Version=""{GrpcCoreVersion}"" />{packageRefs}
+    <PackageReference Include=""Grpc.Core"" Version=""{GrpcCoreVersion}"" />
+    <PackageReference Include=""Google.Protobuf"" Version=""{ProtobufVersion}"" />{packageRefs}
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
And add a direct reference to Google.Protobuf, to get the latest version as required by the latest protoc-generated files