### PR TITLE
Final changes to REST generator for parity

### DIFF
--- a/Google.Api.Generator.Rest/Models/DataModel.cs
+++ b/Google.Api.Generator.Rest/Models/DataModel.cs
@@ -66,8 +66,11 @@ namespace Google.Api.Generator.Rest.Models
             Typ = parent is null ? Typ.Manual(Package.PackageName + ".Data", className) : Typ.Nested(parent.Typ, className);
 
             // We may get a JsonSchema for an array as a nested model. Just use the properties from schema.Items for simplicity.
-            Properties = (schema.Properties ?? schema.Items?.Properties).ToReadOnlyList(pair => new DataPropertyModel(this, pair.Key, pair.Value));
+            Properties = GetProperties(schema).ToReadOnlyList(pair => new DataPropertyModel(this, pair.Key, pair.Value));
         }
+
+        internal static IDictionary<string, JsonSchema> GetProperties(JsonSchema schema) =>
+            schema.Properties ?? (schema.Items is object ? GetProperties(schema.Items) : null);
 
         public ClassDeclarationSyntax GenerateClass(SourceFileContext ctx)
         {

--- a/Google.Api.Generator.Rest/Models/DataModel.cs
+++ b/Google.Api.Generator.Rest/Models/DataModel.cs
@@ -91,9 +91,7 @@ namespace Google.Api.Generator.Rest.Models
             }
             if (_schema.AdditionalProperties is object)
             {
-                // TODO: Check all of this. It's a bit dodgy...
-                var valueTyp = SchemaTypes.GetTypFromSchema(Package, _schema.AdditionalProperties, _schema.AdditionalProperties.Id ?? Name + "Element", ret, inParameter: false);
-                ret = Typ.Generic(Typ.Of(typeof(IDictionary<,>)), Typ.Of<string>(), valueTyp);
+                ret = SchemaTypes.GetTypFromAdditionalProperties(Package, _schema.AdditionalProperties, Name, ret, inParameter: false);                
             }
             return ret;
         }

--- a/Google.Api.Generator.Rest/Models/DataPropertyModel.cs
+++ b/Google.Api.Generator.Rest/Models/DataPropertyModel.cs
@@ -96,12 +96,16 @@ namespace Google.Api.Generator.Rest.Models
 
         public IEnumerable<ClassDeclarationSyntax> GenerateAnonymousModels(SourceFileContext ctx)
         {
-            if (DataModel.GetProperties(_schema) is null)
+            if (_schema.AdditionalProperties is object && DataModel.GetProperties(_schema.AdditionalProperties) is object)
             {
-                yield break;
+                var dataModel = new DataModel(Parent.Package, Parent, (Name + "Element").ToAnonymousModelClassName(Parent.Package, Parent.Typ.Name, true), _schema.AdditionalProperties);
+                yield return dataModel.GenerateClass(ctx);
             }
-            var dataModel = new DataModel(Parent.Package, Parent, (Name + "Data").ToClassName(Parent.Package, Parent.Typ.Name), _schema);
-            yield return dataModel.GenerateClass(ctx);
+            else if (DataModel.GetProperties(_schema) is object)
+            {
+                var dataModel = new DataModel(Parent.Package, Parent, Name.ToAnonymousModelClassName(Parent.Package, Parent.Typ.Name, false), _schema);
+                yield return dataModel.GenerateClass(ctx);
+            }
         }
     }
 }

--- a/Google.Api.Generator.Rest/Models/DataPropertyModel.cs
+++ b/Google.Api.Generator.Rest/Models/DataPropertyModel.cs
@@ -96,7 +96,7 @@ namespace Google.Api.Generator.Rest.Models
 
         public IEnumerable<ClassDeclarationSyntax> GenerateAnonymousModels(SourceFileContext ctx)
         {
-            if ((_schema.Properties ?? _schema.Items?.Properties) is null)
+            if (DataModel.GetProperties(_schema) is null)
             {
                 yield break;
             }

--- a/Google.Api.Generator.Rest/Models/MethodModel.cs
+++ b/Google.Api.Generator.Rest/Models/MethodModel.cs
@@ -58,8 +58,8 @@ namespace Google.Api.Generator.Rest.Models
             PascalCasedName = name.ToClassName(package, resource.ClassName);
             ParentTyp = resource?.Typ ?? package.ServiceTyp;
             RequestTyp = Typ.Nested(ParentTyp, $"{PascalCasedName}Request");
-            BodyTyp = restMethod.Request is object ? package.GetDataModelByReference(restMethod.Request.Ref__).Typ : null;
-            ResponseTyp = restMethod.Response is object ? package.GetDataModelByReference(restMethod.Response.Ref__).Typ : Typ.Of<string>();
+            BodyTyp = restMethod.Request is object ? package.GetDataModelByReference(restMethod.Request.Ref__).GetTypForReference() : null;
+            ResponseTyp = restMethod.Response is object ? package.GetDataModelByReference(restMethod.Response.Ref__).GetTypForReference() : Typ.Of<string>();
             _restMethod = restMethod;
         }
 

--- a/Google.Api.Generator.Rest/Models/Naming.cs
+++ b/Google.Api.Generator.Rest/Models/Naming.cs
@@ -60,6 +60,14 @@ namespace Google.Api.Generator.Rest.Models
             return candidate + suffix;
         }
 
+        internal static string ToAnonymousModelClassName(this string name, PackageModel package, string containingClass, bool inAdditionalProperties)
+        {
+            // This is ugly, but when we've got an anonymous model that's also a dictionary, we end up with things round the
+            // wrong way otherwise :( It's hard to fix the recursion to get this in the right order.
+            name = inAdditionalProperties ? name[..^7] + "DataElement" : name + "Data";
+            return name.ToClassName(package, containingClass);
+        }
+
         /// <summary>
         /// Creates a name suitable for a local variable or parameter, using the package name
         /// as a prefix if necessary.

--- a/Google.Api.Generator.Rest/Models/SchemaTypes.cs
+++ b/Google.Api.Generator.Rest/Models/SchemaTypes.cs
@@ -54,9 +54,7 @@ namespace Google.Api.Generator.Rest.Models
         {
             if (schema.Ref__ is object)
             {
-                var model = package.GetDataModelByReference(schema.Ref__);
-                var modelTyp = model.IsPlaceholder ? Typ.Of<object>() : model.Typ;
-                return model.IsArray ? Typ.Generic(typeof(IList<>), modelTyp) : modelTyp;
+                return package.GetDataModelByReference(schema.Ref__).GetTypForReference();
             }
             else if (schema.Type == "array")
             {


### PR DESCRIPTION
(No urgency to review this)

With these changes in, we generate the same code that the Python generator does.

Next step will be to refactor a bit, ideally to move everything around naming to one place, and reducing the number of public properties.