### PR TITLE
Finish initial generator implementation

### DIFF
--- a/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.Storage.v1/Google.Apis.Storage.v1.cs
+++ b/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.Storage.v1/Google.Apis.Storage.v1.cs
@@ -3904,8 +3904,9 @@ namespace Google.Apis.Storage.v1
             [Google.Apis.Util.RequestParameterAttribute("ifMetagenerationMatch", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> IfMetagenerationMatch { get; set; }
 
-            /// <summary>Not currently supported. Specifying the parameter causes the request to fail with status code
-            /// 400 - Bad Request.</summary>
+            /// <summary>Resource name of the Cloud KMS key, of the form projects/my-project/locations/global/keyRings
+            /// /my-kr/cryptoKeys/my-key, that will be used to encrypt the object. Overrides the object metadata's
+            /// kms_key_name value, if any.</summary>
             [Google.Apis.Util.RequestParameterAttribute("kmsKeyName", Google.Apis.Util.RequestParameterType.Query)]
             public virtual string KmsKeyName { get; set; }
 
@@ -5264,8 +5265,7 @@ namespace Google.Apis.Storage.v1
             /// </description></item>
             /// </list>
             /// </remarks>
-            public InsertMediaUpload(Google.Apis.Services.IClientService service, Google.Apis.Storage.v1.Data.Object body, string
-             bucket, System.IO.Stream stream, string contentType)
+            public InsertMediaUpload(Google.Apis.Services.IClientService service, Google.Apis.Storage.v1.Data.Object body, string bucket, System.IO.Stream stream, string contentType)
                 : base(service, string.Format("/{0}/{1}{2}", "upload", service.BasePath, "b/{bucket}/o"), "POST", stream, contentType)
             {
                 Bucket = bucket;
@@ -8230,7 +8230,8 @@ namespace Google.Apis.Storage.v1.Data
         [Newtonsoft.Json.JsonPropertyAttribute("kind")]
         public virtual string Kind { get; set; } 
 
-        /// <summary>Cloud KMS Key used to encrypt this object, if the object is encrypted by such a key.</summary>
+        /// <summary>Not currently supported. Specifying the parameter causes the request to fail with status code 400 -
+        /// Bad Request.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("kmsKeyName")]
         public virtual string KmsKeyName { get; set; } 
 

--- a/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.Storage.v1/Google.Apis.Storage.v1.cs
+++ b/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.Storage.v1/Google.Apis.Storage.v1.cs
@@ -7305,11 +7305,11 @@ namespace Google.Apis.Storage.v1.Data
 
         /// <summary>The bucket's billing configuration.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("billing")]
-        public virtual Bucket.BillingData Billing { get; set; } 
+        public virtual BillingData Billing { get; set; } 
 
         /// <summary>The bucket's Cross-Origin Resource Sharing (CORS) configuration.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("cors")]
-        public virtual System.Collections.Generic.IList<Bucket.CorsData> Cors { get; set; } 
+        public virtual System.Collections.Generic.IList<CorsData> Cors { get; set; } 
 
         /// <summary>The default value for event-based hold on newly created objects in this bucket. Event-based hold is
         /// a way to retain objects indefinitely until an event occurs, signified by the hold's release. After being
@@ -7329,7 +7329,7 @@ namespace Google.Apis.Storage.v1.Data
 
         /// <summary>Encryption configuration for a bucket.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("encryption")]
-        public virtual Bucket.EncryptionData Encryption { get; set; } 
+        public virtual EncryptionData Encryption { get; set; } 
 
         /// <summary>HTTP 1.1 Entity tag for the bucket.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("etag")]
@@ -7337,7 +7337,7 @@ namespace Google.Apis.Storage.v1.Data
 
         /// <summary>The bucket's IAM configuration.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("iamConfiguration")]
-        public virtual Bucket.IamConfigurationData IamConfiguration { get; set; } 
+        public virtual IamConfigurationData IamConfiguration { get; set; } 
 
         /// <summary>The ID of the bucket. For buckets, the id and name properties are the same.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("id")]
@@ -7353,7 +7353,7 @@ namespace Google.Apis.Storage.v1.Data
 
         /// <summary>The bucket's lifecycle configuration. See lifecycle management for more information.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("lifecycle")]
-        public virtual Bucket.LifecycleData Lifecycle { get; set; } 
+        public virtual LifecycleData Lifecycle { get; set; } 
 
         /// <summary>The location of the bucket. Object data for objects in the bucket resides in physical storage
         /// within this region. Defaults to US. See the developer's guide for the authoritative list.</summary>
@@ -7367,7 +7367,7 @@ namespace Google.Apis.Storage.v1.Data
         /// <summary>The bucket's logging configuration, which defines the destination bucket and optional name prefix
         /// for the current bucket's logs.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("logging")]
-        public virtual Bucket.LoggingData Logging { get; set; } 
+        public virtual LoggingData Logging { get; set; } 
 
         /// <summary>The metadata generation of this bucket.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("metageneration")]
@@ -7379,7 +7379,7 @@ namespace Google.Apis.Storage.v1.Data
 
         /// <summary>The owner of the bucket. This is always the project team's owner group.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("owner")]
-        public virtual Bucket.OwnerData Owner { get; set; } 
+        public virtual OwnerData Owner { get; set; } 
 
         /// <summary>The project number of the project the bucket belongs to.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("projectNumber")]
@@ -7392,7 +7392,7 @@ namespace Google.Apis.Storage.v1.Data
         /// cannot be removed or shortened in duration for the lifetime of the bucket. Attempting to remove or decrease
         /// period of a locked retention policy will result in a PERMISSION_DENIED error.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("retentionPolicy")]
-        public virtual Bucket.RetentionPolicyData RetentionPolicy { get; set; } 
+        public virtual RetentionPolicyData RetentionPolicy { get; set; } 
 
         /// <summary>The URI of this bucket.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("selfLink")]
@@ -7411,17 +7411,11 @@ namespace Google.Apis.Storage.v1.Data
         public virtual string TimeCreatedRaw { get; set; }
 
         /// <summary><seealso cref="System.DateTime"/> representation of <see cref="TimeCreatedRaw"/>.</summary>
-        [Newtonsoft.Json.JsonIgnore]
+        [Newtonsoft.Json.JsonIgnoreAttribute]
         public virtual System.Nullable<System.DateTime> TimeCreated
         {
-            get
-            {
-                return Google.Apis.Util.Utilities.GetDateTimeFromString(TimeCreatedRaw);
-            }
-            set
-            {
-                TimeCreatedRaw = Google.Apis.Util.Utilities.GetStringFromDateTime(value);
-            }
+            get => Google.Apis.Util.Utilities.GetDateTimeFromString(TimeCreatedRaw);
+            set => TimeCreatedRaw = Google.Apis.Util.Utilities.GetStringFromDateTime(value);
         }
 
         /// <summary>The modification time of the bucket in RFC 3339 format.</summary>
@@ -7429,27 +7423,21 @@ namespace Google.Apis.Storage.v1.Data
         public virtual string UpdatedRaw { get; set; }
 
         /// <summary><seealso cref="System.DateTime"/> representation of <see cref="UpdatedRaw"/>.</summary>
-        [Newtonsoft.Json.JsonIgnore]
+        [Newtonsoft.Json.JsonIgnoreAttribute]
         public virtual System.Nullable<System.DateTime> Updated
         {
-            get
-            {
-                return Google.Apis.Util.Utilities.GetDateTimeFromString(UpdatedRaw);
-            }
-            set
-            {
-                UpdatedRaw = Google.Apis.Util.Utilities.GetStringFromDateTime(value);
-            }
+            get => Google.Apis.Util.Utilities.GetDateTimeFromString(UpdatedRaw);
+            set => UpdatedRaw = Google.Apis.Util.Utilities.GetStringFromDateTime(value);
         }
 
         /// <summary>The bucket's versioning configuration.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("versioning")]
-        public virtual Bucket.VersioningData Versioning { get; set; } 
+        public virtual VersioningData Versioning { get; set; } 
 
         /// <summary>The bucket's website configuration, controlling how the service behaves when accessing bucket
         /// contents as a web site. See the Static Website Examples for more information.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("website")]
-        public virtual Bucket.WebsiteData Website { get; set; } 
+        public virtual WebsiteData Website { get; set; } 
 
         /// <summary>The zone or zones from which the bucket is intended to use zonal quota. Requests for data from
         /// outside the specified affinities are still allowed but won't be able to use zonal quota. The zone or zones
@@ -7515,11 +7503,11 @@ namespace Google.Apis.Storage.v1.Data
             /// as the uniformBucketLevelAccess field. We recommend using the uniformBucketLevelAccess field to enable
             /// and disable the feature.</summary>
             [Newtonsoft.Json.JsonPropertyAttribute("bucketPolicyOnly")]
-            public virtual IamConfigurationData.BucketPolicyOnlyData BucketPolicyOnly { get; set; } 
+            public virtual BucketPolicyOnlyData BucketPolicyOnly { get; set; } 
 
             /// <summary>The bucket's uniform bucket-level access configuration.</summary>
             [Newtonsoft.Json.JsonPropertyAttribute("uniformBucketLevelAccess")]
-            public virtual IamConfigurationData.UniformBucketLevelAccessData UniformBucketLevelAccess { get; set; } 
+            public virtual UniformBucketLevelAccessData UniformBucketLevelAccess { get; set; } 
 
             
 
@@ -7540,17 +7528,11 @@ namespace Google.Apis.Storage.v1.Data
                 public virtual string LockedTimeRaw { get; set; }
 
                 /// <summary><seealso cref="System.DateTime"/> representation of <see cref="LockedTimeRaw"/>.</summary>
-                [Newtonsoft.Json.JsonIgnore]
+                [Newtonsoft.Json.JsonIgnoreAttribute]
                 public virtual System.Nullable<System.DateTime> LockedTime
                 {
-                    get
-                    {
-                        return Google.Apis.Util.Utilities.GetDateTimeFromString(LockedTimeRaw);
-                    }
-                    set
-                    {
-                        LockedTimeRaw = Google.Apis.Util.Utilities.GetStringFromDateTime(value);
-                    }
+                    get => Google.Apis.Util.Utilities.GetDateTimeFromString(LockedTimeRaw);
+                    set => LockedTimeRaw = Google.Apis.Util.Utilities.GetStringFromDateTime(value);
                 }
 
             }    
@@ -7569,17 +7551,11 @@ namespace Google.Apis.Storage.v1.Data
                 public virtual string LockedTimeRaw { get; set; }
 
                 /// <summary><seealso cref="System.DateTime"/> representation of <see cref="LockedTimeRaw"/>.</summary>
-                [Newtonsoft.Json.JsonIgnore]
+                [Newtonsoft.Json.JsonIgnoreAttribute]
                 public virtual System.Nullable<System.DateTime> LockedTime
                 {
-                    get
-                    {
-                        return Google.Apis.Util.Utilities.GetDateTimeFromString(LockedTimeRaw);
-                    }
-                    set
-                    {
-                        LockedTimeRaw = Google.Apis.Util.Utilities.GetStringFromDateTime(value);
-                    }
+                    get => Google.Apis.Util.Utilities.GetDateTimeFromString(LockedTimeRaw);
+                    set => LockedTimeRaw = Google.Apis.Util.Utilities.GetStringFromDateTime(value);
                 }
 
             }
@@ -7591,7 +7567,7 @@ namespace Google.Apis.Storage.v1.Data
             /// <summary>A lifecycle management rule, which is made of an action to take and the condition(s) under
             /// which the action will be taken.</summary>
             [Newtonsoft.Json.JsonPropertyAttribute("rule")]
-            public virtual System.Collections.Generic.IList<LifecycleData.RuleData> Rule { get; set; } 
+            public virtual System.Collections.Generic.IList<RuleData> Rule { get; set; } 
 
             
 
@@ -7599,11 +7575,11 @@ namespace Google.Apis.Storage.v1.Data
             {
                 /// <summary>The action to take.</summary>
                 [Newtonsoft.Json.JsonPropertyAttribute("action")]
-                public virtual RuleData.ActionData Action { get; set; } 
+                public virtual ActionData Action { get; set; } 
 
                 /// <summary>The condition(s) under which the action will be taken.</summary>
                 [Newtonsoft.Json.JsonPropertyAttribute("condition")]
-                public virtual RuleData.ConditionData Condition { get; set; } 
+                public virtual ConditionData Condition { get; set; } 
 
                 
 
@@ -7729,17 +7705,11 @@ namespace Google.Apis.Storage.v1.Data
             public virtual string EffectiveTimeRaw { get; set; }
 
             /// <summary><seealso cref="System.DateTime"/> representation of <see cref="EffectiveTimeRaw"/>.</summary>
-            [Newtonsoft.Json.JsonIgnore]
+            [Newtonsoft.Json.JsonIgnoreAttribute]
             public virtual System.Nullable<System.DateTime> EffectiveTime
             {
-                get
-                {
-                    return Google.Apis.Util.Utilities.GetDateTimeFromString(EffectiveTimeRaw);
-                }
-                set
-                {
-                    EffectiveTimeRaw = Google.Apis.Util.Utilities.GetStringFromDateTime(value);
-                }
+                get => Google.Apis.Util.Utilities.GetDateTimeFromString(EffectiveTimeRaw);
+                set => EffectiveTimeRaw = Google.Apis.Util.Utilities.GetStringFromDateTime(value);
             }
 
             /// <summary>Once locked, an object retention policy cannot be modified.</summary>
@@ -7824,7 +7794,7 @@ namespace Google.Apis.Storage.v1.Data
 
         /// <summary>The project team associated with the entity, if any.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("projectTeam")]
-        public virtual BucketAccessControl.ProjectTeamData ProjectTeam { get; set; } 
+        public virtual ProjectTeamData ProjectTeam { get; set; } 
 
         /// <summary>The access permission for the entity.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("role")]
@@ -7950,7 +7920,7 @@ namespace Google.Apis.Storage.v1.Data
 
         /// <summary>The list of source objects that will be concatenated into a single object.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("sourceObjects")]
-        public virtual System.Collections.Generic.IList<ComposeRequest.SourceObjectsData> SourceObjects { get; set; } 
+        public virtual System.Collections.Generic.IList<SourceObjectsData> SourceObjects { get; set; } 
 
         /// <summary>The ETag of the item.</summary>
         public virtual string ETag { get; set; }
@@ -7968,7 +7938,7 @@ namespace Google.Apis.Storage.v1.Data
 
             /// <summary>Conditions that must be met for this operation to execute.</summary>
             [Newtonsoft.Json.JsonPropertyAttribute("objectPreconditions")]
-            public virtual SourceObjectsData.ObjectPreconditionsData ObjectPreconditions { get; set; } 
+            public virtual ObjectPreconditionsData ObjectPreconditions { get; set; } 
 
             
 
@@ -8072,17 +8042,11 @@ namespace Google.Apis.Storage.v1.Data
         public virtual string TimeCreatedRaw { get; set; }
 
         /// <summary><seealso cref="System.DateTime"/> representation of <see cref="TimeCreatedRaw"/>.</summary>
-        [Newtonsoft.Json.JsonIgnore]
+        [Newtonsoft.Json.JsonIgnoreAttribute]
         public virtual System.Nullable<System.DateTime> TimeCreated
         {
-            get
-            {
-                return Google.Apis.Util.Utilities.GetDateTimeFromString(TimeCreatedRaw);
-            }
-            set
-            {
-                TimeCreatedRaw = Google.Apis.Util.Utilities.GetStringFromDateTime(value);
-            }
+            get => Google.Apis.Util.Utilities.GetDateTimeFromString(TimeCreatedRaw);
+            set => TimeCreatedRaw = Google.Apis.Util.Utilities.GetStringFromDateTime(value);
         }
 
         /// <summary>The last modification time of the HMAC key metadata in RFC 3339 format.</summary>
@@ -8090,17 +8054,11 @@ namespace Google.Apis.Storage.v1.Data
         public virtual string UpdatedRaw { get; set; }
 
         /// <summary><seealso cref="System.DateTime"/> representation of <see cref="UpdatedRaw"/>.</summary>
-        [Newtonsoft.Json.JsonIgnore]
+        [Newtonsoft.Json.JsonIgnoreAttribute]
         public virtual System.Nullable<System.DateTime> Updated
         {
-            get
-            {
-                return Google.Apis.Util.Utilities.GetDateTimeFromString(UpdatedRaw);
-            }
-            set
-            {
-                UpdatedRaw = Google.Apis.Util.Utilities.GetStringFromDateTime(value);
-            }
+            get => Google.Apis.Util.Utilities.GetDateTimeFromString(UpdatedRaw);
+            set => UpdatedRaw = Google.Apis.Util.Utilities.GetStringFromDateTime(value);
         }
 
     }    
@@ -8234,22 +8192,16 @@ namespace Google.Apis.Storage.v1.Data
         public virtual string CustomTimeRaw { get; set; }
 
         /// <summary><seealso cref="System.DateTime"/> representation of <see cref="CustomTimeRaw"/>.</summary>
-        [Newtonsoft.Json.JsonIgnore]
+        [Newtonsoft.Json.JsonIgnoreAttribute]
         public virtual System.Nullable<System.DateTime> CustomTime
         {
-            get
-            {
-                return Google.Apis.Util.Utilities.GetDateTimeFromString(CustomTimeRaw);
-            }
-            set
-            {
-                CustomTimeRaw = Google.Apis.Util.Utilities.GetStringFromDateTime(value);
-            }
+            get => Google.Apis.Util.Utilities.GetDateTimeFromString(CustomTimeRaw);
+            set => CustomTimeRaw = Google.Apis.Util.Utilities.GetStringFromDateTime(value);
         }
 
         /// <summary>Metadata of customer-supplied encryption key, if the object is encrypted by such a key.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("customerEncryption")]
-        public virtual Object.CustomerEncryptionData CustomerEncryption { get; set; } 
+        public virtual CustomerEncryptionData CustomerEncryption { get; set; } 
 
         /// <summary>HTTP 1.1 Entity tag for the object.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("etag")]
@@ -8307,7 +8259,7 @@ namespace Google.Apis.Storage.v1.Data
 
         /// <summary>The owner of the object. This will always be the uploader of the object.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("owner")]
-        public virtual Object.OwnerData Owner { get; set; } 
+        public virtual OwnerData Owner { get; set; } 
 
         /// <summary>A server-determined value that specifies the earliest time that the object's retention period
         /// expires. This value is in RFC 3339 format. Note 1: This field is not provided for objects with an active
@@ -8318,17 +8270,11 @@ namespace Google.Apis.Storage.v1.Data
         public virtual string RetentionExpirationTimeRaw { get; set; }
 
         /// <summary><seealso cref="System.DateTime"/> representation of <see cref="RetentionExpirationTimeRaw"/>.</summary>
-        [Newtonsoft.Json.JsonIgnore]
+        [Newtonsoft.Json.JsonIgnoreAttribute]
         public virtual System.Nullable<System.DateTime> RetentionExpirationTime
         {
-            get
-            {
-                return Google.Apis.Util.Utilities.GetDateTimeFromString(RetentionExpirationTimeRaw);
-            }
-            set
-            {
-                RetentionExpirationTimeRaw = Google.Apis.Util.Utilities.GetStringFromDateTime(value);
-            }
+            get => Google.Apis.Util.Utilities.GetDateTimeFromString(RetentionExpirationTimeRaw);
+            set => RetentionExpirationTimeRaw = Google.Apis.Util.Utilities.GetStringFromDateTime(value);
         }
 
         /// <summary>The link to this object.</summary>
@@ -8355,17 +8301,11 @@ namespace Google.Apis.Storage.v1.Data
         public virtual string TimeCreatedRaw { get; set; }
 
         /// <summary><seealso cref="System.DateTime"/> representation of <see cref="TimeCreatedRaw"/>.</summary>
-        [Newtonsoft.Json.JsonIgnore]
+        [Newtonsoft.Json.JsonIgnoreAttribute]
         public virtual System.Nullable<System.DateTime> TimeCreated
         {
-            get
-            {
-                return Google.Apis.Util.Utilities.GetDateTimeFromString(TimeCreatedRaw);
-            }
-            set
-            {
-                TimeCreatedRaw = Google.Apis.Util.Utilities.GetStringFromDateTime(value);
-            }
+            get => Google.Apis.Util.Utilities.GetDateTimeFromString(TimeCreatedRaw);
+            set => TimeCreatedRaw = Google.Apis.Util.Utilities.GetStringFromDateTime(value);
         }
 
         /// <summary>The deletion time of the object in RFC 3339 format. Will be returned if and only if this version of
@@ -8374,17 +8314,11 @@ namespace Google.Apis.Storage.v1.Data
         public virtual string TimeDeletedRaw { get; set; }
 
         /// <summary><seealso cref="System.DateTime"/> representation of <see cref="TimeDeletedRaw"/>.</summary>
-        [Newtonsoft.Json.JsonIgnore]
+        [Newtonsoft.Json.JsonIgnoreAttribute]
         public virtual System.Nullable<System.DateTime> TimeDeleted
         {
-            get
-            {
-                return Google.Apis.Util.Utilities.GetDateTimeFromString(TimeDeletedRaw);
-            }
-            set
-            {
-                TimeDeletedRaw = Google.Apis.Util.Utilities.GetStringFromDateTime(value);
-            }
+            get => Google.Apis.Util.Utilities.GetDateTimeFromString(TimeDeletedRaw);
+            set => TimeDeletedRaw = Google.Apis.Util.Utilities.GetStringFromDateTime(value);
         }
 
         /// <summary>The time at which the object's storage class was last changed. When the object is initially
@@ -8393,17 +8327,11 @@ namespace Google.Apis.Storage.v1.Data
         public virtual string TimeStorageClassUpdatedRaw { get; set; }
 
         /// <summary><seealso cref="System.DateTime"/> representation of <see cref="TimeStorageClassUpdatedRaw"/>.</summary>
-        [Newtonsoft.Json.JsonIgnore]
+        [Newtonsoft.Json.JsonIgnoreAttribute]
         public virtual System.Nullable<System.DateTime> TimeStorageClassUpdated
         {
-            get
-            {
-                return Google.Apis.Util.Utilities.GetDateTimeFromString(TimeStorageClassUpdatedRaw);
-            }
-            set
-            {
-                TimeStorageClassUpdatedRaw = Google.Apis.Util.Utilities.GetStringFromDateTime(value);
-            }
+            get => Google.Apis.Util.Utilities.GetDateTimeFromString(TimeStorageClassUpdatedRaw);
+            set => TimeStorageClassUpdatedRaw = Google.Apis.Util.Utilities.GetStringFromDateTime(value);
         }
 
         /// <summary>The modification time of the object metadata in RFC 3339 format.</summary>
@@ -8411,17 +8339,11 @@ namespace Google.Apis.Storage.v1.Data
         public virtual string UpdatedRaw { get; set; }
 
         /// <summary><seealso cref="System.DateTime"/> representation of <see cref="UpdatedRaw"/>.</summary>
-        [Newtonsoft.Json.JsonIgnore]
+        [Newtonsoft.Json.JsonIgnoreAttribute]
         public virtual System.Nullable<System.DateTime> Updated
         {
-            get
-            {
-                return Google.Apis.Util.Utilities.GetDateTimeFromString(UpdatedRaw);
-            }
-            set
-            {
-                UpdatedRaw = Google.Apis.Util.Utilities.GetStringFromDateTime(value);
-            }
+            get => Google.Apis.Util.Utilities.GetDateTimeFromString(UpdatedRaw);
+            set => UpdatedRaw = Google.Apis.Util.Utilities.GetStringFromDateTime(value);
         }
 
         
@@ -8503,7 +8425,7 @@ namespace Google.Apis.Storage.v1.Data
 
         /// <summary>The project team associated with the entity, if any.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("projectTeam")]
-        public virtual ObjectAccessControl.ProjectTeamData ProjectTeam { get; set; } 
+        public virtual ProjectTeamData ProjectTeam { get; set; } 
 
         /// <summary>The access permission for the entity.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("role")]
@@ -8576,7 +8498,7 @@ namespace Google.Apis.Storage.v1.Data
         /// <summary>An association between a role, which comes with a set of permissions, and members who may assume
         /// that role.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("bindings")]
-        public virtual System.Collections.Generic.IList<Policy.BindingsData> Bindings { get; set; } 
+        public virtual System.Collections.Generic.IList<BindingsData> Bindings { get; set; } 
 
         /// <summary>HTTP 1.1  Entity tag for the policy.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("etag")]

--- a/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.Storage.v1/discovery.json
+++ b/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.Storage.v1/discovery.json
@@ -26,7 +26,7 @@
  "description": "Stores and retrieves potentially large, immutable data objects.", 
  "discoveryVersion": "v1", 
  "documentationLink": "https://developers.google.com/storage/docs/json_api/", 
- "etag": "\"-2NioU2H8y8siEzrBOV_qzRI6kQ/sPMqcoPqdFD0a_Hhegm2T9RGrZc\"", 
+ "etag": "\"34323635383234343034323936383436333233\"", 
  "icons": {
   "x16": "https://www.google.com/images/icons/product/cloud_storage-16.png", 
   "x32": "https://www.google.com/images/icons/product/cloud_storage-32.png"
@@ -1781,7 +1781,7 @@
        "type": "string"
       }, 
       "kmsKeyName": {
-       "description": "Not currently supported. Specifying the parameter causes the request to fail with status code 400 - Bad Request.", 
+       "description": "Resource name of the Cloud KMS key, of the form projects/my-project/locations/global/keyRings/my-kr/cryptoKeys/my-key, that will be used to encrypt the object. Overrides the object metadata's kms_key_name value, if any.", 
        "location": "query", 
        "type": "string"
       }, 
@@ -3229,7 +3229,7 @@
    }
   }
  }, 
- "revision": "20200826", 
+ "revision": "20200813", 
  "rootUrl": "https://storage.googleapis.com/", 
  "schemas": {
   "Bucket": {
@@ -4096,7 +4096,7 @@
      "type": "string"
     }, 
     "kmsKeyName": {
-     "description": "Cloud KMS Key used to encrypt this object, if the object is encrypted by such a key.", 
+     "description": "Not currently supported. Specifying the parameter causes the request to fail with status code 400 - Bad Request.", 
      "type": "string"
     }, 
     "md5Hash": {

--- a/Google.Api.Generator.Rest/CodeGenerator.cs
+++ b/Google.Api.Generator.Rest/CodeGenerator.cs
@@ -108,16 +108,24 @@ namespace Google.Api.Generator.Rest
                 "        #endif"
             });
 
-            int batchBaseUriIndex = lines.FindIndex(line => line.Contains("/// <summary>Gets the batch base URI; <c>null</c> if unspecified.</summary>"));
-            lines.Insert(batchBaseUriIndex, "        #if !NET40");
+            InsertLine("/// <summary>Gets the batch base URI; <c>null</c> if unspecified.</summary>", 0, "        #if !NET40");
+            InsertLine("public override string BatchPath =>", 1, "        #endif");
 
-            int batchPathIndex = lines.FindIndex(line => line.Contains("public override string BatchPath =>"));
-            lines.Insert(batchPathIndex + 1, "        #endif");
-
-            // TODO: Media downloads have #if as well, for the DownloadRange and DownloadRangeAsync methods.
+            InsertLine("/// <summary>Synchronously download a range of the media into the given stream.</summary>", 0, "            #if !NET40");
+            // We need to insert the line two lines lower, after the closing } of the method
+            InsertLine("return mediaDownloader.DownloadAsync(this.GenerateRequestUri(), stream, cancellationToken);", 2, "            #endif");
 
             string separator = usesCarriageReturn ? "\r\n" : "\n";
             return string.Join(separator, lines);
+
+            void InsertLine(string contentToFind, int offset, string extraLine)
+            {
+                int index = lines.FindIndex(line => line.Contains(contentToFind));
+                if (index != -1)
+                {
+                    lines.Insert(index + offset, extraLine);
+                }
+            }
         }
 
         private static ResultFile GenerateProjectFile(PackageModel package)

--- a/Google.Api.Generator.Rest/Models/AuthScope.cs
+++ b/Google.Api.Generator.Rest/Models/AuthScope.cs
@@ -38,7 +38,7 @@ namespace Google.Api.Generator.Rest.Models
             {
                 value = value[HttpsPrefix.Length..];
             }
-            Name = value.ToUpperCamelCase();
+            Name = value.ToMemberName();
         }
     }
 }

--- a/Google.Api.Generator.Rest/Models/DataModel.cs
+++ b/Google.Api.Generator.Rest/Models/DataModel.cs
@@ -39,22 +39,23 @@ namespace Google.Api.Generator.Rest.Models
         /// The parent of this data model, if any.
         /// </summary>
         public DataModel Parent { get; }
-        public string Name { get; }
         public Typ Typ { get; }
+        public bool IsArray => _schema.Type == "array";
+
         public IReadOnlyList<DataModel> Children { get; }
         public IReadOnlyList<DataPropertyModel> Properties { get; }
 
         public DataModel(PackageModel package, DataModel parent, string name, JsonSchema schema)
         {
+            _schema = schema;
             Id = schema.Id;
             Package = package;
             Parent = parent;
-            Name = name;
-            Typ = parent is null ? Typ.Manual(Package.PackageName + ".Data", Name) : Typ.Nested(parent.Typ, Name);
+            string className = schema.Id is object && IsArray ? name + "Items" : name;
+            Typ = parent is null ? Typ.Manual(Package.PackageName + ".Data", className) : Typ.Nested(parent.Typ, className);
 
             // We may get a JsonSchema for an array as a nested model. Just use the properties from schema.Items for simplicity.
             Properties = (schema.Properties ?? schema.Items.Properties).ToReadOnlyList(pair => new DataPropertyModel(this, pair.Key, pair.Value));
-            _schema = schema;
         }
 
         public ClassDeclarationSyntax GenerateClass(SourceFileContext ctx)

--- a/Google.Api.Generator.Rest/Models/DataModel.cs
+++ b/Google.Api.Generator.Rest/Models/DataModel.cs
@@ -67,7 +67,6 @@ namespace Google.Api.Generator.Rest.Models
                     cls = cls.WithXmlDoc(XmlDoc.Summary(description));
                 }
                 cls = cls.AddMembers(Properties.SelectMany(p => p.GeneratePropertyDeclarations(ctx)).ToArray());
-                cls = cls.AddMembers(Properties.SelectMany(p => p.GenerateAnonymousModels(ctx)).ToArray());
 
                 // Top-level data models automatically have an etag property if one isn't otherwise generated.
                 if (Parent is null && !Properties.Any(p => p.Name == "etag"))
@@ -76,6 +75,8 @@ namespace Google.Api.Generator.Rest.Models
                         .WithXmlDoc(XmlDoc.Summary("The ETag of the item."));
                     cls = cls.AddMembers(etag);
                 }
+
+                cls = cls.AddMembers(Properties.SelectMany(p => p.GenerateAnonymousModels(ctx)).ToArray());
             }
             return cls;
         }

--- a/Google.Api.Generator.Rest/Models/DataPropertyModel.cs
+++ b/Google.Api.Generator.Rest/Models/DataPropertyModel.cs
@@ -51,7 +51,7 @@ namespace Google.Api.Generator.Rest.Models
             Parent = parent;
             Name = name;
             // Not sure why this special-casing exists in the template, but it does...
-            PropertyName = name == "etag" && parent.Parent is null ? "ETag" : name.ToUpperCamelCase();
+            PropertyName = name == "etag" && parent.Parent is null ? "ETag" : name.ToMemberName();
             _schema = schema;
         }
 

--- a/Google.Api.Generator.Rest/Models/EnumMemberModel.cs
+++ b/Google.Api.Generator.Rest/Models/EnumMemberModel.cs
@@ -32,16 +32,7 @@ namespace Google.Api.Generator.Rest.Models
         public EnumMemberModel(string value, string description)
         {
             OriginalValue = value;
-            MemberName = value.ToUpperCamelCase();
-            if (char.IsDigit(MemberName[0]))
-            {
-                MemberName = "Value" + MemberName;
-            }
-            // Not really needed here, as the Pascal case version won't be a keyword, but...
-            else if (Keywords.IsKeyword(value))
-            {
-                MemberName += "__";
-            }
+            MemberName = value.ToMemberName();
             Description = description;
         }
 

--- a/Google.Api.Generator.Rest/Models/EnumModel.cs
+++ b/Google.Api.Generator.Rest/Models/EnumModel.cs
@@ -36,7 +36,7 @@ namespace Google.Api.Generator.Rest.Models
             IList<string> values = schema.Enum__;
             IList<string> description = schema.EnumDescriptions;
             Description = schema.Description;
-            TypeName = name.ToUpperCamelCase() + "Enum";
+            TypeName = name.ToMemberName() + "Enum";
             Members = schema.Enum__
                 .Zip(schema.EnumDescriptions)
                 .ToReadOnlyList(pair => new EnumMemberModel(pair.First, pair.Second));

--- a/Google.Api.Generator.Rest/Models/MethodModel.cs
+++ b/Google.Api.Generator.Rest/Models/MethodModel.cs
@@ -17,6 +17,8 @@ using Google.Api.Generator.Utils.Roslyn;
 using Google.Apis.Discovery.v1.Data;
 using Google.Apis.Download;
 using Google.Apis.Services;
+using Google.Apis.Upload;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
 using System.IO;
@@ -39,7 +41,6 @@ namespace Google.Api.Generator.Rest.Models
         /// </summary>
         public ResourceModel Resource { get; }
         
-        public IReadOnlyList<ParameterModel> Parameters { get; }
         public Typ ParentTyp { get; }
         public Typ RequestTyp { get; }
         public Typ ResponseTyp { get; }
@@ -59,17 +60,15 @@ namespace Google.Api.Generator.Rest.Models
             RequestTyp = Typ.Nested(ParentTyp, $"{PascalCasedName}Request");
             BodyTyp = restMethod.Request is object ? package.GetDataModelByReference(restMethod.Request.Ref__).Typ : null;
             ResponseTyp = restMethod.Response is object ? package.GetDataModelByReference(restMethod.Response.Ref__).Typ : Typ.Of<string>();
-            Parameters = CreateParameterList(package, restMethod, RequestTyp);
             _restMethod = restMethod;
         }
 
-        private static IReadOnlyList<ParameterModel> CreateParameterList(PackageModel package, RestMethod restMethod, Typ parentTyp)
+        private IReadOnlyList<ParameterModel> CreateParameterList(Typ parentTyp)
         {
-            var parameterOrder = restMethod.ParameterOrder ?? new List<string>();
+            var parameterOrder = _restMethod.ParameterOrder ?? new List<string>();
             // TODO: Skip the Alt parameter
-            // TODO: Handle the body parameter if restMethod.Request is non-null
-            return (restMethod.Parameters ?? new Dictionary<string, JsonSchema>())
-                .Select(pair => new ParameterModel(package, pair.Key, pair.Value, parentTyp))
+            return (_restMethod.Parameters ?? new Dictionary<string, JsonSchema>())
+                .Select(pair => new ParameterModel(Package, pair.Key, pair.Value, parentTyp))
                 .OrderBy(p => !p.IsRequired)
                 .ThenBy(p => parameterOrder.IndexOf(p.Name))
                 .ToList()
@@ -80,12 +79,20 @@ namespace Google.Api.Generator.Rest.Models
         {
             yield return GenerateMethodDeclaration(ctx);
             yield return GenerateRequestType(ctx);
+            if (SupportsMediaUpload)
+            {
+                foreach (var member in GenerateUploadMembers(ctx))
+                {
+                    yield return member;
+                }
+            }
         }
 
         private MethodDeclarationSyntax GenerateMethodDeclaration(SourceFileContext ctx)
         {
+            var parameters = CreateParameterList(RequestTyp);
             var docs = new List<DocumentationCommentTriviaSyntax>();
-            var methodParameters = Parameters.TakeWhile(p => p.IsRequired).ToList();
+            var methodParameters = parameters.TakeWhile(p => p.IsRequired).ToList();
             var parameterDeclarations = methodParameters.Select(p => Parameter(ctx.Type(p.Typ), p.CodeParameterName)).ToList();
             if (_restMethod.Description is object)
             {
@@ -141,7 +148,8 @@ namespace Google.Api.Generator.Rest.Models
                         .WithXmlDoc(XmlDoc.Summary("Gets the media downloader."))
                     : null;
 
-                var requiredParameters = Parameters
+                var parameters = CreateParameterList(RequestTyp);
+                var requiredParameters = parameters
                     .TakeWhile(p => p.IsRequired)
                     .Select(p => (param: p, decl: Parameter(ctx.Type(p.Typ), p.CodeParameterName)))
                     .ToList();
@@ -181,13 +189,13 @@ namespace Google.Api.Generator.Rest.Models
                 var initParameters = Method(Modifier.Protected | Modifier.Override, VoidType, "InitParameters")()
                     .WithBlockBody(
                         BaseExpression().Call("InitParameters")(),
-                        Parameters.Select(p => p.GenerateInitializer(ctx)).ToArray())
+                        parameters.Select(p => p.GenerateInitializer(ctx)).ToArray())
                     .WithXmlDoc(XmlDoc.Summary($"Initializes {PascalCasedName} parameter list."));
 
                 // TODO: Media downloader members
 
                 cls = cls.AddMembers(ctor);
-                cls = cls.AddMembers(Parameters.SelectMany(p => p.GenerateDeclarations(ctx)).ToArray());
+                cls = cls.AddMembers(parameters.SelectMany(p => p.GenerateDeclarations(ctx)).ToArray());
                 cls = cls.AddMembers(bodyDeclarations);
                 cls = cls.AddMembers(methodName, httpMethod, restPath, initParameters);
 
@@ -195,11 +203,6 @@ namespace Google.Api.Generator.Rest.Models
                 {
                     cls = cls.AddMembers(mediaDownloaderProperty);
                     cls = AddMediaDownloadMethods(mediaDownloaderProperty, cls, ctx);
-                }
-
-                if (SupportsMediaUpload)
-                {
-                    cls = AddMediaUploadMethods(cls, ctx);
                 }
             }
             return cls;
@@ -253,10 +256,99 @@ namespace Google.Api.Generator.Rest.Models
             return cls.AddMembers(syncDownload, syncDownloadWithStatus, asyncDownloadNoToken, asyncDownloadWithToken, syncRange, asyncRange);
         }
 
-        private static ClassDeclarationSyntax AddMediaUploadMethods(ClassDeclarationSyntax cls, SourceFileContext ctx)
+        private IEnumerable<MemberDeclarationSyntax> GenerateUploadMembers(SourceFileContext ctx)
         {
-            // TODO: add the members
-            return cls;
+            var uploadTyp = Typ.Nested(ctx.CurrentTyp, PascalCasedName + "MediaUpload");
+
+            var baseTypArgument1 = BodyTyp ?? Typ.Of<string>();
+            var baseTyp = ResponseTyp is object
+                ? Typ.Generic(Typ.Of(typeof(ResumableUpload<,>)), baseTypArgument1, ResponseTyp)
+                : Typ.Generic(Typ.Of(typeof(ResumableUpload<>)), baseTypArgument1);
+
+            var uploadCls = Class(Modifier.Public, uploadTyp, ctx.Type(baseTyp))
+                .WithXmlDoc(XmlDoc.Summary($"{PascalCasedName} media upload which supports resumable upload."));
+
+            var parameters = CreateParameterList(uploadTyp);
+            var requiredParameters = parameters
+                .TakeWhile(p => p.IsRequired)
+                .Select(p => (param: p, decl: Parameter(ctx.Type(p.Typ), p.CodeParameterName)))
+                .ToList();
+
+            var insertMethodParameters = new List<ParameterSyntax>();
+            if (BodyTyp is object)
+            {
+                insertMethodParameters.Add(Parameter(ctx.Type(BodyTyp), "body"));
+            }
+            insertMethodParameters.AddRange(requiredParameters.Select(pair => pair.decl));
+            var streamParam = Parameter(ctx.Type<Stream>(), "stream");
+
+            var contentTypeParam = Parameter(ctx.Type<string>(), "contentType");
+            insertMethodParameters.Add(streamParam);
+            insertMethodParameters.Add(contentTypeParam);
+
+            // This doc comment is common between the method and the constructor.
+            var remarks = XmlDoc.Remarks("Considerations regarding ", streamParam, ":",
+                XmlDoc.UL(
+                    XmlDoc.Item("If ", streamParam, " is seekable, then the stream position will be reset to ", 0, " before reading commences. If ", streamParam, " is not seekable, then it will be read from its current position"),
+                    XmlDoc.Item("Caller is responsible for maintaining the ", streamParam, " open until the upload is completed"),
+                    XmlDoc.Item("Caller is responsible for closing the ", streamParam)));
+
+            var methodDocComments = new List<DocumentationCommentTriviaSyntax>
+            {
+                XmlDoc.Summary("Stores a new object and metadata"),
+                remarks
+            };
+            if (BodyTyp is object)
+            {
+                methodDocComments.Add(XmlDoc.Param(Parameter(ctx.Type(BodyTyp), "body"), "The body of the request."));
+            }
+
+            methodDocComments.AddRange(requiredParameters.Select(pair => XmlDoc.Param(pair.decl, pair.param.Description)));
+            methodDocComments.Add(XmlDoc.Param(streamParam, "The stream to upload. See remarks for further information."));
+            methodDocComments.Add(XmlDoc.Param(contentTypeParam, "The content type of the stream to upload."));
+
+            // We're taking it from the field in the parent type, but it becomes a parameter for the constructor...
+            // So long as it appears as "service" we don't really mind.
+            var serviceParam = Parameter(ctx.Type<IClientService>(), "service");
+            var ctorParameters = new List<ParameterSyntax> { serviceParam };
+            ctorParameters.AddRange(insertMethodParameters);
+
+            var insertMethod = Method(Modifier.Public | Modifier.Virtual, ctx.Type(uploadTyp), PascalCasedName)(insertMethodParameters.ToArray())
+                .WithBlockBody(Return(New(ctx.Type(uploadTyp))(ctorParameters)))
+                .WithXmlDoc(methodDocComments.ToArray());
+
+            using (ctx.InClass(uploadTyp))
+            {
+                var baseInitializerArgs = new List<object>
+                {
+                    serviceParam,
+                    ctx.Type<string>().Call(nameof(string.Format))("/{0}/{1}{2}", "upload", serviceParam.Access("BasePath"), _restMethod.Path),
+                    _restMethod.HttpMethod,
+                    streamParam,
+                    contentTypeParam
+                };
+                var baseInitializer = BaseInitializer(baseInitializerArgs).WithAdditionalAnnotations(Annotations.LineBreakAnnotation);
+                var assignments = requiredParameters.Select(p => Field(0, ctx.Type(p.param.Typ), p.param.PropertyName).Assign(p.decl)).ToList();
+
+                if (BodyTyp is object)
+                {
+                    // The Body property is in the base class.
+                    var bodyProperty = Property(Modifier.Public, ctx.Type(BodyTyp), "Body");
+                    assignments.Add(bodyProperty.Assign(Parameter(ctx.Type(BodyTyp), "body")));
+                }
+
+                // The parameters to the constructor are the same as for the method.
+                var uploadCtor = Ctor(Modifier.Public, uploadCls, baseInitializer)(ctorParameters.ToArray())
+                    .WithBlockBody(assignments)
+                    .WithXmlDoc(XmlDoc.Summary($"Constructs a new {PascalCasedName} media upload instance."), remarks);
+
+                uploadCls = uploadCls.AddMembers(Package.CreateParameterList(uploadTyp).SelectMany(p => p.GenerateDeclarations(ctx)).ToArray());
+                uploadCls = uploadCls.AddMembers(parameters.SelectMany(p => p.GenerateDeclarations(ctx)).ToArray());
+                uploadCls = uploadCls.AddMembers(uploadCtor);
+            }
+
+            yield return insertMethod;
+            yield return uploadCls;
         }
     }
 }

--- a/Google.Api.Generator.Rest/Models/MethodModel.cs
+++ b/Google.Api.Generator.Rest/Models/MethodModel.cs
@@ -288,7 +288,7 @@ namespace Google.Api.Generator.Rest.Models
 
             // This doc comment is common between the method and the constructor.
             var remarks = XmlDoc.Remarks("Considerations regarding ", streamParam, ":",
-                XmlDoc.UL(
+                XmlDoc.BulletListOfItemNodes(
                     XmlDoc.Item("If ", streamParam, " is seekable, then the stream position will be reset to ", 0, " before reading commences. If ", streamParam, " is not seekable, then it will be read from its current position"),
                     XmlDoc.Item("Caller is responsible for maintaining the ", streamParam, " open until the upload is completed"),
                     XmlDoc.Item("Caller is responsible for closing the ", streamParam)));

--- a/Google.Api.Generator.Rest/Models/MethodModel.cs
+++ b/Google.Api.Generator.Rest/Models/MethodModel.cs
@@ -47,7 +47,7 @@ namespace Google.Api.Generator.Rest.Models
             Package = package;
             Resource = resource;
             Name = name;
-            PascalCasedName = name.ToUpperCamelCase();
+            PascalCasedName = name.ToMemberName();
             ParentTyp = resource?.Typ ?? package.ServiceTyp;
             RequestTyp = Typ.Nested(ParentTyp, $"{PascalCasedName}Request");
             BodyTyp = restMethod.Request is object ? package.GetDataModelByReference(restMethod.Request.Ref__).Typ : null;

--- a/Google.Api.Generator.Rest/Models/Naming.cs
+++ b/Google.Api.Generator.Rest/Models/Naming.cs
@@ -14,7 +14,6 @@
 
 using Google.Api.Generator.Utils;
 using Google.Api.Generator.Utils.Roslyn;
-using System.Linq;
 
 namespace Google.Api.Generator.Rest.Models
 {
@@ -54,8 +53,9 @@ namespace Google.Api.Generator.Rest.Models
             {
                 return package.PackageName.ToUpperCamelCase() + name.ToUpperCamelCase();
             }
-            string[] bits = name.Split('.');
-            return string.Join('.', bits.Select(bit => bit.ToMemberName()));
+            // csharp_generator.py splits by dots and then joins the bits together with dots,
+            // but we never need that (and it causes issues with names like "$.xgafv").
+            return ToMemberName(name);
         }
 
         /// <summary>

--- a/Google.Api.Generator.Rest/Models/Naming.cs
+++ b/Google.Api.Generator.Rest/Models/Naming.cs
@@ -1,0 +1,68 @@
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Generator.Utils;
+using Google.Api.Generator.Utils.Roslyn;
+using System.Linq;
+
+namespace Google.Api.Generator.Rest.Models
+{
+    /// <summary>
+    /// Centralized place for naming rules within the REST generator.
+    /// </summary>
+    internal static class Naming
+    {
+        /// <summary>
+        /// Creates a member name from the given name in the discovery doc.
+        /// This is generally just the upper-camel-case version of the name,
+        /// but with some tweaks.
+        /// </summary>
+        internal static string ToMemberName(this string name, bool addUnderscoresToEscape = true)
+        {
+            if (char.IsDigit(name[0]))
+            {
+                name = "Value" + name;
+            }
+            var upper = name.ToUpperCamelCase(upperAfterDigit: null);
+
+            // We don't really need to escape keywords given that we've upper-cased it,
+            // but this is what the Python code does.
+            if (addUnderscoresToEscape && Keywords.IsKeyword(name))
+            {
+                upper += "__";
+            }
+            return upper;
+        }
+
+        /// <summary>
+        /// Equivalent to ToClassName in csharp_generator.py
+        /// </summary>
+        internal static string ToClassName(this string name, PackageModel package)
+        {
+            if (Keywords.IsKeyword(name))
+            {
+                return package.PackageName.ToUpperCamelCase() + name.ToUpperCamelCase();
+            }
+            string[] bits = name.Split('.');
+            return string.Join('.', bits.Select(bit => bit.ToMemberName()));
+        }
+
+        /// <summary>
+        /// Creates a name suitable for a local variable or parameter, using the package name
+        /// as a prefix if necessary.
+        /// </summary>
+        internal static string ToLocalVariableName(this string name, PackageModel package) =>
+            Keywords.IsKeyword(name) ? package.ApiName + name.ToUpperCamelCase() : name;
+    }
+}

--- a/Google.Api.Generator.Rest/Models/PackageModel.cs
+++ b/Google.Api.Generator.Rest/Models/PackageModel.cs
@@ -212,7 +212,7 @@ namespace Google.Api.Generator.Rest.Models
                 ctx.Type(Typ.Generic(typeof(ClientServiceRequest<>), Typ.GenericParam("TResponse"))))
                 .WithXmlDoc(XmlDoc.Summary($"A base abstract class for {ClassName} requests."));
 
-            using (ctx.InClass(cls))
+            using (ctx.InClass(BaseRequestTyp))
             {
                 var serviceParam = Parameter(ctx.Type<IClientService>(), "service");
                 var ctor = Ctor(Modifier.Protected, cls, BaseInitializer(serviceParam))(serviceParam)

--- a/Google.Api.Generator.Rest/Models/PackageModel.cs
+++ b/Google.Api.Generator.Rest/Models/PackageModel.cs
@@ -80,8 +80,8 @@ namespace Google.Api.Generator.Rest.Models
             // TODO: Ordering?
             AuthScopes = (discoveryDoc.Auth?.Oauth2?.Scopes).ToReadOnlyList(pair => new AuthScope(pair.Key, pair.Value.Description));
             ServiceTyp = Typ.Manual(PackageName, ServiceClassName);
-            BaseRequestTyp = Typ.Generic(Typ.Manual(PackageName, $"{ClassName}BaseServiceRequest"), Typ.GenericParam("TResponse"));
             GenericBaseRequestTypDef = Typ.Manual(PackageName, $"{ClassName}BaseServiceRequest");
+            BaseRequestTyp = Typ.Generic(GenericBaseRequestTypDef, Typ.GenericParam("TResponse"));
             BaseUri = discoveryDoc.RootUrl + discoveryDoc.ServicePath;
             BasePath = discoveryDoc.ServicePath;
             BatchUri = discoveryDoc.RootUrl + discoveryDoc.BatchPath;

--- a/Google.Api.Generator.Rest/Models/PackageModel.cs
+++ b/Google.Api.Generator.Rest/Models/PackageModel.cs
@@ -90,6 +90,11 @@ namespace Google.Api.Generator.Rest.Models
             Methods = discoveryDoc.Methods.ToReadOnlyList(pair => new MethodModel(this, null, pair.Key, pair.Value));
         }
 
+        public IReadOnlyList<ParameterModel> CreateParameterList(Typ baseTyp) =>
+            _discoveryDoc.Parameters.Select(p => new ParameterModel(this, p.Key, p.Value, baseTyp))
+                .OrderBy(p => p.Name, StringComparer.Ordinal)
+                .ToList();
+
         public ClassDeclarationSyntax GenerateServiceClass(SourceFileContext ctx)
         {
             var cls = Class(Modifier.Public, ServiceTyp, ctx.Type<BaseClientService>()).WithXmlDoc(XmlDoc.Summary($"The {ClassName} Service."));
@@ -204,12 +209,9 @@ namespace Google.Api.Generator.Rest.Models
                     .WithBody()
                     .WithXmlDoc(XmlDoc.Summary($"Constructs a new {ClassName}BaseServiceRequest instance."));
 
+                var parameters = CreateParameterList(BaseRequestTyp);
+
                 cls = cls.AddMembers(ctor);
-
-                var parameters = _discoveryDoc.Parameters.Select(p => new ParameterModel(this, p.Key, p.Value, BaseRequestTyp))
-                    .OrderBy(p => p.Name, StringComparer.Ordinal)
-                    .ToList();
-
                 cls = cls.AddMembers(parameters.SelectMany(p => p.GenerateDeclarations(ctx)).ToArray());
 
                 var initParameters = Method(Modifier.Protected | Modifier.Override, VoidType, "InitParameters")()

--- a/Google.Api.Generator.Rest/Models/PackageModel.cs
+++ b/Google.Api.Generator.Rest/Models/PackageModel.cs
@@ -63,7 +63,7 @@ namespace Google.Api.Generator.Rest.Models
         {
             _discoveryDoc = discoveryDoc;
             ApiName = discoveryDoc.Name;
-            ClassName = ToClassName(discoveryDoc.CanonicalName ?? discoveryDoc.Name);
+            ClassName = (discoveryDoc.CanonicalName ?? discoveryDoc.Name).ToClassName(this);
             ServiceClassName = $"{ClassName}Service";
             ApiVersion = discoveryDoc.Version;
             PackageName = $"Google.Apis.{ClassName}.{ApiVersion}";
@@ -88,21 +88,6 @@ namespace Google.Api.Generator.Rest.Models
             BatchPath = discoveryDoc.BatchPath;
             Title = discoveryDoc.Title;
             Methods = discoveryDoc.Methods.ToReadOnlyList(pair => new MethodModel(this, null, pair.Key, pair.Value));
-        }
-
-        /// <summary>
-        /// Equivalent to ToClassName in csharp_generator.py
-        /// </summary>
-        /// <param name="text"></param>
-        /// <returns></returns>
-        internal string ToClassName(string text)
-        {
-            if (Keywords.IsKeyword(text))
-            {
-                return PackageName.ToUpperCamelCase() + text.ToUpperCamelCase();
-            }
-            string[] bits = text.Split('.');
-            return string.Join('.', bits.Select(bit => bit.ToUpperCamelCase()));
         }
 
         public ClassDeclarationSyntax GenerateServiceClass(SourceFileContext ctx)

--- a/Google.Api.Generator.Rest/Models/ParameterModel.cs
+++ b/Google.Api.Generator.Rest/Models/ParameterModel.cs
@@ -45,9 +45,10 @@ namespace Google.Api.Generator.Rest.Models
         {
             _package = package;
             Name = name;
-            // TODO: Move this to a helper method and make sure we apply it consistently.
-            CodeParameterName = Keywords.IsKeyword(name) ? package.ApiName + name.ToUpperCamelCase() : name;
-            PropertyName = name.ToUpperCamelCase();
+            CodeParameterName = name.ToLocalVariableName(package);
+
+            // It's unclear why these properties don't get the "__" treatment, but apparently they don't.
+            PropertyName = name.ToMemberName(addUnderscoresToEscape: false);
             Location = schema.Location switch
             {
                 "query" => RequestParameterType.Query,

--- a/Google.Api.Generator.Rest/Models/ParameterModel.cs
+++ b/Google.Api.Generator.Rest/Models/ParameterModel.cs
@@ -16,7 +16,6 @@ using Google.Api.Generator.Utils;
 using Google.Api.Generator.Utils.Roslyn;
 using Google.Apis.Discovery.v1.Data;
 using Google.Apis.Util;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
@@ -64,17 +63,8 @@ namespace Google.Api.Generator.Rest.Models
         {
             var propertyType = ctx.Type(Typ);
             var locationExpression = ctx.Type<RequestParameterType>().Access(Location.ToString());
-            var property = AutoProperty(Modifier.Public | Modifier.Virtual, propertyType, PropertyName)
+            var property = AutoProperty(Modifier.Public | Modifier.Virtual, propertyType, PropertyName, hasSetter: true, setterIsPrivate: IsRequired)
                 .WithAttribute(ctx.Type<RequestParameterAttribute>())(Name, locationExpression);
-
-            // We always have a setter, but it's private if the parameter is required.
-            var setter = AccessorDeclaration(SyntaxKind.SetAccessorDeclaration).WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
-            if (IsRequired)
-            {
-                setter = setter.WithModifiers(TokenList(Token(SyntaxKind.PrivateKeyword).WithTrailingSpace()));
-            }
-            property = property.AddAccessorListAccessors(setter);
-
             if (_schema.Description is string description)
             {
                 property = property.WithXmlDoc(XmlDoc.Summary(description));

--- a/Google.Api.Generator.Rest/Models/ResourceModel.cs
+++ b/Google.Api.Generator.Rest/Models/ResourceModel.cs
@@ -17,7 +17,6 @@ using Google.Api.Generator.Utils.Roslyn;
 using Google.Apis.Discovery.v1.Data;
 using Google.Apis.Services;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using static Google.Api.Generator.Utils.Roslyn.RoslynBuilder;
@@ -47,8 +46,8 @@ namespace Google.Api.Generator.Rest.Models
         {
             Package = package;
             Name = name;
-            PropertyName = package.ToClassName(name);
-            ClassName = $"{PropertyName}Resource";
+            PropertyName = name.ToMemberName();
+            ClassName = name.ToClassName(package) + "Resource";
             Parent = parent;
             Typ = parent is null ? Typ.Manual(package.PackageName, ClassName) : Typ.Nested(parent.Typ, ClassName);
             Subresources = discoveryResource.Resources.ToReadOnlyList(pair => new ResourceModel(package, this, pair.Key, pair.Value));

--- a/Google.Api.Generator.Rest/Models/SchemaTypes.cs
+++ b/Google.Api.Generator.Rest/Models/SchemaTypes.cs
@@ -62,11 +62,16 @@ namespace Google.Api.Generator.Rest.Models
             else if (schema.Properties is object)
             {
                 // Anonymous schema embedded in the current type.
-                return Typ.Nested(currentTyp, name.ToUpperCamelCase() + "Data");
+                return Typ.Nested(currentTyp, name.ToClassName(package) + "Data");
+            }
+            else if (schema.AdditionalProperties is object)
+            {
+                var valueTyp = GetTypFromSchema(package, schema.AdditionalProperties, schema.AdditionalProperties.Id ?? name + "Element", currentTyp);
+                return Typ.Generic(Typ.Of(typeof(IDictionary<,>)), Typ.Of<string>(), valueTyp);
             }
             if (schema.Enum__ is object)
             {
-                Typ enumTyp = Typ.Nested(currentTyp, name.ToUpperCamelCase() + "Enum", isEnum: true);
+                Typ enumTyp = Typ.Nested(currentTyp, name.ToClassName(package) + "Enum", isEnum: true);
                 return (schema.Required ?? false) ? enumTyp : Typ.Generic(Typ.Of(typeof(Nullable<>)), enumTyp);
             }
             else if (schema.Type is object)

--- a/Google.Api.Generator.Rest/Models/SchemaTypes.cs
+++ b/Google.Api.Generator.Rest/Models/SchemaTypes.cs
@@ -45,14 +45,14 @@ namespace Google.Api.Generator.Rest.Models
 
         internal static Typ GetTypFromSchema(PackageModel package, JsonSchema schema, string name, Typ currentTyp)
         {
-            // TODO: Additional properties, becoming a dictionary.
             if (schema.Repeated ?? false)
             {
                 return Typ.Of<Repeatable<string>>();
             }
             if (schema.Ref__ is object)
             {
-                return package.GetDataModelByReference(schema.Ref__).Typ;
+                var model = package.GetDataModelByReference(schema.Ref__);
+                return model.IsArray ? Typ.Generic(typeof(IList<>), model.Typ) : model.Typ;
             }
             else if (schema.Type == "array")
             {

--- a/Google.Api.Generator.Utils/Formatting/WhitespaceFormatter.cs
+++ b/Google.Api.Generator.Utils/Formatting/WhitespaceFormatter.cs
@@ -48,6 +48,14 @@ namespace Google.Api.Generator.Utils.Formatting
         private SyntaxTrivia _indentTrivia = SyntaxTrivia(SyntaxKind.WhitespaceTrivia, "");
         private SyntaxTrivia _previousIndentTrivia = SyntaxTrivia(SyntaxKind.WhitespaceTrivia, "");
 
+        private IEnumerable<SyntaxToken> CommaLineBreakIndents(int count)
+        {
+            using (WithIndent())
+            {
+                return Enumerable.Repeat(Token(SyntaxKind.CommaToken).WithTrailingTrivia(WhitespaceFormatterNewLine.NewLine, _indentTrivia), Math.Max(0, count)).ToList();
+            }
+        }
+
         private IDisposable WithIndent(bool withIndent = true)
         {
             if (withIndent)
@@ -266,7 +274,10 @@ namespace Google.Api.Generator.Utils.Formatting
         public override SyntaxNode VisitParameterList(ParameterListSyntax node)
         {
             node = (ParameterListSyntax)base.VisitParameterList(node);
-            node = node.WithParameters(SeparatedList(node.Parameters, CommaSpaces(node.Parameters.Count - 1)));
+            var separators = node.HasAnnotation(Annotations.LineBreakAnnotation)
+                ? CommaLineBreakIndents(node.Parameters.Count - 1)
+                : CommaSpaces(node.Parameters.Count - 1);
+            node = node.WithParameters(SeparatedList(node.Parameters, separators));
             return node;
         }
 

--- a/Google.Api.Generator.Utils/Formatting/WhitespaceFormatter.cs
+++ b/Google.Api.Generator.Utils/Formatting/WhitespaceFormatter.cs
@@ -184,7 +184,17 @@ namespace Google.Api.Generator.Utils.Formatting
         public override SyntaxNode VisitConstructorInitializer(ConstructorInitializerSyntax node)
         {
             node = (ConstructorInitializerSyntax)base.VisitConstructorInitializer(node);
-            node = node.WithColonToken(node.ColonToken.WithLeadingSpace().WithTrailingSpace());
+            if (node.HasAnnotation(Annotations.LineBreakAnnotation))
+            {
+                using (WithIndent())
+                {
+                    node = node.WithColonToken(node.ColonToken.WithLeadingTrivia(WhitespaceFormatterNewLine.NewLine, _indentTrivia).WithTrailingSpace());
+                }
+            }
+            else
+            {
+                node = node.WithColonToken(node.ColonToken.WithLeadingSpace().WithTrailingSpace());
+            }
             return node;
         }
 

--- a/Google.Api.Generator.Utils/Roslyn/Annotations.cs
+++ b/Google.Api.Generator.Utils/Roslyn/Annotations.cs
@@ -1,0 +1,26 @@
+﻿// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.CodeAnalysis;
+
+namespace Google.Api.Generator.Utils.Roslyn
+{
+    /// <summary>
+    /// Annotations recognized by aspects of our pipeline, e.g. formatting.
+    /// </summary>
+    public static class Annotations
+    {
+        public static SyntaxAnnotation LineBreakAnnotation { get; } = new SyntaxAnnotation("line_break");
+    }
+}

--- a/Google.Api.Generator.Utils/Roslyn/RoslynExtensions.cs
+++ b/Google.Api.Generator.Utils/Roslyn/RoslynExtensions.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Api.Generator.Utils.Formatting;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -331,5 +332,8 @@ namespace Google.Api.Generator.Utils.Roslyn
 
         public static SyntaxToken WithPragmaWarning(this SyntaxToken token, string errorCode) =>
             token.WithAdditionalAnnotations(new SyntaxAnnotation(PragmaWarnings.AnnotationKind, errorCode));
+
+        public static MethodDeclarationSyntax WithParameterLineBreaks(this MethodDeclarationSyntax method) =>
+            method.WithParameterList(method.ParameterList.WithAdditionalAnnotations(Annotations.LineBreakAnnotation));
     }
 }

--- a/Google.Api.Generator.Utils/Roslyn/XmlDoc.cs
+++ b/Google.Api.Generator.Utils/Roslyn/XmlDoc.cs
@@ -91,14 +91,16 @@ namespace Google.Api.Generator.Utils.Roslyn
         public static XmlNodeSyntax Code(params string[] lines) => XmlElement("code", List(lines.Select(ToNode)));
 
         public static XmlNodeSyntax Para(params object[] parts) => XmlParaElement(parts.Select(ToNode).ToArray());
+
+        public static XmlNodeSyntax Item(params object[] parts) => XmlElement("item", SingletonList<XmlNodeSyntax>(XmlElement("description", List(parts.Select(ToNode)))));
+
         public static XmlNodeSyntax UL(params object[] items) => UL((IEnumerable<object>)items);
-        public static XmlNodeSyntax UL<T>(IEnumerable<T> items) => XmlElement(
-            XmlElementStartTag(XmlName("list"), SingletonList<XmlAttributeSyntax>(XmlTextAttribute("type", "bullet"))),
-                List<XmlNodeSyntax>(items.Select(item =>
-                {
-                    var desc = XmlElement("description", SingletonList(ToNode(item)));
-                    return XmlElement("item", SingletonList<XmlNodeSyntax>(desc));
-                })),
+        public static XmlNodeSyntax UL<T>(IEnumerable<T> items) => UL(items.Select(item => Item(item)));
+        public static XmlNodeSyntax UL(params XmlNodeSyntax[] itemNodes) =>
+            XmlElement(
+                XmlElementStartTag(XmlName("list"), SingletonList<XmlAttributeSyntax>(XmlTextAttribute("type", "bullet"))),
+                List(itemNodes),
                 XmlElementEndTag(XmlName("list")));
+
     }
 }

--- a/Google.Api.Generator.Utils/Roslyn/XmlDoc.cs
+++ b/Google.Api.Generator.Utils/Roslyn/XmlDoc.cs
@@ -95,8 +95,8 @@ namespace Google.Api.Generator.Utils.Roslyn
         public static XmlNodeSyntax Item(params object[] parts) => XmlElement("item", SingletonList<XmlNodeSyntax>(XmlElement("description", List(parts.Select(ToNode)))));
 
         public static XmlNodeSyntax UL(params object[] items) => UL((IEnumerable<object>)items);
-        public static XmlNodeSyntax UL<T>(IEnumerable<T> items) => UL(items.Select(item => Item(item)));
-        public static XmlNodeSyntax UL(params XmlNodeSyntax[] itemNodes) =>
+        public static XmlNodeSyntax UL<T>(IEnumerable<T> items) => BulletListOfItemNodes(items.Select(item => Item(item)).ToArray());
+        public static XmlNodeSyntax BulletListOfItemNodes(params XmlNodeSyntax[] itemNodes) =>
             XmlElement(
                 XmlElementStartTag(XmlName("list"), SingletonList<XmlAttributeSyntax>(XmlTextAttribute("type", "bullet"))),
                 List(itemNodes),

--- a/Google.Api.Generator.Utils/Roslyn/XmlDoc.cs
+++ b/Google.Api.Generator.Utils/Roslyn/XmlDoc.cs
@@ -90,6 +90,7 @@ namespace Google.Api.Generator.Utils.Roslyn
         public static XmlNodeSyntax C(string c) => XmlElement("c", SingletonList<XmlNodeSyntax>(XmlText(c)));
         public static XmlNodeSyntax Code(params string[] lines) => XmlElement("code", List(lines.Select(ToNode)));
 
+        public static XmlNodeSyntax Para(params object[] parts) => XmlParaElement(parts.Select(ToNode).ToArray());
         public static XmlNodeSyntax UL(params object[] items) => UL((IEnumerable<object>)items);
         public static XmlNodeSyntax UL<T>(IEnumerable<T> items) => XmlElement(
             XmlElementStartTag(XmlName("list"), SingletonList<XmlAttributeSyntax>(XmlTextAttribute("type", "bullet"))),

--- a/Google.Api.Generator.Utils/SourceFileContext.cs
+++ b/Google.Api.Generator.Utils/SourceFileContext.cs
@@ -395,6 +395,10 @@ namespace Google.Api.Generator.Utils
             {
                 return PredefinedType(Token(SyntaxKind.VoidKeyword));
             }
+            if (typ is Typ.VarTyp)
+            {
+                return IdentifierName("var");
+            }
             if (typ.ElementTyp != null)
             {
                 // Handle array typs.

--- a/Google.Api.Generator.Utils/SystemExtensions.cs
+++ b/Google.Api.Generator.Utils/SystemExtensions.cs
@@ -22,16 +22,16 @@ namespace Google.Api.Generator.Utils
         private static char MaybeForceCase(char c, bool? toUpper) =>
             toUpper is bool upper ? upper ? char.ToUpperInvariant(c) : char.ToLowerInvariant(c) : c;
 
-        private static string Camelizer(string s, bool firstUpper, bool forceAllChars) =>
+        private static string Camelizer(string s, bool firstUpper, bool forceAllChars, bool? upperAfterDigit) =>
             s.Aggregate((upper: (bool?)firstUpper, prev: '\0', sb: new StringBuilder()), (acc, c) =>
                 !char.IsLetterOrDigit(c) ?
                     (acc.sb.Length > 0 ? true : firstUpper, c, acc.sb) :
-                    (char.IsDigit(c) ? true : forceAllChars ? (bool?)false : null, c,
+                    (char.IsDigit(c) ? upperAfterDigit : forceAllChars ? (bool?)false : null, c,
                         acc.sb.Append(MaybeForceCase(c, char.IsLower(acc.prev) && char.IsUpper(c) ? true : acc.upper))),
                 acc => acc.sb.ToString());
 
-        public static string ToLowerCamelCase(this string s) => Camelizer(s, firstUpper: false, forceAllChars: false);
-        public static string ToUpperCamelCase(this string s, bool forceAllChars = false) => Camelizer(s, firstUpper: true, forceAllChars);
+        public static string ToLowerCamelCase(this string s) => Camelizer(s, firstUpper: false, forceAllChars: false, upperAfterDigit: true);
+        public static string ToUpperCamelCase(this string s, bool forceAllChars = false, bool? upperAfterDigit = true) => Camelizer(s, firstUpper: true, forceAllChars, upperAfterDigit);
 
         public static string RemoveSuffix(this string s, string suffix) => s.EndsWith(suffix) ? s.Substring(0, s.Length - suffix.Length) : s;
     }

--- a/Google.Api.Generator.Utils/Typ.cs
+++ b/Google.Api.Generator.Utils/Typ.cs
@@ -32,6 +32,12 @@ namespace Google.Api.Generator.Utils
             public override string Name => "void";
         }
 
+        public sealed class VarTyp : Typ
+        {
+            public override string Namespace => null;
+            public override string Name => "var";
+        }
+
         private sealed class FromType : Typ
         {
             public FromType(System.Type type) => _type = type;
@@ -107,6 +113,7 @@ namespace Google.Api.Generator.Utils
         }
 
         public static Typ Void { get; } = new VoidTyp();
+        public static Typ Var { get; } = new VarTyp();
 
         public static Typ Of<T>() => Of(typeof(T));
         public static Typ Of(System.Type type) => new FromType(type);


### PR DESCRIPTION
There's one annoyance with the feature list formatting, but apart from that, Translate, WebFonts and Storage all generate in a whitespace-only-diff (and copyright) fashion. (For the C# code. We don't generate the project files yet.)

There may well be more differences to take account of when we generate more APIs...

Note that I'm assuming that https://github.com/googleapis/google-api-dotnet-client/pull/1651 will be merged - the final Storage sample update is based on that.