### PR TITLE
fix: rerun dotnet compiler if the first invocation fails

### DIFF
--- a/rules_csharp_gapic/csharp_compiler.bzl
+++ b/rules_csharp_gapic/csharp_compiler.bzl
@@ -25,9 +25,11 @@ DOTNET_CLI_HOME="$(pwd)/local_tmp" \
 DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 \
 DOTNET_CLI_TELEMETRY_OPTOUT=1 \
 DOTNET_NOLOGO=1 \
-{csharp_compiler}/dotnet build src/{csproj_relative} \
+cmd="{csharp_compiler}/dotnet build src/{csproj_relative} \
   --framework {framework} --configuration {configuration} \
-  --no-restore --nologo --verbosity=quiet --packages packages
+  --no-restore --nologo --verbosity=quiet --packages packages"
+# If the first invocation fails, try once more
+$cmd || $cmd
 cp -r src/* {out}/
     """.format(
         restore = ctx.file.restore.path,
@@ -48,9 +50,11 @@ DOTNET_CLI_HOME="$(pwd)/local_tmp" \
 DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 \
 DOTNET_CLI_TELEMETRY_OPTOUT=1 \
 DOTNET_NOLOGO=1 \
-$(dirname $0)/run.sh.runfiles/$(basename $(pwd))/{csharp_compiler}/dotnet run \
+cmd="$(dirname $0)/run.sh.runfiles/$(basename $(pwd))/{csharp_compiler}/dotnet run \
   --project $(dirname $0)/run.sh.runfiles/$(basename $(pwd))/{out}/{csproj_relative} \
-  --no-restore --no-build
+  --no-restore --no-build"
+# If the first invocation fails, try once more
+$cmd || $cmd
     """.format(
         csharp_compiler = ctx.file.csharp_compiler.short_path,
         out = out_dir.short_path,


### PR DESCRIPTION
A lot of continuous integration builds (one or two per day) fail in Kokoro for no reason with this error:
```
failed: error executing command bazel-out/host/bin/external/com_google_protobuf/protoc --experimental_allow_proto3_optional '--plugin=protoc-gen-gapic=bazel-out/host/bin/external/gapic_generator_csharp/rules_csharp_gapic/run.sh' ... (remaining 17 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
Failed to create CoreCLR, HRESULT: 0x80004005
--gapic_out: protoc-gen-gapic: Plugin failed with status code 137.
```

The latest example of this failure can be seen in Sponge with ID 4a0cfd5f-e352-4b26-94a6-bf56052d59aa. They always pass if I restart the build.

Until the root cause is found (if it's possible to find the root cause at all :) ), let's try this simple hack to run the `dotnet` binary for the second time if the first invocation fails. What do you folks think?