### PR TITLE
Each snippet is now generated in and individual file (also).

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTest.cs
+++ b/Google.Api.Generator.Tests/ProtoTest.cs
@@ -19,7 +19,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using Xunit;
 
 namespace Google.Api.Generator.Tests
@@ -69,6 +68,7 @@ namespace Google.Api.Generator.Tests
             {
                 if ((ignoreCsProj && file.RelativePath.EndsWith(".csproj")) ||
                     (ignoreSnippets && file.RelativePath.Contains($".Snippets{Path.DirectorySeparatorChar}")) ||
+                    (ignoreSnippets && file.RelativePath.Contains($".StandaloneSnippets{Path.DirectorySeparatorChar}")) ||
                     (ignoreUnitTests && file.RelativePath.Contains($".Tests{Path.DirectorySeparatorChar}")))
                 {
                     continue;

--- a/Google.Api.Generator.Tests/ProtoTests/Basic/Testing.Basic.StandaloneSnippets/BasicClient.AMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic/Testing.Basic.StandaloneSnippets/BasicClient.AMethodRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Basic.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedBasicClientStandaloneSnippets
+    {
+        /// <summary>Snippet for AMethodAsync</summary>
+        public async Task AMethodRequestObjectAsync()
+        {
+            // Snippet: AMethodAsync(Request, CallSettings)
+            // Additional: AMethodAsync(Request, CancellationToken)
+            // Create client
+            BasicClient basicClient = await BasicClient.CreateAsync();
+            // Initialize request argument(s)
+            Request request = new Request { };
+            // Make the request
+            Response response = await basicClient.AMethodAsync(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Basic/Testing.Basic.StandaloneSnippets/BasicClient.AMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic/Testing.Basic.StandaloneSnippets/BasicClient.AMethodRequestObjectSnippet.g.cs
@@ -1,0 +1,34 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Basic.Snippets
+{
+    public sealed partial class GeneratedBasicClientStandaloneSnippets
+    {
+        /// <summary>Snippet for AMethod</summary>
+        public void AMethodRequestObject()
+        {
+            // Snippet: AMethod(Request, CallSettings)
+            // Create client
+            BasicClient basicClient = BasicClient.Create();
+            // Initialize request argument(s)
+            Request request = new Request { };
+            // Make the request
+            Response response = basicClient.AMethod(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Basic/Testing.Basic.StandaloneSnippets/Testing.Basic.StandaloneSnippets.csproj
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic/Testing.Basic.StandaloneSnippets/Testing.Basic.StandaloneSnippets.csproj
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.2</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Testing.Basic/Testing.Basic.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Google.Api.Generator.Tests/ProtoTests/BasicLro/Testing.BasicLro.StandaloneSnippets/BasicLroClient.Method1RequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/BasicLro/Testing.BasicLro.StandaloneSnippets/BasicLroClient.Method1RequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,54 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.BasicLro.Snippets
+{
+    using Google.LongRunning;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedBasicLroClientStandaloneSnippets
+    {
+        /// <summary>Snippet for Method1Async</summary>
+        public async Task Method1RequestObjectAsync()
+        {
+            // Snippet: Method1Async(Request, CallSettings)
+            // Additional: Method1Async(Request, CancellationToken)
+            // Create client
+            BasicLroClient basicLroClient = await BasicLroClient.CreateAsync();
+            // Initialize request argument(s)
+            Request request = new Request { };
+            // Make the request
+            Operation<LroResponse, LroMetadata> response = await basicLroClient.Method1Async(request);
+
+            // Poll until the returned long-running operation is complete
+            Operation<LroResponse, LroMetadata> completedResponse = await response.PollUntilCompletedAsync();
+            // Retrieve the operation result
+            LroResponse result = completedResponse.Result;
+
+            // Or get the name of the operation
+            string operationName = response.Name;
+            // This name can be stored, then the long-running operation retrieved later by name
+            Operation<LroResponse, LroMetadata> retrievedResponse = await basicLroClient.PollOnceMethod1Async(operationName);
+            // Check if the retrieved long-running operation has completed
+            if (retrievedResponse.IsCompleted)
+            {
+                // If it has completed, then access the result
+                LroResponse retrievedResult = retrievedResponse.Result;
+            }
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/BasicLro/Testing.BasicLro.StandaloneSnippets/BasicLroClient.Method1RequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/BasicLro/Testing.BasicLro.StandaloneSnippets/BasicLroClient.Method1RequestObjectSnippet.g.cs
@@ -1,0 +1,52 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.BasicLro.Snippets
+{
+    using Google.LongRunning;
+
+    public sealed partial class GeneratedBasicLroClientStandaloneSnippets
+    {
+        /// <summary>Snippet for Method1</summary>
+        public void Method1RequestObject()
+        {
+            // Snippet: Method1(Request, CallSettings)
+            // Create client
+            BasicLroClient basicLroClient = BasicLroClient.Create();
+            // Initialize request argument(s)
+            Request request = new Request { };
+            // Make the request
+            Operation<LroResponse, LroMetadata> response = basicLroClient.Method1(request);
+
+            // Poll until the returned long-running operation is complete
+            Operation<LroResponse, LroMetadata> completedResponse = response.PollUntilCompleted();
+            // Retrieve the operation result
+            LroResponse result = completedResponse.Result;
+
+            // Or get the name of the operation
+            string operationName = response.Name;
+            // This name can be stored, then the long-running operation retrieved later by name
+            Operation<LroResponse, LroMetadata> retrievedResponse = basicLroClient.PollOnceMethod1(operationName);
+            // Check if the retrieved long-running operation has completed
+            if (retrievedResponse.IsCompleted)
+            {
+                // If it has completed, then access the result
+                LroResponse retrievedResult = retrievedResponse.Result;
+            }
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedFieldMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedFieldMethodAsyncSnippet.g.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Deprecated.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedDeprecatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for DeprecatedFieldMethodAsync</summary>
+        public async Task DeprecatedFieldMethodAsync()
+        {
+            // Snippet: DeprecatedFieldMethodAsync(string, string, CallSettings)
+            // Additional: DeprecatedFieldMethodAsync(string, string, CancellationToken)
+            // Create client
+            DeprecatedClient deprecatedClient = await DeprecatedClient.CreateAsync();
+            // Initialize request argument(s)
+            string deprecatedField1 = "";
+            string deprecatedField2 = "";
+            // Make the request
+            Response response = await deprecatedClient.DeprecatedFieldMethodAsync(deprecatedField1, deprecatedField2);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedFieldMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedFieldMethodRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Deprecated.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedDeprecatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for DeprecatedFieldMethodAsync</summary>
+        public async Task DeprecatedFieldMethodRequestObjectAsync()
+        {
+            // Snippet: DeprecatedFieldMethodAsync(DeprecatedFieldRequest, CallSettings)
+            // Additional: DeprecatedFieldMethodAsync(DeprecatedFieldRequest, CancellationToken)
+            // Create client
+            DeprecatedClient deprecatedClient = await DeprecatedClient.CreateAsync();
+            // Initialize request argument(s)
+            DeprecatedFieldRequest request = new DeprecatedFieldRequest { };
+            // Make the request
+            Response response = await deprecatedClient.DeprecatedFieldMethodAsync(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedFieldMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedFieldMethodRequestObjectSnippet.g.cs
@@ -1,0 +1,34 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Deprecated.Snippets
+{
+    public sealed partial class GeneratedDeprecatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for DeprecatedFieldMethod</summary>
+        public void DeprecatedFieldMethodRequestObject()
+        {
+            // Snippet: DeprecatedFieldMethod(DeprecatedFieldRequest, CallSettings)
+            // Create client
+            DeprecatedClient deprecatedClient = DeprecatedClient.Create();
+            // Initialize request argument(s)
+            DeprecatedFieldRequest request = new DeprecatedFieldRequest { };
+            // Make the request
+            Response response = deprecatedClient.DeprecatedFieldMethod(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedFieldMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedFieldMethodSnippet.g.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Deprecated.Snippets
+{
+    public sealed partial class GeneratedDeprecatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for DeprecatedFieldMethod</summary>
+        public void DeprecatedFieldMethod()
+        {
+            // Snippet: DeprecatedFieldMethod(string, string, CallSettings)
+            // Create client
+            DeprecatedClient deprecatedClient = DeprecatedClient.Create();
+            // Initialize request argument(s)
+            string deprecatedField1 = "";
+            string deprecatedField2 = "";
+            // Make the request
+            Response response = deprecatedClient.DeprecatedFieldMethod(deprecatedField1, deprecatedField2);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedMessageMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedMessageMethodRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Deprecated.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedDeprecatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for DeprecatedMessageMethodAsync</summary>
+        public async Task DeprecatedMessageMethodRequestObjectAsync()
+        {
+            // Snippet: DeprecatedMessageMethodAsync(DeprecatedMessageRequest, CallSettings)
+            // Additional: DeprecatedMessageMethodAsync(DeprecatedMessageRequest, CancellationToken)
+            // Create client
+            DeprecatedClient deprecatedClient = await DeprecatedClient.CreateAsync();
+            // Initialize request argument(s)
+#pragma warning disable CS0612
+            DeprecatedMessageRequest request = new DeprecatedMessageRequest { };
+#pragma warning restore CS0612
+            // Make the request
+            Response response = await deprecatedClient.DeprecatedMessageMethodAsync(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedMessageMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedMessageMethodRequestObjectSnippet.g.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Deprecated.Snippets
+{
+    public sealed partial class GeneratedDeprecatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for DeprecatedMessageMethod</summary>
+        public void DeprecatedMessageMethodRequestObject()
+        {
+            // Snippet: DeprecatedMessageMethod(DeprecatedMessageRequest, CallSettings)
+            // Create client
+            DeprecatedClient deprecatedClient = DeprecatedClient.Create();
+            // Initialize request argument(s)
+#pragma warning disable CS0612
+            DeprecatedMessageRequest request = new DeprecatedMessageRequest { };
+#pragma warning restore CS0612
+            // Make the request
+            Response response = deprecatedClient.DeprecatedMessageMethod(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedMethodRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Deprecated.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedDeprecatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for DeprecatedMethodAsync</summary>
+        public async Task DeprecatedMethodRequestObjectAsync()
+        {
+            // Snippet: DeprecatedMethodAsync(Request, CallSettings)
+            // Additional: DeprecatedMethodAsync(Request, CancellationToken)
+            // Create client
+            DeprecatedClient deprecatedClient = await DeprecatedClient.CreateAsync();
+            // Initialize request argument(s)
+            Request request = new Request { };
+            // Make the request
+            Response response = await deprecatedClient.DeprecatedMethodAsync(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedMethodRequestObjectSnippet.g.cs
@@ -1,0 +1,34 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Deprecated.Snippets
+{
+    public sealed partial class GeneratedDeprecatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for DeprecatedMethod</summary>
+        public void DeprecatedMethodRequestObject()
+        {
+            // Snippet: DeprecatedMethod(Request, CallSettings)
+            // Create client
+            DeprecatedClient deprecatedClient = DeprecatedClient.Create();
+            // Initialize request argument(s)
+            Request request = new Request { };
+            // Make the request
+            Response response = deprecatedClient.DeprecatedMethod(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedResponseMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedResponseMethodRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Deprecated.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedDeprecatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for DeprecatedResponseMethodAsync</summary>
+        public async Task DeprecatedResponseMethodRequestObjectAsync()
+        {
+            // Snippet: DeprecatedResponseMethodAsync(Request, CallSettings)
+            // Additional: DeprecatedResponseMethodAsync(Request, CancellationToken)
+            // Create client
+            DeprecatedClient deprecatedClient = await DeprecatedClient.CreateAsync();
+            // Initialize request argument(s)
+            Request request = new Request { };
+            // Make the request
+#pragma warning disable CS0612
+            DeprecatedMessageResponse response = await deprecatedClient.DeprecatedResponseMethodAsync(request);
+#pragma warning restore CS0612
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedResponseMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedResponseMethodRequestObjectSnippet.g.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Deprecated.Snippets
+{
+    public sealed partial class GeneratedDeprecatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for DeprecatedResponseMethod</summary>
+        public void DeprecatedResponseMethodRequestObject()
+        {
+            // Snippet: DeprecatedResponseMethod(Request, CallSettings)
+            // Create client
+            DeprecatedClient deprecatedClient = DeprecatedClient.Create();
+            // Initialize request argument(s)
+            Request request = new Request { };
+            // Make the request
+#pragma warning disable CS0612
+            DeprecatedMessageResponse response = deprecatedClient.DeprecatedResponseMethod(request);
+#pragma warning restore CS0612
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1AsyncSnippet.g.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Keywords.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedKeywordsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for Method1Async</summary>
+        public async Task Method1Async()
+        {
+            // Snippet: Method1Async(string, int, Enum, string, string, CallSettings)
+            // Additional: Method1Async(string, int, Enum, string, string, CancellationToken)
+            // Create client
+            KeywordsClient keywordsClient = await KeywordsClient.CreateAsync();
+            // Initialize request argument(s)
+            string @event = "items/[ITEM_ID]";
+            int @switch = 0;
+            Enum @void = Enum.Void;
+            string request = "";
+            string types = "";
+            // Make the request
+            Response response = await keywordsClient.Method1Async(@event, @switch, @void, request, types);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1RequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1RequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Keywords.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedKeywordsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for Method1Async</summary>
+        public async Task Method1RequestObjectAsync()
+        {
+            // Snippet: Method1Async(Request, CallSettings)
+            // Additional: Method1Async(Request, CancellationToken)
+            // Create client
+            KeywordsClient keywordsClient = await KeywordsClient.CreateAsync();
+            // Initialize request argument(s)
+            Request request = new Request
+            {
+                EventAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
+                Switch = 0,
+                Void = Enum.Void,
+                Request_ = "",
+                Types_ = "",
+            };
+            // Make the request
+            Response response = await keywordsClient.Method1Async(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1RequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1RequestObjectSnippet.g.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Keywords.Snippets
+{
+    public sealed partial class GeneratedKeywordsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for Method1</summary>
+        public void Method1RequestObject()
+        {
+            // Snippet: Method1(Request, CallSettings)
+            // Create client
+            KeywordsClient keywordsClient = KeywordsClient.Create();
+            // Initialize request argument(s)
+            Request request = new Request
+            {
+                EventAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
+                Switch = 0,
+                Void = Enum.Void,
+                Request_ = "",
+                Types_ = "",
+            };
+            // Make the request
+            Response response = keywordsClient.Method1(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1ResourceNamesAsyncSnippet.g.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Keywords.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedKeywordsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for Method1Async</summary>
+        public async Task Method1ResourceNamesAsync()
+        {
+            // Snippet: Method1Async(ResourceName, int, Enum, string, string, CallSettings)
+            // Additional: Method1Async(ResourceName, int, Enum, string, string, CancellationToken)
+            // Create client
+            KeywordsClient keywordsClient = await KeywordsClient.CreateAsync();
+            // Initialize request argument(s)
+            ResourceName @event = ResourceName.FromItem("[ITEM_ID]");
+            int @switch = 0;
+            Enum @void = Enum.Void;
+            string request = "";
+            string types = "";
+            // Make the request
+            Response response = await keywordsClient.Method1Async(@event, @switch, @void, request, types);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1ResourceNamesSnippet.g.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Keywords.Snippets
+{
+    public sealed partial class GeneratedKeywordsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for Method1</summary>
+        public void Method1ResourceNames()
+        {
+            // Snippet: Method1(ResourceName, int, Enum, string, string, CallSettings)
+            // Create client
+            KeywordsClient keywordsClient = KeywordsClient.Create();
+            // Initialize request argument(s)
+            ResourceName @event = ResourceName.FromItem("[ITEM_ID]");
+            int @switch = 0;
+            Enum @void = Enum.Void;
+            string request = "";
+            string types = "";
+            // Make the request
+            Response response = keywordsClient.Method1(@event, @switch, @void, request, types);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1Snippet.g.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Keywords.Snippets
+{
+    public sealed partial class GeneratedKeywordsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for Method1</summary>
+        public void Method1()
+        {
+            // Snippet: Method1(string, int, Enum, string, string, CallSettings)
+            // Create client
+            KeywordsClient keywordsClient = KeywordsClient.Create();
+            // Initialize request argument(s)
+            string @event = "items/[ITEM_ID]";
+            int @switch = 0;
+            Enum @void = Enum.Void;
+            string request = "";
+            string types = "";
+            // Make the request
+            Response response = keywordsClient.Method1(@event, @switch, @void, request, types);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2AsyncSnippet.g.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Keywords.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedKeywordsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for Method2Async</summary>
+        public async Task Method2Async()
+        {
+            // Snippet: Method2Async(string, Enum, CallSettings)
+            // Additional: Method2Async(string, Enum, CancellationToken)
+            // Create client
+            KeywordsClient keywordsClient = await KeywordsClient.CreateAsync();
+            // Initialize request argument(s)
+            string @while = "items/[ITEM_ID]";
+            Enum @enum = Enum.Void;
+            // Make the request
+            Response response = await keywordsClient.Method2Async(@while, @enum);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2RequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2RequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Keywords.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedKeywordsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for Method2Async</summary>
+        public async Task Method2RequestObjectAsync()
+        {
+            // Snippet: Method2Async(Resource, CallSettings)
+            // Additional: Method2Async(Resource, CancellationToken)
+            // Create client
+            KeywordsClient keywordsClient = await KeywordsClient.CreateAsync();
+            // Initialize request argument(s)
+            Resource request = new Resource
+            {
+                WhileAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
+                Enum = Enum.Void,
+            };
+            // Make the request
+            Response response = await keywordsClient.Method2Async(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2RequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2RequestObjectSnippet.g.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Keywords.Snippets
+{
+    public sealed partial class GeneratedKeywordsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for Method2</summary>
+        public void Method2RequestObject()
+        {
+            // Snippet: Method2(Resource, CallSettings)
+            // Create client
+            KeywordsClient keywordsClient = KeywordsClient.Create();
+            // Initialize request argument(s)
+            Resource request = new Resource
+            {
+                WhileAsResourceName = ResourceName.FromItem("[ITEM_ID]"),
+                Enum = Enum.Void,
+            };
+            // Make the request
+            Response response = keywordsClient.Method2(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2ResourceNamesAsyncSnippet.g.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Keywords.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedKeywordsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for Method2Async</summary>
+        public async Task Method2ResourceNamesAsync()
+        {
+            // Snippet: Method2Async(ResourceName, Enum, CallSettings)
+            // Additional: Method2Async(ResourceName, Enum, CancellationToken)
+            // Create client
+            KeywordsClient keywordsClient = await KeywordsClient.CreateAsync();
+            // Initialize request argument(s)
+            ResourceName @while = ResourceName.FromItem("[ITEM_ID]");
+            Enum @enum = Enum.Void;
+            // Make the request
+            Response response = await keywordsClient.Method2Async(@while, @enum);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2ResourceNamesSnippet.g.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Keywords.Snippets
+{
+    public sealed partial class GeneratedKeywordsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for Method2</summary>
+        public void Method2ResourceNames()
+        {
+            // Snippet: Method2(ResourceName, Enum, CallSettings)
+            // Create client
+            KeywordsClient keywordsClient = KeywordsClient.Create();
+            // Initialize request argument(s)
+            ResourceName @while = ResourceName.FromItem("[ITEM_ID]");
+            Enum @enum = Enum.Void;
+            // Make the request
+            Response response = keywordsClient.Method2(@while, @enum);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2Snippet.g.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Keywords.Snippets
+{
+    public sealed partial class GeneratedKeywordsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for Method2</summary>
+        public void Method2()
+        {
+            // Snippet: Method2(string, Enum, CallSettings)
+            // Create client
+            KeywordsClient keywordsClient = KeywordsClient.Create();
+            // Initialize request argument(s)
+            string @while = "items/[ITEM_ID]";
+            Enum @enum = Enum.Void;
+            // Make the request
+            Response response = keywordsClient.Method2(@while, @enum);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro.StandaloneSnippets/LroClient.ResourcedMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro.StandaloneSnippets/LroClient.ResourcedMethodAsyncSnippet.g.cs
@@ -1,0 +1,1 @@
+﻿// TEST_DISABLE

--- a/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro.StandaloneSnippets/LroClient.ResourcedMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro.StandaloneSnippets/LroClient.ResourcedMethodRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,1 @@
+﻿// TEST_DISABLE

--- a/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro.StandaloneSnippets/LroClient.ResourcedMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro.StandaloneSnippets/LroClient.ResourcedMethodRequestObjectSnippet.g.cs
@@ -1,0 +1,1 @@
+﻿// TEST_DISABLE

--- a/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro.StandaloneSnippets/LroClient.ResourcedMethodResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro.StandaloneSnippets/LroClient.ResourcedMethodResourceNamesAsyncSnippet.g.cs
@@ -1,0 +1,1 @@
+﻿// TEST_DISABLE

--- a/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro.StandaloneSnippets/LroClient.ResourcedMethodResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro.StandaloneSnippets/LroClient.ResourcedMethodResourceNamesSnippet.g.cs
@@ -1,0 +1,1 @@
+﻿// TEST_DISABLE

--- a/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro.StandaloneSnippets/LroClient.ResourcedMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro.StandaloneSnippets/LroClient.ResourcedMethodSnippet.g.cs
@@ -1,0 +1,1 @@
+﻿// TEST_DISABLE

--- a/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro.StandaloneSnippets/LroClient.SignatureMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro.StandaloneSnippets/LroClient.SignatureMethodAsyncSnippet.g.cs
@@ -1,0 +1,1 @@
+﻿// TEST_DISABLE

--- a/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro.StandaloneSnippets/LroClient.SignatureMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro.StandaloneSnippets/LroClient.SignatureMethodRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,1 @@
+﻿// TEST_DISABLE

--- a/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro.StandaloneSnippets/LroClient.SignatureMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro.StandaloneSnippets/LroClient.SignatureMethodRequestObjectSnippet.g.cs
@@ -1,0 +1,1 @@
+﻿// TEST_DISABLE

--- a/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro.StandaloneSnippets/LroClient.SignatureMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro.StandaloneSnippets/LroClient.SignatureMethodSnippet.g.cs
@@ -1,0 +1,1 @@
+﻿// TEST_DISABLE

--- a/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro.StandaloneSnippets/Testing.Lro.StandaloneSnippets.csproj
+++ b/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro.StandaloneSnippets/Testing.Lro.StandaloneSnippets.csproj
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.2</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Testing.Lro/Testing.Lro.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1AsyncSnippet.g.cs
@@ -1,0 +1,71 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Paginated.Snippets
+{
+    using Google.Api.Gax;
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedPaginatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for ResourcedMethod</summary>
+        public async Task ResourcedMethod1Async()
+        {
+            // Snippet: ResourcedMethodAsync(string, string, int?, CallSettings)
+            // Create client
+            PaginatedClient paginatedClient = await PaginatedClient.CreateAsync();
+            // Initialize request argument(s)
+            string name = "items/[ITEM_ID]";
+            // Make the request
+            PagedAsyncEnumerable<ResourceResponse, string> response = paginatedClient.ResourcedMethodAsync(name);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((string item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((ResourceResponse page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (string item in page)
+                {
+                    // Do something with each item
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<string> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (string item in singlePage)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1ResourceNamesAsyncSnippet.g.cs
@@ -1,0 +1,71 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Paginated.Snippets
+{
+    using Google.Api.Gax;
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedPaginatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for ResourcedMethod</summary>
+        public async Task ResourcedMethod1ResourceNamesAsync()
+        {
+            // Snippet: ResourcedMethodAsync(ResourceName, string, int?, CallSettings)
+            // Create client
+            PaginatedClient paginatedClient = await PaginatedClient.CreateAsync();
+            // Initialize request argument(s)
+            ResourceName name = ResourceName.FromItem("[ITEM_ID]");
+            // Make the request
+            PagedAsyncEnumerable<ResourceResponse, string> response = paginatedClient.ResourcedMethodAsync(name);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((string item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((ResourceResponse page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (string item in page)
+                {
+                    // Do something with each item
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<string> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (string item in singlePage)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1ResourceNamesSnippet.g.cs
@@ -1,0 +1,69 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Paginated.Snippets
+{
+    using Google.Api.Gax;
+    using System;
+
+    public sealed partial class GeneratedPaginatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for ResourcedMethod</summary>
+        public void ResourcedMethod1ResourceNames()
+        {
+            // Snippet: ResourcedMethod(ResourceName, string, int?, CallSettings)
+            // Create client
+            PaginatedClient paginatedClient = PaginatedClient.Create();
+            // Initialize request argument(s)
+            ResourceName name = ResourceName.FromItem("[ITEM_ID]");
+            // Make the request
+            PagedEnumerable<ResourceResponse, string> response = paginatedClient.ResourcedMethod(name);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (string item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (ResourceResponse page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (string item in page)
+                {
+                    // Do something with each item
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<string> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (string item in singlePage)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1Snippet.g.cs
@@ -1,0 +1,69 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Paginated.Snippets
+{
+    using Google.Api.Gax;
+    using System;
+
+    public sealed partial class GeneratedPaginatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for ResourcedMethod</summary>
+        public void ResourcedMethod1()
+        {
+            // Snippet: ResourcedMethod(string, string, int?, CallSettings)
+            // Create client
+            PaginatedClient paginatedClient = PaginatedClient.Create();
+            // Initialize request argument(s)
+            string name = "items/[ITEM_ID]";
+            // Make the request
+            PagedEnumerable<ResourceResponse, string> response = paginatedClient.ResourcedMethod(name);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (string item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (ResourceResponse page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (string item in page)
+                {
+                    // Do something with each item
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<string> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (string item in singlePage)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2AsyncSnippet.g.cs
@@ -1,0 +1,72 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Paginated.Snippets
+{
+    using Google.Api.Gax;
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedPaginatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for ResourcedMethod</summary>
+        public async Task ResourcedMethod2Async()
+        {
+            // Snippet: ResourcedMethodAsync(string, string, string, int?, CallSettings)
+            // Create client
+            PaginatedClient paginatedClient = await PaginatedClient.CreateAsync();
+            // Initialize request argument(s)
+            string name = "items/[ITEM_ID]";
+            string extraString = "";
+            // Make the request
+            PagedAsyncEnumerable<ResourceResponse, string> response = paginatedClient.ResourcedMethodAsync(name, extraString: extraString);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((string item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((ResourceResponse page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (string item in page)
+                {
+                    // Do something with each item
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<string> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (string item in singlePage)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2ResourceNamesAsyncSnippet.g.cs
@@ -1,0 +1,72 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Paginated.Snippets
+{
+    using Google.Api.Gax;
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedPaginatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for ResourcedMethod</summary>
+        public async Task ResourcedMethod2ResourceNamesAsync()
+        {
+            // Snippet: ResourcedMethodAsync(ResourceName, string, string, int?, CallSettings)
+            // Create client
+            PaginatedClient paginatedClient = await PaginatedClient.CreateAsync();
+            // Initialize request argument(s)
+            ResourceName name = ResourceName.FromItem("[ITEM_ID]");
+            string extraString = "";
+            // Make the request
+            PagedAsyncEnumerable<ResourceResponse, string> response = paginatedClient.ResourcedMethodAsync(name, extraString: extraString);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((string item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((ResourceResponse page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (string item in page)
+                {
+                    // Do something with each item
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<string> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (string item in singlePage)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2ResourceNamesSnippet.g.cs
@@ -1,0 +1,70 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Paginated.Snippets
+{
+    using Google.Api.Gax;
+    using System;
+
+    public sealed partial class GeneratedPaginatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for ResourcedMethod</summary>
+        public void ResourcedMethod2ResourceNames()
+        {
+            // Snippet: ResourcedMethod(ResourceName, string, string, int?, CallSettings)
+            // Create client
+            PaginatedClient paginatedClient = PaginatedClient.Create();
+            // Initialize request argument(s)
+            ResourceName name = ResourceName.FromItem("[ITEM_ID]");
+            string extraString = "";
+            // Make the request
+            PagedEnumerable<ResourceResponse, string> response = paginatedClient.ResourcedMethod(name, extraString: extraString);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (string item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (ResourceResponse page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (string item in page)
+                {
+                    // Do something with each item
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<string> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (string item in singlePage)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2Snippet.g.cs
@@ -1,0 +1,70 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Paginated.Snippets
+{
+    using Google.Api.Gax;
+    using System;
+
+    public sealed partial class GeneratedPaginatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for ResourcedMethod</summary>
+        public void ResourcedMethod2()
+        {
+            // Snippet: ResourcedMethod(string, string, string, int?, CallSettings)
+            // Create client
+            PaginatedClient paginatedClient = PaginatedClient.Create();
+            // Initialize request argument(s)
+            string name = "items/[ITEM_ID]";
+            string extraString = "";
+            // Make the request
+            PagedEnumerable<ResourceResponse, string> response = paginatedClient.ResourcedMethod(name, extraString: extraString);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (string item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (ResourceResponse page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (string item in page)
+                {
+                    // Do something with each item
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<string> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (string item in singlePage)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethodRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,75 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Paginated.Snippets
+{
+    using Google.Api.Gax;
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedPaginatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for ResourcedMethod</summary>
+        public async Task ResourcedMethodRequestObjectAsync()
+        {
+            // Snippet: ResourcedMethodAsync(ResourceRequest, CallSettings)
+            // Create client
+            PaginatedClient paginatedClient = await PaginatedClient.CreateAsync();
+            // Initialize request argument(s)
+            ResourceRequest request = new ResourceRequest
+            {
+                ResourceName = ResourceName.FromItem("[ITEM_ID]"),
+                ExtraString = "",
+            };
+            // Make the request
+            PagedAsyncEnumerable<ResourceResponse, string> response = paginatedClient.ResourcedMethodAsync(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((string item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((ResourceResponse page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (string item in page)
+                {
+                    // Do something with each item
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<string> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (string item in singlePage)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethodRequestObjectSnippet.g.cs
@@ -1,0 +1,73 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Paginated.Snippets
+{
+    using Google.Api.Gax;
+    using System;
+
+    public sealed partial class GeneratedPaginatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for ResourcedMethod</summary>
+        public void ResourcedMethodRequestObject()
+        {
+            // Snippet: ResourcedMethod(ResourceRequest, CallSettings)
+            // Create client
+            PaginatedClient paginatedClient = PaginatedClient.Create();
+            // Initialize request argument(s)
+            ResourceRequest request = new ResourceRequest
+            {
+                ResourceName = ResourceName.FromItem("[ITEM_ID]"),
+                ExtraString = "",
+            };
+            // Make the request
+            PagedEnumerable<ResourceResponse, string> response = paginatedClient.ResourcedMethod(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (string item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (ResourceResponse page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (string item in page)
+                {
+                    // Do something with each item
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<string> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (string item in singlePage)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod1AsyncSnippet.g.cs
@@ -1,0 +1,72 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Paginated.Snippets
+{
+    using Google.Api.Gax;
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedPaginatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for SignatureMethod</summary>
+        public async Task SignatureMethod1Async()
+        {
+            // Snippet: SignatureMethodAsync(string, int, string, int?, CallSettings)
+            // Create client
+            PaginatedClient paginatedClient = await PaginatedClient.CreateAsync();
+            // Initialize request argument(s)
+            string aString = "";
+            int aNumber = 0;
+            // Make the request
+            PagedAsyncEnumerable<Response, Response.Types.NestedResult> response = paginatedClient.SignatureMethodAsync(aString, aNumber);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((Response.Types.NestedResult item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((Response page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (Response.Types.NestedResult item in page)
+                {
+                    // Do something with each item
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<Response.Types.NestedResult> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (Response.Types.NestedResult item in singlePage)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod1Snippet.g.cs
@@ -1,0 +1,70 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Paginated.Snippets
+{
+    using Google.Api.Gax;
+    using System;
+
+    public sealed partial class GeneratedPaginatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for SignatureMethod</summary>
+        public void SignatureMethod1()
+        {
+            // Snippet: SignatureMethod(string, int, string, int?, CallSettings)
+            // Create client
+            PaginatedClient paginatedClient = PaginatedClient.Create();
+            // Initialize request argument(s)
+            string aString = "";
+            int aNumber = 0;
+            // Make the request
+            PagedEnumerable<Response, Response.Types.NestedResult> response = paginatedClient.SignatureMethod(aString, aNumber);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (Response.Types.NestedResult item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (Response page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (Response.Types.NestedResult item in page)
+                {
+                    // Do something with each item
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<Response.Types.NestedResult> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (Response.Types.NestedResult item in singlePage)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2AsyncSnippet.g.cs
@@ -1,0 +1,71 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Paginated.Snippets
+{
+    using Google.Api.Gax;
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedPaginatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for SignatureMethod</summary>
+        public async Task SignatureMethod2Async()
+        {
+            // Snippet: SignatureMethodAsync(string, string, int?, CallSettings)
+            // Create client
+            PaginatedClient paginatedClient = await PaginatedClient.CreateAsync();
+            // Initialize request argument(s)
+            string aString = "";
+            // Make the request
+            PagedAsyncEnumerable<Response, Response.Types.NestedResult> response = paginatedClient.SignatureMethodAsync(aString: aString);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((Response.Types.NestedResult item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((Response page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (Response.Types.NestedResult item in page)
+                {
+                    // Do something with each item
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<Response.Types.NestedResult> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (Response.Types.NestedResult item in singlePage)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2RequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2RequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,75 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Paginated.Snippets
+{
+    using Google.Api.Gax;
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedPaginatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for SignatureMethod2</summary>
+        public async Task SignatureMethod2RequestObjectAsync()
+        {
+            // Snippet: SignatureMethod2Async(Request, CallSettings)
+            // Create client
+            PaginatedClient paginatedClient = await PaginatedClient.CreateAsync();
+            // Initialize request argument(s)
+            Request request = new Request
+            {
+                AString = "",
+                ANumber = 0,
+            };
+            // Make the request
+            PagedAsyncEnumerable<Response, Response.Types.NestedResult> response = paginatedClient.SignatureMethod2Async(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((Response.Types.NestedResult item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((Response page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (Response.Types.NestedResult item in page)
+                {
+                    // Do something with each item
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<Response.Types.NestedResult> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (Response.Types.NestedResult item in singlePage)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2RequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2RequestObjectSnippet.g.cs
@@ -1,0 +1,73 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Paginated.Snippets
+{
+    using Google.Api.Gax;
+    using System;
+
+    public sealed partial class GeneratedPaginatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for SignatureMethod2</summary>
+        public void SignatureMethod2RequestObject()
+        {
+            // Snippet: SignatureMethod2(Request, CallSettings)
+            // Create client
+            PaginatedClient paginatedClient = PaginatedClient.Create();
+            // Initialize request argument(s)
+            Request request = new Request
+            {
+                AString = "",
+                ANumber = 0,
+            };
+            // Make the request
+            PagedEnumerable<Response, Response.Types.NestedResult> response = paginatedClient.SignatureMethod2(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (Response.Types.NestedResult item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (Response page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (Response.Types.NestedResult item in page)
+                {
+                    // Do something with each item
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<Response.Types.NestedResult> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (Response.Types.NestedResult item in singlePage)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2Snippet.g.cs
@@ -1,0 +1,69 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Paginated.Snippets
+{
+    using Google.Api.Gax;
+    using System;
+
+    public sealed partial class GeneratedPaginatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for SignatureMethod</summary>
+        public void SignatureMethod2()
+        {
+            // Snippet: SignatureMethod(string, string, int?, CallSettings)
+            // Create client
+            PaginatedClient paginatedClient = PaginatedClient.Create();
+            // Initialize request argument(s)
+            string aString = "";
+            // Make the request
+            PagedEnumerable<Response, Response.Types.NestedResult> response = paginatedClient.SignatureMethod(aString: aString);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (Response.Types.NestedResult item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (Response page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (Response.Types.NestedResult item in page)
+                {
+                    // Do something with each item
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<Response.Types.NestedResult> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (Response.Types.NestedResult item in singlePage)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod3AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod3AsyncSnippet.g.cs
@@ -1,0 +1,69 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Paginated.Snippets
+{
+    using Google.Api.Gax;
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedPaginatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for SignatureMethod</summary>
+        public async Task SignatureMethod3Async()
+        {
+            // Snippet: SignatureMethodAsync(string, int?, CallSettings)
+            // Create client
+            PaginatedClient paginatedClient = await PaginatedClient.CreateAsync();
+            // Make the request
+            PagedAsyncEnumerable<Response, Response.Types.NestedResult> response = paginatedClient.SignatureMethodAsync();
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((Response.Types.NestedResult item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((Response page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (Response.Types.NestedResult item in page)
+                {
+                    // Do something with each item
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<Response.Types.NestedResult> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (Response.Types.NestedResult item in singlePage)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod3Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod3Snippet.g.cs
@@ -1,0 +1,67 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Paginated.Snippets
+{
+    using Google.Api.Gax;
+    using System;
+
+    public sealed partial class GeneratedPaginatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for SignatureMethod</summary>
+        public void SignatureMethod3()
+        {
+            // Snippet: SignatureMethod(string, int?, CallSettings)
+            // Create client
+            PaginatedClient paginatedClient = PaginatedClient.Create();
+            // Make the request
+            PagedEnumerable<Response, Response.Types.NestedResult> response = paginatedClient.SignatureMethod();
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (Response.Types.NestedResult item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (Response page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (Response.Types.NestedResult item in page)
+                {
+                    // Do something with each item
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<Response.Types.NestedResult> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (Response.Types.NestedResult item in singlePage)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethodRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,75 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Paginated.Snippets
+{
+    using Google.Api.Gax;
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedPaginatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for SignatureMethod</summary>
+        public async Task SignatureMethodRequestObjectAsync()
+        {
+            // Snippet: SignatureMethodAsync(Request, CallSettings)
+            // Create client
+            PaginatedClient paginatedClient = await PaginatedClient.CreateAsync();
+            // Initialize request argument(s)
+            Request request = new Request
+            {
+                AString = "",
+                ANumber = 0,
+            };
+            // Make the request
+            PagedAsyncEnumerable<Response, Response.Types.NestedResult> response = paginatedClient.SignatureMethodAsync(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            await response.ForEachAsync((Response.Types.NestedResult item) =>
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            });
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            await response.AsRawResponses().ForEachAsync((Response page) =>
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (Response.Types.NestedResult item in page)
+                {
+                    // Do something with each item
+                    Console.WriteLine(item);
+                }
+            });
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<Response.Types.NestedResult> singlePage = await response.ReadPageAsync(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (Response.Types.NestedResult item in singlePage)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethodRequestObjectSnippet.g.cs
@@ -1,0 +1,73 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Paginated.Snippets
+{
+    using Google.Api.Gax;
+    using System;
+
+    public sealed partial class GeneratedPaginatedClientStandaloneSnippets
+    {
+        /// <summary>Snippet for SignatureMethod</summary>
+        public void SignatureMethodRequestObject()
+        {
+            // Snippet: SignatureMethod(Request, CallSettings)
+            // Create client
+            PaginatedClient paginatedClient = PaginatedClient.Create();
+            // Initialize request argument(s)
+            Request request = new Request
+            {
+                AString = "",
+                ANumber = 0,
+            };
+            // Make the request
+            PagedEnumerable<Response, Response.Types.NestedResult> response = paginatedClient.SignatureMethod(request);
+
+            // Iterate over all response items, lazily performing RPCs as required
+            foreach (Response.Types.NestedResult item in response)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+
+            // Or iterate over pages (of server-defined size), performing one RPC per page
+            foreach (Response page in response.AsRawResponses())
+            {
+                // Do something with each page of items
+                Console.WriteLine("A page of results:");
+                foreach (Response.Types.NestedResult item in page)
+                {
+                    // Do something with each item
+                    Console.WriteLine(item);
+                }
+            }
+
+            // Or retrieve a single page of known size (unless it's the final page), performing as many RPCs as required
+            int pageSize = 10;
+            Page<Response.Types.NestedResult> singlePage = response.ReadPage(pageSize);
+            // Do something with the page of items
+            Console.WriteLine($"A page of {pageSize} results (unless it's the final page):");
+            foreach (Response.Types.NestedResult item in singlePage)
+            {
+                // Do something with each item
+                Console.WriteLine(item);
+            }
+            // Store the pageToken, for when the next page is required.
+            string nextPageToken = singlePage.NextPageToken;
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1AsyncSnippet.g.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNameSeparator.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedResourceNameSeparatorClientStandaloneSnippets
+    {
+        /// <summary>Snippet for Method1Async</summary>
+        public async Task Method1Async()
+        {
+            // Snippet: Method1Async(string, string, CallSettings)
+            // Additional: Method1Async(string, string, CancellationToken)
+            // Create client
+            ResourceNameSeparatorClient resourceNameSeparatorClient = await ResourceNameSeparatorClient.CreateAsync();
+            // Initialize request argument(s)
+            string name = "items/[ITEM_A_ID].[ITEM_B_ID]/details/[DETAILS_A_ID]_[DETAILS_B_ID]-[DETAILS_C_ID]/extra/[EXTRA_ID]";
+            string @ref = "items/[ITEM_A_ID].[ITEM_B_ID]/details/[DETAILS_A_ID]_[DETAILS_B_ID]-[DETAILS_C_ID]/extra/[EXTRA_ID]";
+            // Make the request
+            Response response = await resourceNameSeparatorClient.Method1Async(name, @ref);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1RequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1RequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNameSeparator.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedResourceNameSeparatorClientStandaloneSnippets
+    {
+        /// <summary>Snippet for Method1Async</summary>
+        public async Task Method1RequestObjectAsync()
+        {
+            // Snippet: Method1Async(Request, CallSettings)
+            // Additional: Method1Async(Request, CancellationToken)
+            // Create client
+            ResourceNameSeparatorClient resourceNameSeparatorClient = await ResourceNameSeparatorClient.CreateAsync();
+            // Initialize request argument(s)
+            Request request = new Request
+            {
+                RequestName = RequestName.FromItemAItemBDetailsADetailsBDetailsCExtra("[ITEM_A_ID]", "[ITEM_B_ID]", "[DETAILS_A_ID]", "[DETAILS_B_ID]", "[DETAILS_C_ID]", "[EXTRA_ID]"),
+                RefAsRequestName = RequestName.FromItemAItemBDetailsADetailsBDetailsCExtra("[ITEM_A_ID]", "[ITEM_B_ID]", "[DETAILS_A_ID]", "[DETAILS_B_ID]", "[DETAILS_C_ID]", "[EXTRA_ID]"),
+            };
+            // Make the request
+            Response response = await resourceNameSeparatorClient.Method1Async(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1RequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1RequestObjectSnippet.g.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNameSeparator.Snippets
+{
+    public sealed partial class GeneratedResourceNameSeparatorClientStandaloneSnippets
+    {
+        /// <summary>Snippet for Method1</summary>
+        public void Method1RequestObject()
+        {
+            // Snippet: Method1(Request, CallSettings)
+            // Create client
+            ResourceNameSeparatorClient resourceNameSeparatorClient = ResourceNameSeparatorClient.Create();
+            // Initialize request argument(s)
+            Request request = new Request
+            {
+                RequestName = RequestName.FromItemAItemBDetailsADetailsBDetailsCExtra("[ITEM_A_ID]", "[ITEM_B_ID]", "[DETAILS_A_ID]", "[DETAILS_B_ID]", "[DETAILS_C_ID]", "[EXTRA_ID]"),
+                RefAsRequestName = RequestName.FromItemAItemBDetailsADetailsBDetailsCExtra("[ITEM_A_ID]", "[ITEM_B_ID]", "[DETAILS_A_ID]", "[DETAILS_B_ID]", "[DETAILS_C_ID]", "[EXTRA_ID]"),
+            };
+            // Make the request
+            Response response = resourceNameSeparatorClient.Method1(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1ResourceNamesAsyncSnippet.g.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNameSeparator.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedResourceNameSeparatorClientStandaloneSnippets
+    {
+        /// <summary>Snippet for Method1Async</summary>
+        public async Task Method1ResourceNamesAsync()
+        {
+            // Snippet: Method1Async(RequestName, RequestName, CallSettings)
+            // Additional: Method1Async(RequestName, RequestName, CancellationToken)
+            // Create client
+            ResourceNameSeparatorClient resourceNameSeparatorClient = await ResourceNameSeparatorClient.CreateAsync();
+            // Initialize request argument(s)
+            RequestName name = RequestName.FromItemAItemBDetailsADetailsBDetailsCExtra("[ITEM_A_ID]", "[ITEM_B_ID]", "[DETAILS_A_ID]", "[DETAILS_B_ID]", "[DETAILS_C_ID]", "[EXTRA_ID]");
+            RequestName @ref = RequestName.FromItemAItemBDetailsADetailsBDetailsCExtra("[ITEM_A_ID]", "[ITEM_B_ID]", "[DETAILS_A_ID]", "[DETAILS_B_ID]", "[DETAILS_C_ID]", "[EXTRA_ID]");
+            // Make the request
+            Response response = await resourceNameSeparatorClient.Method1Async(name, @ref);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1ResourceNamesSnippet.g.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNameSeparator.Snippets
+{
+    public sealed partial class GeneratedResourceNameSeparatorClientStandaloneSnippets
+    {
+        /// <summary>Snippet for Method1</summary>
+        public void Method1ResourceNames()
+        {
+            // Snippet: Method1(RequestName, RequestName, CallSettings)
+            // Create client
+            ResourceNameSeparatorClient resourceNameSeparatorClient = ResourceNameSeparatorClient.Create();
+            // Initialize request argument(s)
+            RequestName name = RequestName.FromItemAItemBDetailsADetailsBDetailsCExtra("[ITEM_A_ID]", "[ITEM_B_ID]", "[DETAILS_A_ID]", "[DETAILS_B_ID]", "[DETAILS_C_ID]", "[EXTRA_ID]");
+            RequestName @ref = RequestName.FromItemAItemBDetailsADetailsBDetailsCExtra("[ITEM_A_ID]", "[ITEM_B_ID]", "[DETAILS_A_ID]", "[DETAILS_B_ID]", "[DETAILS_C_ID]", "[EXTRA_ID]");
+            // Make the request
+            Response response = resourceNameSeparatorClient.Method1(name, @ref);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1Snippet.g.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNameSeparator.Snippets
+{
+    public sealed partial class GeneratedResourceNameSeparatorClientStandaloneSnippets
+    {
+        /// <summary>Snippet for Method1</summary>
+        public void Method1()
+        {
+            // Snippet: Method1(string, string, CallSettings)
+            // Create client
+            ResourceNameSeparatorClient resourceNameSeparatorClient = ResourceNameSeparatorClient.Create();
+            // Initialize request argument(s)
+            string name = "items/[ITEM_A_ID].[ITEM_B_ID]/details/[DETAILS_A_ID]_[DETAILS_B_ID]-[DETAILS_C_ID]/extra/[EXTRA_ID]";
+            string @ref = "items/[ITEM_A_ID].[ITEM_B_ID]/details/[DETAILS_A_ID]_[DETAILS_B_ID]-[DETAILS_C_ID]/extra/[EXTRA_ID]";
+            // Make the request
+            Response response = resourceNameSeparatorClient.Method1(name, @ref);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodAsyncSnippet.g.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for SinglePatternMethodAsync</summary>
+        public async Task SinglePatternMethodAsync()
+        {
+            // Snippet: SinglePatternMethodAsync(string, string, IEnumerable<string>, string, IEnumerable<string>, CallSettings)
+            // Additional: SinglePatternMethodAsync(string, string, IEnumerable<string>, string, IEnumerable<string>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            string realName = "items/[ITEM_ID]";
+            string @ref = "items/[ITEM_ID]";
+            IEnumerable<string> repeatedRef = new string[] { "items/[ITEM_ID]", };
+            string valueRef = "items/[ITEM_ID]";
+            IEnumerable<string> repeatedValueRef = new string[] { "items/[ITEM_ID]", };
+            // Make the request
+            Response response = await resourceNamesClient.SinglePatternMethodAsync(realName, @ref, repeatedRef, valueRef, repeatedValueRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,50 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for SinglePatternMethodAsync</summary>
+        public async Task SinglePatternMethodRequestObjectAsync()
+        {
+            // Snippet: SinglePatternMethodAsync(SinglePattern, CallSettings)
+            // Additional: SinglePatternMethodAsync(SinglePattern, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            SinglePattern request = new SinglePattern
+            {
+                RealNameAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RefAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsSinglePatternNames =
+                {
+                    SinglePatternName.FromItem("[ITEM_ID]"),
+                },
+                ValueRefAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RepeatedValueRefAsSinglePatternNames =
+                {
+                    SinglePatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            // Make the request
+            Response response = await resourceNamesClient.SinglePatternMethodAsync(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodRequestObjectSnippet.g.cs
@@ -1,0 +1,47 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for SinglePatternMethod</summary>
+        public void SinglePatternMethodRequestObject()
+        {
+            // Snippet: SinglePatternMethod(SinglePattern, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            SinglePattern request = new SinglePattern
+            {
+                RealNameAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RefAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RepeatedRefAsSinglePatternNames =
+                {
+                    SinglePatternName.FromItem("[ITEM_ID]"),
+                },
+                ValueRefAsSinglePatternName = SinglePatternName.FromItem("[ITEM_ID]"),
+                RepeatedValueRefAsSinglePatternNames =
+                {
+                    SinglePatternName.FromItem("[ITEM_ID]"),
+                },
+            };
+            // Make the request
+            Response response = resourceNamesClient.SinglePatternMethod(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodResourceNamesAsyncSnippet.g.cs
@@ -1,0 +1,48 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for SinglePatternMethodAsync</summary>
+        public async Task SinglePatternMethodResourceNamesAsync()
+        {
+            // Snippet: SinglePatternMethodAsync(SinglePatternName, SinglePatternName, IEnumerable<SinglePatternName>, SinglePatternName, IEnumerable<SinglePatternName>, CallSettings)
+            // Additional: SinglePatternMethodAsync(SinglePatternName, SinglePatternName, IEnumerable<SinglePatternName>, SinglePatternName, IEnumerable<SinglePatternName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            SinglePatternName realName = SinglePatternName.FromItem("[ITEM_ID]");
+            SinglePatternName @ref = SinglePatternName.FromItem("[ITEM_ID]");
+            IEnumerable<SinglePatternName> repeatedRef = new SinglePatternName[]
+            {
+                SinglePatternName.FromItem("[ITEM_ID]"),
+            };
+            SinglePatternName valueRef = SinglePatternName.FromItem("[ITEM_ID]");
+            IEnumerable<SinglePatternName> repeatedValueRef = new SinglePatternName[]
+            {
+                SinglePatternName.FromItem("[ITEM_ID]"),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.SinglePatternMethodAsync(realName, @ref, repeatedRef, valueRef, repeatedValueRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodResourceNamesSnippet.g.cs
@@ -1,0 +1,46 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using System.Collections.Generic;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for SinglePatternMethod</summary>
+        public void SinglePatternMethodResourceNames()
+        {
+            // Snippet: SinglePatternMethod(SinglePatternName, SinglePatternName, IEnumerable<SinglePatternName>, SinglePatternName, IEnumerable<SinglePatternName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            SinglePatternName realName = SinglePatternName.FromItem("[ITEM_ID]");
+            SinglePatternName @ref = SinglePatternName.FromItem("[ITEM_ID]");
+            IEnumerable<SinglePatternName> repeatedRef = new SinglePatternName[]
+            {
+                SinglePatternName.FromItem("[ITEM_ID]"),
+            };
+            SinglePatternName valueRef = SinglePatternName.FromItem("[ITEM_ID]");
+            IEnumerable<SinglePatternName> repeatedValueRef = new SinglePatternName[]
+            {
+                SinglePatternName.FromItem("[ITEM_ID]"),
+            };
+            // Make the request
+            Response response = resourceNamesClient.SinglePatternMethod(realName, @ref, repeatedRef, valueRef, repeatedValueRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodSnippet.g.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using System.Collections.Generic;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for SinglePatternMethod</summary>
+        public void SinglePatternMethod()
+        {
+            // Snippet: SinglePatternMethod(string, string, IEnumerable<string>, string, IEnumerable<string>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            string realName = "items/[ITEM_ID]";
+            string @ref = "items/[ITEM_ID]";
+            IEnumerable<string> repeatedRef = new string[] { "items/[ITEM_ID]", };
+            string valueRef = "items/[ITEM_ID]";
+            IEnumerable<string> repeatedValueRef = new string[] { "items/[ITEM_ID]", };
+            // Make the request
+            Response response = resourceNamesClient.SinglePatternMethod(realName, @ref, repeatedRef, valueRef, repeatedValueRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodAsyncSnippet.g.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        public async Task WildcardMultiPatternMethodAsync()
+        {
+            // Snippet: WildcardMultiPatternMethodAsync(string, string, IEnumerable<string>, CallSettings)
+            // Additional: WildcardMultiPatternMethodAsync(string, string, IEnumerable<string>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            string name = "singular_item";
+            string @ref = "singular_item";
+            IEnumerable<string> repeatedRef = new string[] { "singular_item", };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,45 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        public async Task WildcardMultiPatternMethodRequestObjectAsync()
+        {
+            // Snippet: WildcardMultiPatternMethodAsync(WildcardMultiPattern, CallSettings)
+            // Additional: WildcardMultiPatternMethodAsync(WildcardMultiPattern, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            WildcardMultiPattern request = new WildcardMultiPattern
+            {
+                WildcardMultiPatternName = WildcardMultiPatternName.FromSingularItem(),
+                RefAsWildcardMultiPatternName = WildcardMultiPatternName.FromSingularItem(),
+                RepeatedRefAsWildcardMultiPatternNames =
+                {
+                    WildcardMultiPatternName.FromSingularItem(),
+                },
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodRequestObjectSnippet.g.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        public void WildcardMultiPatternMethodRequestObject()
+        {
+            // Snippet: WildcardMultiPatternMethod(WildcardMultiPattern, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            WildcardMultiPattern request = new WildcardMultiPattern
+            {
+                WildcardMultiPatternName = WildcardMultiPatternName.FromSingularItem(),
+                RefAsWildcardMultiPatternName = WildcardMultiPatternName.FromSingularItem(),
+                RepeatedRefAsWildcardMultiPatternNames =
+                {
+                    WildcardMultiPatternName.FromSingularItem(),
+                },
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMethod(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames1AsyncSnippet.g.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        public async Task WildcardMultiPatternMethodResourceNames1Async()
+        {
+            // Snippet: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, WildcardMultiPatternName, IEnumerable<WildcardMultiPatternName>, CallSettings)
+            // Additional: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, WildcardMultiPatternName, IEnumerable<WildcardMultiPatternName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            WildcardMultiPatternName name = WildcardMultiPatternName.FromSingularItem();
+            WildcardMultiPatternName @ref = WildcardMultiPatternName.FromSingularItem();
+            IEnumerable<WildcardMultiPatternName> repeatedRef = new WildcardMultiPatternName[]
+            {
+                WildcardMultiPatternName.FromSingularItem(),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames1Snippet.g.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using System.Collections.Generic;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        public void WildcardMultiPatternMethodResourceNames1()
+        {
+            // Snippet: WildcardMultiPatternMethod(WildcardMultiPatternName, WildcardMultiPatternName, IEnumerable<WildcardMultiPatternName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            WildcardMultiPatternName name = WildcardMultiPatternName.FromSingularItem();
+            WildcardMultiPatternName @ref = WildcardMultiPatternName.FromSingularItem();
+            IEnumerable<WildcardMultiPatternName> repeatedRef = new WildcardMultiPatternName[]
+            {
+                WildcardMultiPatternName.FromSingularItem(),
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames2AsyncSnippet.g.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using Google.Api.Gax;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        public async Task WildcardMultiPatternMethodResourceNames2Async()
+        {
+            // Snippet: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, WildcardMultiPatternName, IEnumerable<IResourceName>, CallSettings)
+            // Additional: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, WildcardMultiPatternName, IEnumerable<IResourceName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            WildcardMultiPatternName name = WildcardMultiPatternName.FromSingularItem();
+            WildcardMultiPatternName @ref = WildcardMultiPatternName.FromSingularItem();
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames2Snippet.g.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using Google.Api.Gax;
+    using System.Collections.Generic;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        public void WildcardMultiPatternMethodResourceNames2()
+        {
+            // Snippet: WildcardMultiPatternMethod(WildcardMultiPatternName, WildcardMultiPatternName, IEnumerable<IResourceName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            WildcardMultiPatternName name = WildcardMultiPatternName.FromSingularItem();
+            WildcardMultiPatternName @ref = WildcardMultiPatternName.FromSingularItem();
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames3AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames3AsyncSnippet.g.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using Google.Api.Gax;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        public async Task WildcardMultiPatternMethodResourceNames3Async()
+        {
+            // Snippet: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, IResourceName, IEnumerable<WildcardMultiPatternName>, CallSettings)
+            // Additional: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, IResourceName, IEnumerable<WildcardMultiPatternName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            WildcardMultiPatternName name = WildcardMultiPatternName.FromSingularItem();
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<WildcardMultiPatternName> repeatedRef = new WildcardMultiPatternName[]
+            {
+                WildcardMultiPatternName.FromSingularItem(),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames3Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames3Snippet.g.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using Google.Api.Gax;
+    using System.Collections.Generic;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        public void WildcardMultiPatternMethodResourceNames3()
+        {
+            // Snippet: WildcardMultiPatternMethod(WildcardMultiPatternName, IResourceName, IEnumerable<WildcardMultiPatternName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            WildcardMultiPatternName name = WildcardMultiPatternName.FromSingularItem();
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<WildcardMultiPatternName> repeatedRef = new WildcardMultiPatternName[]
+            {
+                WildcardMultiPatternName.FromSingularItem(),
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames4AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames4AsyncSnippet.g.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using Google.Api.Gax;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        public async Task WildcardMultiPatternMethodResourceNames4Async()
+        {
+            // Snippet: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, IResourceName, IEnumerable<IResourceName>, CallSettings)
+            // Additional: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, IResourceName, IEnumerable<IResourceName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            WildcardMultiPatternName name = WildcardMultiPatternName.FromSingularItem();
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames4Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames4Snippet.g.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using Google.Api.Gax;
+    using System.Collections.Generic;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        public void WildcardMultiPatternMethodResourceNames4()
+        {
+            // Snippet: WildcardMultiPatternMethod(WildcardMultiPatternName, IResourceName, IEnumerable<IResourceName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            WildcardMultiPatternName name = WildcardMultiPatternName.FromSingularItem();
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames5AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames5AsyncSnippet.g.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using Google.Api.Gax;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        public async Task WildcardMultiPatternMethodResourceNames5Async()
+        {
+            // Snippet: WildcardMultiPatternMethodAsync(IResourceName, WildcardMultiPatternName, IEnumerable<WildcardMultiPatternName>, CallSettings)
+            // Additional: WildcardMultiPatternMethodAsync(IResourceName, WildcardMultiPatternName, IEnumerable<WildcardMultiPatternName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            IResourceName name = new UnparsedResourceName("a/wildcard/resource");
+            WildcardMultiPatternName @ref = WildcardMultiPatternName.FromSingularItem();
+            IEnumerable<WildcardMultiPatternName> repeatedRef = new WildcardMultiPatternName[]
+            {
+                WildcardMultiPatternName.FromSingularItem(),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames5Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames5Snippet.g.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using Google.Api.Gax;
+    using System.Collections.Generic;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        public void WildcardMultiPatternMethodResourceNames5()
+        {
+            // Snippet: WildcardMultiPatternMethod(IResourceName, WildcardMultiPatternName, IEnumerable<WildcardMultiPatternName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            IResourceName name = new UnparsedResourceName("a/wildcard/resource");
+            WildcardMultiPatternName @ref = WildcardMultiPatternName.FromSingularItem();
+            IEnumerable<WildcardMultiPatternName> repeatedRef = new WildcardMultiPatternName[]
+            {
+                WildcardMultiPatternName.FromSingularItem(),
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames6AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames6AsyncSnippet.g.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using Google.Api.Gax;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        public async Task WildcardMultiPatternMethodResourceNames6Async()
+        {
+            // Snippet: WildcardMultiPatternMethodAsync(IResourceName, WildcardMultiPatternName, IEnumerable<IResourceName>, CallSettings)
+            // Additional: WildcardMultiPatternMethodAsync(IResourceName, WildcardMultiPatternName, IEnumerable<IResourceName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            IResourceName name = new UnparsedResourceName("a/wildcard/resource");
+            WildcardMultiPatternName @ref = WildcardMultiPatternName.FromSingularItem();
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames6Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames6Snippet.g.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using Google.Api.Gax;
+    using System.Collections.Generic;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        public void WildcardMultiPatternMethodResourceNames6()
+        {
+            // Snippet: WildcardMultiPatternMethod(IResourceName, WildcardMultiPatternName, IEnumerable<IResourceName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            IResourceName name = new UnparsedResourceName("a/wildcard/resource");
+            WildcardMultiPatternName @ref = WildcardMultiPatternName.FromSingularItem();
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames7AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames7AsyncSnippet.g.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using Google.Api.Gax;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        public async Task WildcardMultiPatternMethodResourceNames7Async()
+        {
+            // Snippet: WildcardMultiPatternMethodAsync(IResourceName, IResourceName, IEnumerable<WildcardMultiPatternName>, CallSettings)
+            // Additional: WildcardMultiPatternMethodAsync(IResourceName, IResourceName, IEnumerable<WildcardMultiPatternName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            IResourceName name = new UnparsedResourceName("a/wildcard/resource");
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<WildcardMultiPatternName> repeatedRef = new WildcardMultiPatternName[]
+            {
+                WildcardMultiPatternName.FromSingularItem(),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames7Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames7Snippet.g.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using Google.Api.Gax;
+    using System.Collections.Generic;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        public void WildcardMultiPatternMethodResourceNames7()
+        {
+            // Snippet: WildcardMultiPatternMethod(IResourceName, IResourceName, IEnumerable<WildcardMultiPatternName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            IResourceName name = new UnparsedResourceName("a/wildcard/resource");
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<WildcardMultiPatternName> repeatedRef = new WildcardMultiPatternName[]
+            {
+                WildcardMultiPatternName.FromSingularItem(),
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames8AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames8AsyncSnippet.g.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using Google.Api.Gax;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        public async Task WildcardMultiPatternMethodResourceNames8Async()
+        {
+            // Snippet: WildcardMultiPatternMethodAsync(IResourceName, IResourceName, IEnumerable<IResourceName>, CallSettings)
+            // Additional: WildcardMultiPatternMethodAsync(IResourceName, IResourceName, IEnumerable<IResourceName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            IResourceName name = new UnparsedResourceName("a/wildcard/resource");
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames8Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames8Snippet.g.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using Google.Api.Gax;
+    using System.Collections.Generic;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        public void WildcardMultiPatternMethodResourceNames8()
+        {
+            // Snippet: WildcardMultiPatternMethod(IResourceName, IResourceName, IEnumerable<IResourceName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            IResourceName name = new UnparsedResourceName("a/wildcard/resource");
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodSnippet.g.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using System.Collections.Generic;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        public void WildcardMultiPatternMethod()
+        {
+            // Snippet: WildcardMultiPatternMethod(string, string, IEnumerable<string>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            string name = "singular_item";
+            string @ref = "singular_item";
+            IEnumerable<string> repeatedRef = new string[] { "singular_item", };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodAsyncSnippet.g.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMultipleMethodAsync</summary>
+        public async Task WildcardMultiPatternMultipleMethodAsync()
+        {
+            // Snippet: WildcardMultiPatternMultipleMethodAsync(string, IEnumerable<string>, CallSettings)
+            // Additional: WildcardMultiPatternMultipleMethodAsync(string, IEnumerable<string>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            string @ref = "constPattern";
+            IEnumerable<string> repeatedRef = new string[] { "constPattern", };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMultipleMethodAsync(@ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,45 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMultipleMethodAsync</summary>
+        public async Task WildcardMultiPatternMultipleMethodRequestObjectAsync()
+        {
+            // Snippet: WildcardMultiPatternMultipleMethodAsync(WildcardMultiPatternMultiple, CallSettings)
+            // Additional: WildcardMultiPatternMultipleMethodAsync(WildcardMultiPatternMultiple, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            WildcardMultiPatternMultiple request = new WildcardMultiPatternMultiple
+            {
+                WildcardMultiPatternMultipleName = WildcardMultiPatternMultipleName.FromConstPattern(),
+                RefAsWildcardMultiPatternMultipleName = WildcardMultiPatternMultipleName.FromConstPattern(),
+                RepeatedRefAsWildcardMultiPatternMultipleNames =
+                {
+                    WildcardMultiPatternMultipleName.FromConstPattern(),
+                },
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMultipleMethodAsync(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodRequestObjectSnippet.g.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMultipleMethod</summary>
+        public void WildcardMultiPatternMultipleMethodRequestObject()
+        {
+            // Snippet: WildcardMultiPatternMultipleMethod(WildcardMultiPatternMultiple, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            WildcardMultiPatternMultiple request = new WildcardMultiPatternMultiple
+            {
+                WildcardMultiPatternMultipleName = WildcardMultiPatternMultipleName.FromConstPattern(),
+                RefAsWildcardMultiPatternMultipleName = WildcardMultiPatternMultipleName.FromConstPattern(),
+                RepeatedRefAsWildcardMultiPatternMultipleNames =
+                {
+                    WildcardMultiPatternMultipleName.FromConstPattern(),
+                },
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMultipleMethod(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames1AsyncSnippet.g.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMultipleMethodAsync</summary>
+        public async Task WildcardMultiPatternMultipleMethodResourceNames1Async()
+        {
+            // Snippet: WildcardMultiPatternMultipleMethodAsync(WildcardMultiPatternMultipleName, IEnumerable<WildcardMultiPatternMultipleName>, CallSettings)
+            // Additional: WildcardMultiPatternMultipleMethodAsync(WildcardMultiPatternMultipleName, IEnumerable<WildcardMultiPatternMultipleName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            WildcardMultiPatternMultipleName @ref = WildcardMultiPatternMultipleName.FromConstPattern();
+            IEnumerable<WildcardMultiPatternMultipleName> repeatedRef = new WildcardMultiPatternMultipleName[]
+            {
+                WildcardMultiPatternMultipleName.FromConstPattern(),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMultipleMethodAsync(@ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames1Snippet.g.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using System.Collections.Generic;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMultipleMethod</summary>
+        public void WildcardMultiPatternMultipleMethodResourceNames1()
+        {
+            // Snippet: WildcardMultiPatternMultipleMethod(WildcardMultiPatternMultipleName, IEnumerable<WildcardMultiPatternMultipleName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            WildcardMultiPatternMultipleName @ref = WildcardMultiPatternMultipleName.FromConstPattern();
+            IEnumerable<WildcardMultiPatternMultipleName> repeatedRef = new WildcardMultiPatternMultipleName[]
+            {
+                WildcardMultiPatternMultipleName.FromConstPattern(),
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMultipleMethod(@ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames2AsyncSnippet.g.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using Google.Api.Gax;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMultipleMethodAsync</summary>
+        public async Task WildcardMultiPatternMultipleMethodResourceNames2Async()
+        {
+            // Snippet: WildcardMultiPatternMultipleMethodAsync(WildcardMultiPatternMultipleName, IEnumerable<IResourceName>, CallSettings)
+            // Additional: WildcardMultiPatternMultipleMethodAsync(WildcardMultiPatternMultipleName, IEnumerable<IResourceName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            WildcardMultiPatternMultipleName @ref = WildcardMultiPatternMultipleName.FromConstPattern();
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMultipleMethodAsync(@ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames2Snippet.g.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using Google.Api.Gax;
+    using System.Collections.Generic;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMultipleMethod</summary>
+        public void WildcardMultiPatternMultipleMethodResourceNames2()
+        {
+            // Snippet: WildcardMultiPatternMultipleMethod(WildcardMultiPatternMultipleName, IEnumerable<IResourceName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            WildcardMultiPatternMultipleName @ref = WildcardMultiPatternMultipleName.FromConstPattern();
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMultipleMethod(@ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames3AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames3AsyncSnippet.g.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using Google.Api.Gax;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMultipleMethodAsync</summary>
+        public async Task WildcardMultiPatternMultipleMethodResourceNames3Async()
+        {
+            // Snippet: WildcardMultiPatternMultipleMethodAsync(IResourceName, IEnumerable<WildcardMultiPatternMultipleName>, CallSettings)
+            // Additional: WildcardMultiPatternMultipleMethodAsync(IResourceName, IEnumerable<WildcardMultiPatternMultipleName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<WildcardMultiPatternMultipleName> repeatedRef = new WildcardMultiPatternMultipleName[]
+            {
+                WildcardMultiPatternMultipleName.FromConstPattern(),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMultipleMethodAsync(@ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames3Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames3Snippet.g.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using Google.Api.Gax;
+    using System.Collections.Generic;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMultipleMethod</summary>
+        public void WildcardMultiPatternMultipleMethodResourceNames3()
+        {
+            // Snippet: WildcardMultiPatternMultipleMethod(IResourceName, IEnumerable<WildcardMultiPatternMultipleName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<WildcardMultiPatternMultipleName> repeatedRef = new WildcardMultiPatternMultipleName[]
+            {
+                WildcardMultiPatternMultipleName.FromConstPattern(),
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMultipleMethod(@ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames4AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames4AsyncSnippet.g.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using Google.Api.Gax;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMultipleMethodAsync</summary>
+        public async Task WildcardMultiPatternMultipleMethodResourceNames4Async()
+        {
+            // Snippet: WildcardMultiPatternMultipleMethodAsync(IResourceName, IEnumerable<IResourceName>, CallSettings)
+            // Additional: WildcardMultiPatternMultipleMethodAsync(IResourceName, IEnumerable<IResourceName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardMultiPatternMultipleMethodAsync(@ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames4Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames4Snippet.g.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using Google.Api.Gax;
+    using System.Collections.Generic;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMultipleMethod</summary>
+        public void WildcardMultiPatternMultipleMethodResourceNames4()
+        {
+            // Snippet: WildcardMultiPatternMultipleMethod(IResourceName, IEnumerable<IResourceName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMultipleMethod(@ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodSnippet.g.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using System.Collections.Generic;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardMultiPatternMultipleMethod</summary>
+        public void WildcardMultiPatternMultipleMethod()
+        {
+            // Snippet: WildcardMultiPatternMultipleMethod(string, IEnumerable<string>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            string @ref = "constPattern";
+            IEnumerable<string> repeatedRef = new string[] { "constPattern", };
+            // Make the request
+            Response response = resourceNamesClient.WildcardMultiPatternMultipleMethod(@ref, repeatedRef);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodAsyncSnippet.g.cs
@@ -1,0 +1,48 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardOnlyPatternMethodAsync</summary>
+        public async Task WildcardOnlyPatternMethodAsync()
+        {
+            // Snippet: WildcardOnlyPatternMethodAsync(string, string, IEnumerable<string>, string, IEnumerable<string>, CallSettings)
+            // Additional: WildcardOnlyPatternMethodAsync(string, string, IEnumerable<string>, string, IEnumerable<string>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            string name = "a/wildcard/resource";
+            string @ref = "a/wildcard/resource";
+            IEnumerable<string> repeatedRef = new string[]
+            {
+                "a/wildcard/resource",
+            };
+            string refSugar = "a/wildcard/resource";
+            IEnumerable<string> repeatedRefSugar = new string[]
+            {
+                "a/wildcard/resource",
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardOnlyPatternMethodAsync(name, @ref, repeatedRef, refSugar, repeatedRefSugar);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,51 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using Google.Api.Gax;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardOnlyPatternMethodAsync</summary>
+        public async Task WildcardOnlyPatternMethodRequestObjectAsync()
+        {
+            // Snippet: WildcardOnlyPatternMethodAsync(WildcardOnlyPattern, CallSettings)
+            // Additional: WildcardOnlyPatternMethodAsync(WildcardOnlyPattern, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            WildcardOnlyPattern request = new WildcardOnlyPattern
+            {
+                ResourceName = new UnparsedResourceName("a/wildcard/resource"),
+                RefAsResourceName = new UnparsedResourceName("a/wildcard/resource"),
+                RepeatedRefAsResourceNames =
+                {
+                    new UnparsedResourceName("a/wildcard/resource"),
+                },
+                RefSugarAsResourceName = new UnparsedResourceName("a/wildcard/resource"),
+                RepeatedRefSugarAsResourceNames =
+                {
+                    new UnparsedResourceName("a/wildcard/resource"),
+                },
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardOnlyPatternMethodAsync(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodRequestObjectSnippet.g.cs
@@ -1,0 +1,49 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using Google.Api.Gax;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardOnlyPatternMethod</summary>
+        public void WildcardOnlyPatternMethodRequestObject()
+        {
+            // Snippet: WildcardOnlyPatternMethod(WildcardOnlyPattern, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            WildcardOnlyPattern request = new WildcardOnlyPattern
+            {
+                ResourceName = new UnparsedResourceName("a/wildcard/resource"),
+                RefAsResourceName = new UnparsedResourceName("a/wildcard/resource"),
+                RepeatedRefAsResourceNames =
+                {
+                    new UnparsedResourceName("a/wildcard/resource"),
+                },
+                RefSugarAsResourceName = new UnparsedResourceName("a/wildcard/resource"),
+                RepeatedRefSugarAsResourceNames =
+                {
+                    new UnparsedResourceName("a/wildcard/resource"),
+                },
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardOnlyPatternMethod(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodResourceNamesAsyncSnippet.g.cs
@@ -1,0 +1,49 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using Google.Api.Gax;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardOnlyPatternMethodAsync</summary>
+        public async Task WildcardOnlyPatternMethodResourceNamesAsync()
+        {
+            // Snippet: WildcardOnlyPatternMethodAsync(IResourceName, IResourceName, IEnumerable<IResourceName>, IResourceName, IEnumerable<IResourceName>, CallSettings)
+            // Additional: WildcardOnlyPatternMethodAsync(IResourceName, IResourceName, IEnumerable<IResourceName>, IResourceName, IEnumerable<IResourceName>, CancellationToken)
+            // Create client
+            ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
+            // Initialize request argument(s)
+            IResourceName name = new UnparsedResourceName("a/wildcard/resource");
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            IResourceName refSugar = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<IResourceName> repeatedRefSugar = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = await resourceNamesClient.WildcardOnlyPatternMethodAsync(name, @ref, repeatedRef, refSugar, repeatedRefSugar);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodResourceNamesSnippet.g.cs
@@ -1,0 +1,47 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using Google.Api.Gax;
+    using System.Collections.Generic;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardOnlyPatternMethod</summary>
+        public void WildcardOnlyPatternMethodResourceNames()
+        {
+            // Snippet: WildcardOnlyPatternMethod(IResourceName, IResourceName, IEnumerable<IResourceName>, IResourceName, IEnumerable<IResourceName>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            IResourceName name = new UnparsedResourceName("a/wildcard/resource");
+            IResourceName @ref = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<IResourceName> repeatedRef = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            IResourceName refSugar = new UnparsedResourceName("a/wildcard/resource");
+            IEnumerable<IResourceName> repeatedRefSugar = new IResourceName[]
+            {
+                new UnparsedResourceName("a/wildcard/resource"),
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardOnlyPatternMethod(name, @ref, repeatedRef, refSugar, repeatedRefSugar);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodSnippet.g.cs
@@ -1,0 +1,46 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.ResourceNames.Snippets
+{
+    using System.Collections.Generic;
+
+    public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
+    {
+        /// <summary>Snippet for WildcardOnlyPatternMethod</summary>
+        public void WildcardOnlyPatternMethod()
+        {
+            // Snippet: WildcardOnlyPatternMethod(string, string, IEnumerable<string>, string, IEnumerable<string>, CallSettings)
+            // Create client
+            ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
+            // Initialize request argument(s)
+            string name = "a/wildcard/resource";
+            string @ref = "a/wildcard/resource";
+            IEnumerable<string> repeatedRef = new string[]
+            {
+                "a/wildcard/resource",
+            };
+            string refSugar = "a/wildcard/resource";
+            IEnumerable<string> repeatedRefSugar = new string[]
+            {
+                "a/wildcard/resource",
+            };
+            // Make the request
+            Response response = resourceNamesClient.WildcardOnlyPatternMethod(name, @ref, repeatedRef, refSugar, repeatedRefSugar);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodBidiStreamingSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodBidiStreamingSnippet.g.cs
@@ -1,0 +1,74 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using Google.Api.Gax.Grpc;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodBidiStreaming</summary>
+        public async Task MethodBidiStreaming()
+        {
+            // Snippet: MethodBidiStreaming(CallSettings, BidirectionalStreamingSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize streaming call, retrieving the stream object
+            SnippetsClient.MethodBidiStreamingStream response = snippetsClient.MethodBidiStreaming();
+
+            // Sending requests and retrieving responses can be arbitrarily interleaved
+            // Exact sequence will depend on client/server behavior
+
+            // Create task to do something with responses from server
+            Task responseHandlerTask = Task.Run(async () =>
+            {
+                // Note that C# 8 code can use await foreach
+                AsyncResponseStream<Response> responseStream = response.GetResponseStream();
+                while (await responseStream.MoveNextAsync())
+                {
+                    Response responseItem = responseStream.Current;
+                    // Do something with streamed response
+                }
+                // The response stream has completed
+            });
+
+            // Send requests to the server
+            bool done = false;
+            while (!done)
+            {
+                // Initialize a request
+                SignatureRequest request = new SignatureRequest
+                {
+                    AString = "",
+                    AnInt = 0,
+                    ABool = false,
+                    MapIntString = { { 0, "" }, },
+                };
+                // Stream a request to the server
+                await response.WriteAsync(request);
+                // Set "done" to true when sending requests is complete
+            }
+
+            // Complete writing requests to the stream
+            await response.WriteCompleteAsync();
+            // Await the response handler
+            // This will complete once all server responses have been processed
+            await responseHandlerTask;
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesAsyncSnippet.g.cs
@@ -1,0 +1,46 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodDefaultValuesAsync</summary>
+        public async Task MethodDefaultValuesAsync()
+        {
+            // Snippet: MethodDefaultValuesAsync(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, IEnumerable<string>, CallSettings)
+            // Additional: MethodDefaultValuesAsync(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, IEnumerable<string>, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            IEnumerable<double> repeatedDouble = new double[] { 0, };
+            IEnumerable<DefaultValuesRequest.Types.NestedMessage> repeatedNestedMessage = new DefaultValuesRequest.Types.NestedMessage[]
+            {
+                new DefaultValuesRequest.Types.NestedMessage(),
+            };
+            IEnumerable<string> repeatedResourceName = new string[]
+            {
+                "items/[ITEM_ID]/parts/[PART_ID]",
+            };
+            // Make the request
+            Response response = await snippetsClient.MethodDefaultValuesAsync(repeatedDouble, repeatedNestedMessage, repeatedResourceName);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,122 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using Google.Api.Gax;
+    using Google.Protobuf;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodDefaultValuesAsync</summary>
+        public async Task MethodDefaultValuesRequestObjectAsync()
+        {
+            // Snippet: MethodDefaultValuesAsync(DefaultValuesRequest, CallSettings)
+            // Additional: MethodDefaultValuesAsync(DefaultValuesRequest, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            DefaultValuesRequest request = new DefaultValuesRequest
+            {
+                SingleDouble = 0,
+                SingleFloat = 0F,
+                SingleInt32 = 0,
+                SingleInt64 = 0L,
+                SingleUint32 = 0U,
+                SingleUint64 = 0UL,
+                SingleSint32 = 0,
+                SingleSint64 = 0L,
+                SingleFixed32 = 0U,
+                SingleFixed64 = 0UL,
+                SingleSfixed32 = 0,
+                SingleSfixed64 = 0L,
+                SingleBool = false,
+                SingleString = "",
+                SingleBytes = ByteString.Empty,
+                SingleMessage = new AnotherMessage(),
+                SingleNestedMessage = new DefaultValuesRequest.Types.NestedMessage(),
+                SingleEnum = Enum.Default,
+                SingleNestedEnum = DefaultValuesRequest.Types.NestedEnum.DefaultValue,
+                RepeatedDouble = { 0, },
+                RepeatedFloat = { 0F, },
+                RepeatedInt32 = { 0, },
+                RepeatedInt64 = { 0L, },
+                RepeatedUint32 = { 0U, },
+                RepeatedUint64 = { 0UL, },
+                RepeatedSint32 = { 0, },
+                RepeatedSint64 = { 0L, },
+                RepeatedFixed32 = { 0U, },
+                RepeatedFixed64 = { 0UL, },
+                RepeatedSfixed32 = { 0, },
+                RepeatedSfixed64 = { 0L, },
+                RepeatedBool = { false, },
+                RepeatedString = { "", },
+                RepeatedBytes = { ByteString.Empty, },
+                RepeatedMessage =
+                {
+                    new AnotherMessage(),
+                },
+                RepeatedNestedMessage =
+                {
+                    new DefaultValuesRequest.Types.NestedMessage(),
+                },
+                RepeatedEnum = { Enum.Default, },
+                RepeatedNestedEnum =
+                {
+                    DefaultValuesRequest.Types.NestedEnum.DefaultValue,
+                },
+                SingleResourceNameAsAResourceName = AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
+                RepeatedResourceNameAsAResourceNames =
+                {
+                    AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
+                },
+                SingleWildcardResourceAsResourceName = new UnparsedResourceName("a/wildcard/resource"),
+                RepeatedWildcardResourceAsResourceNames =
+                {
+                    new UnparsedResourceName("a/wildcard/resource"),
+                },
+                MultiPatternResourceNameAsMultiPatternResourceName = MultiPatternResourceName.FromRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
+                RepeatedMultiPatternResourceNameAsMultiPatternResourceNames =
+                {
+                    MultiPatternResourceName.FromRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
+                },
+                MapIntString = { { 0, "" }, },
+                SingleWrappedDouble = 0,
+                SingleWrappedFloat = 0F,
+                SingleWrappedInt64 = 0L,
+                SingleWrappedUint64 = 0UL,
+                SingleWrappedInt32 = 0,
+                SingleWrappedUint32 = 0U,
+                SingleWrappedBool = false,
+                SingleWrappedString = "",
+                SingleWrappedBytes = ByteString.Empty,
+                RepeatedWrappedDouble = { 0, },
+                RepeatedWrappedFloat = { 0F, },
+                RepeatedWrappedInt64 = { 0L, },
+                RepeatedWrappedUint64 = { 0UL, },
+                RepeatedWrappedInt32 = { 0, },
+                RepeatedWrappedUint32 = { 0U, },
+                RepeatedWrappedBool = { false, },
+                RepeatedWrappedString = { "", },
+                RepeatedWrappedBytes = { ByteString.Empty, },
+            };
+            // Make the request
+            Response response = await snippetsClient.MethodDefaultValuesAsync(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesRequestObjectSnippet.g.cs
@@ -1,0 +1,120 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using Google.Api.Gax;
+    using Google.Protobuf;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodDefaultValues</summary>
+        public void MethodDefaultValuesRequestObject()
+        {
+            // Snippet: MethodDefaultValues(DefaultValuesRequest, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            DefaultValuesRequest request = new DefaultValuesRequest
+            {
+                SingleDouble = 0,
+                SingleFloat = 0F,
+                SingleInt32 = 0,
+                SingleInt64 = 0L,
+                SingleUint32 = 0U,
+                SingleUint64 = 0UL,
+                SingleSint32 = 0,
+                SingleSint64 = 0L,
+                SingleFixed32 = 0U,
+                SingleFixed64 = 0UL,
+                SingleSfixed32 = 0,
+                SingleSfixed64 = 0L,
+                SingleBool = false,
+                SingleString = "",
+                SingleBytes = ByteString.Empty,
+                SingleMessage = new AnotherMessage(),
+                SingleNestedMessage = new DefaultValuesRequest.Types.NestedMessage(),
+                SingleEnum = Enum.Default,
+                SingleNestedEnum = DefaultValuesRequest.Types.NestedEnum.DefaultValue,
+                RepeatedDouble = { 0, },
+                RepeatedFloat = { 0F, },
+                RepeatedInt32 = { 0, },
+                RepeatedInt64 = { 0L, },
+                RepeatedUint32 = { 0U, },
+                RepeatedUint64 = { 0UL, },
+                RepeatedSint32 = { 0, },
+                RepeatedSint64 = { 0L, },
+                RepeatedFixed32 = { 0U, },
+                RepeatedFixed64 = { 0UL, },
+                RepeatedSfixed32 = { 0, },
+                RepeatedSfixed64 = { 0L, },
+                RepeatedBool = { false, },
+                RepeatedString = { "", },
+                RepeatedBytes = { ByteString.Empty, },
+                RepeatedMessage =
+                {
+                    new AnotherMessage(),
+                },
+                RepeatedNestedMessage =
+                {
+                    new DefaultValuesRequest.Types.NestedMessage(),
+                },
+                RepeatedEnum = { Enum.Default, },
+                RepeatedNestedEnum =
+                {
+                    DefaultValuesRequest.Types.NestedEnum.DefaultValue,
+                },
+                SingleResourceNameAsAResourceName = AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
+                RepeatedResourceNameAsAResourceNames =
+                {
+                    AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
+                },
+                SingleWildcardResourceAsResourceName = new UnparsedResourceName("a/wildcard/resource"),
+                RepeatedWildcardResourceAsResourceNames =
+                {
+                    new UnparsedResourceName("a/wildcard/resource"),
+                },
+                MultiPatternResourceNameAsMultiPatternResourceName = MultiPatternResourceName.FromRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
+                RepeatedMultiPatternResourceNameAsMultiPatternResourceNames =
+                {
+                    MultiPatternResourceName.FromRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
+                },
+                MapIntString = { { 0, "" }, },
+                SingleWrappedDouble = 0,
+                SingleWrappedFloat = 0F,
+                SingleWrappedInt64 = 0L,
+                SingleWrappedUint64 = 0UL,
+                SingleWrappedInt32 = 0,
+                SingleWrappedUint32 = 0U,
+                SingleWrappedBool = false,
+                SingleWrappedString = "",
+                SingleWrappedBytes = ByteString.Empty,
+                RepeatedWrappedDouble = { 0, },
+                RepeatedWrappedFloat = { 0F, },
+                RepeatedWrappedInt64 = { 0L, },
+                RepeatedWrappedUint64 = { 0UL, },
+                RepeatedWrappedInt32 = { 0, },
+                RepeatedWrappedUint32 = { 0U, },
+                RepeatedWrappedBool = { false, },
+                RepeatedWrappedString = { "", },
+                RepeatedWrappedBytes = { ByteString.Empty, },
+            };
+            // Make the request
+            Response response = snippetsClient.MethodDefaultValues(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesResourceNamesAsyncSnippet.g.cs
@@ -1,0 +1,46 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodDefaultValuesAsync</summary>
+        public async Task MethodDefaultValuesResourceNamesAsync()
+        {
+            // Snippet: MethodDefaultValuesAsync(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, IEnumerable<AResourceName>, CallSettings)
+            // Additional: MethodDefaultValuesAsync(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, IEnumerable<AResourceName>, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            IEnumerable<double> repeatedDouble = new double[] { 0, };
+            IEnumerable<DefaultValuesRequest.Types.NestedMessage> repeatedNestedMessage = new DefaultValuesRequest.Types.NestedMessage[]
+            {
+                new DefaultValuesRequest.Types.NestedMessage(),
+            };
+            IEnumerable<AResourceName> repeatedResourceName = new AResourceName[]
+            {
+                AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
+            };
+            // Make the request
+            Response response = await snippetsClient.MethodDefaultValuesAsync(repeatedDouble, repeatedNestedMessage, repeatedResourceName);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesResourceNamesSnippet.g.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using System.Collections.Generic;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodDefaultValues</summary>
+        public void MethodDefaultValuesResourceNames()
+        {
+            // Snippet: MethodDefaultValues(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, IEnumerable<AResourceName>, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            IEnumerable<double> repeatedDouble = new double[] { 0, };
+            IEnumerable<DefaultValuesRequest.Types.NestedMessage> repeatedNestedMessage = new DefaultValuesRequest.Types.NestedMessage[]
+            {
+                new DefaultValuesRequest.Types.NestedMessage(),
+            };
+            IEnumerable<AResourceName> repeatedResourceName = new AResourceName[]
+            {
+                AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
+            };
+            // Make the request
+            Response response = snippetsClient.MethodDefaultValues(repeatedDouble, repeatedNestedMessage, repeatedResourceName);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesSnippet.g.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using System.Collections.Generic;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodDefaultValues</summary>
+        public void MethodDefaultValues()
+        {
+            // Snippet: MethodDefaultValues(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, IEnumerable<string>, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            IEnumerable<double> repeatedDouble = new double[] { 0, };
+            IEnumerable<DefaultValuesRequest.Types.NestedMessage> repeatedNestedMessage = new DefaultValuesRequest.Types.NestedMessage[]
+            {
+                new DefaultValuesRequest.Types.NestedMessage(),
+            };
+            IEnumerable<string> repeatedResourceName = new string[]
+            {
+                "items/[ITEM_ID]/parts/[PART_ID]",
+            };
+            // Make the request
+            Response response = snippetsClient.MethodDefaultValues(repeatedDouble, repeatedNestedMessage, repeatedResourceName);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureAsyncSnippet.g.cs
@@ -1,0 +1,56 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using Google.LongRunning;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodLroResourceSignatureAsync</summary>
+        public async Task MethodLroResourceSignatureAsync()
+        {
+            // Snippet: MethodLroResourceSignatureAsync(string, string, string, CallSettings)
+            // Additional: MethodLroResourceSignatureAsync(string, string, string, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            string firstName = "items/[ITEM_ID]";
+            string secondName = "items/[ITEM_ID]";
+            string thirdName = "items/[ITEM_ID]";
+            // Make the request
+            Operation<LroResponse, LroMetadata> response = await snippetsClient.MethodLroResourceSignatureAsync(firstName, secondName, thirdName);
+
+            // Poll until the returned long-running operation is complete
+            Operation<LroResponse, LroMetadata> completedResponse = await response.PollUntilCompletedAsync();
+            // Retrieve the operation result
+            LroResponse result = completedResponse.Result;
+
+            // Or get the name of the operation
+            string operationName = response.Name;
+            // This name can be stored, then the long-running operation retrieved later by name
+            Operation<LroResponse, LroMetadata> retrievedResponse = await snippetsClient.PollOnceMethodLroResourceSignatureAsync(operationName);
+            // Check if the retrieved long-running operation has completed
+            if (retrievedResponse.IsCompleted)
+            {
+                // If it has completed, then access the result
+                LroResponse retrievedResult = retrievedResponse.Result;
+            }
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,59 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using Google.LongRunning;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodLroResourceSignatureAsync</summary>
+        public async Task MethodLroResourceSignatureRequestObjectAsync()
+        {
+            // Snippet: MethodLroResourceSignatureAsync(ResourceSignatureRequest, CallSettings)
+            // Additional: MethodLroResourceSignatureAsync(ResourceSignatureRequest, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            ResourceSignatureRequest request = new ResourceSignatureRequest
+            {
+                FirstNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                SecondNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                ThirdNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+            };
+            // Make the request
+            Operation<LroResponse, LroMetadata> response = await snippetsClient.MethodLroResourceSignatureAsync(request);
+
+            // Poll until the returned long-running operation is complete
+            Operation<LroResponse, LroMetadata> completedResponse = await response.PollUntilCompletedAsync();
+            // Retrieve the operation result
+            LroResponse result = completedResponse.Result;
+
+            // Or get the name of the operation
+            string operationName = response.Name;
+            // This name can be stored, then the long-running operation retrieved later by name
+            Operation<LroResponse, LroMetadata> retrievedResponse = await snippetsClient.PollOnceMethodLroResourceSignatureAsync(operationName);
+            // Check if the retrieved long-running operation has completed
+            if (retrievedResponse.IsCompleted)
+            {
+                // If it has completed, then access the result
+                LroResponse retrievedResult = retrievedResponse.Result;
+            }
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureRequestObjectSnippet.g.cs
@@ -1,0 +1,57 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using Google.LongRunning;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodLroResourceSignature</summary>
+        public void MethodLroResourceSignatureRequestObject()
+        {
+            // Snippet: MethodLroResourceSignature(ResourceSignatureRequest, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            ResourceSignatureRequest request = new ResourceSignatureRequest
+            {
+                FirstNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                SecondNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                ThirdNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+            };
+            // Make the request
+            Operation<LroResponse, LroMetadata> response = snippetsClient.MethodLroResourceSignature(request);
+
+            // Poll until the returned long-running operation is complete
+            Operation<LroResponse, LroMetadata> completedResponse = response.PollUntilCompleted();
+            // Retrieve the operation result
+            LroResponse result = completedResponse.Result;
+
+            // Or get the name of the operation
+            string operationName = response.Name;
+            // This name can be stored, then the long-running operation retrieved later by name
+            Operation<LroResponse, LroMetadata> retrievedResponse = snippetsClient.PollOnceMethodLroResourceSignature(operationName);
+            // Check if the retrieved long-running operation has completed
+            if (retrievedResponse.IsCompleted)
+            {
+                // If it has completed, then access the result
+                LroResponse retrievedResult = retrievedResponse.Result;
+            }
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureResourceNamesAsyncSnippet.g.cs
@@ -1,0 +1,56 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using Google.LongRunning;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodLroResourceSignatureAsync</summary>
+        public async Task MethodLroResourceSignatureResourceNamesAsync()
+        {
+            // Snippet: MethodLroResourceSignatureAsync(SimpleResourceName, SimpleResourceName, SimpleResourceName, CallSettings)
+            // Additional: MethodLroResourceSignatureAsync(SimpleResourceName, SimpleResourceName, SimpleResourceName, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
+            SimpleResourceName secondName = SimpleResourceName.FromItem("[ITEM_ID]");
+            SimpleResourceName thirdName = SimpleResourceName.FromItem("[ITEM_ID]");
+            // Make the request
+            Operation<LroResponse, LroMetadata> response = await snippetsClient.MethodLroResourceSignatureAsync(firstName, secondName, thirdName);
+
+            // Poll until the returned long-running operation is complete
+            Operation<LroResponse, LroMetadata> completedResponse = await response.PollUntilCompletedAsync();
+            // Retrieve the operation result
+            LroResponse result = completedResponse.Result;
+
+            // Or get the name of the operation
+            string operationName = response.Name;
+            // This name can be stored, then the long-running operation retrieved later by name
+            Operation<LroResponse, LroMetadata> retrievedResponse = await snippetsClient.PollOnceMethodLroResourceSignatureAsync(operationName);
+            // Check if the retrieved long-running operation has completed
+            if (retrievedResponse.IsCompleted)
+            {
+                // If it has completed, then access the result
+                LroResponse retrievedResult = retrievedResponse.Result;
+            }
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureResourceNamesSnippet.g.cs
@@ -1,0 +1,54 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using Google.LongRunning;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodLroResourceSignature</summary>
+        public void MethodLroResourceSignatureResourceNames()
+        {
+            // Snippet: MethodLroResourceSignature(SimpleResourceName, SimpleResourceName, SimpleResourceName, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
+            SimpleResourceName secondName = SimpleResourceName.FromItem("[ITEM_ID]");
+            SimpleResourceName thirdName = SimpleResourceName.FromItem("[ITEM_ID]");
+            // Make the request
+            Operation<LroResponse, LroMetadata> response = snippetsClient.MethodLroResourceSignature(firstName, secondName, thirdName);
+
+            // Poll until the returned long-running operation is complete
+            Operation<LroResponse, LroMetadata> completedResponse = response.PollUntilCompleted();
+            // Retrieve the operation result
+            LroResponse result = completedResponse.Result;
+
+            // Or get the name of the operation
+            string operationName = response.Name;
+            // This name can be stored, then the long-running operation retrieved later by name
+            Operation<LroResponse, LroMetadata> retrievedResponse = snippetsClient.PollOnceMethodLroResourceSignature(operationName);
+            // Check if the retrieved long-running operation has completed
+            if (retrievedResponse.IsCompleted)
+            {
+                // If it has completed, then access the result
+                LroResponse retrievedResult = retrievedResponse.Result;
+            }
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureSnippet.g.cs
@@ -1,0 +1,54 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using Google.LongRunning;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodLroResourceSignature</summary>
+        public void MethodLroResourceSignature()
+        {
+            // Snippet: MethodLroResourceSignature(string, string, string, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            string firstName = "items/[ITEM_ID]";
+            string secondName = "items/[ITEM_ID]";
+            string thirdName = "items/[ITEM_ID]";
+            // Make the request
+            Operation<LroResponse, LroMetadata> response = snippetsClient.MethodLroResourceSignature(firstName, secondName, thirdName);
+
+            // Poll until the returned long-running operation is complete
+            Operation<LroResponse, LroMetadata> completedResponse = response.PollUntilCompleted();
+            // Retrieve the operation result
+            LroResponse result = completedResponse.Result;
+
+            // Or get the name of the operation
+            string operationName = response.Name;
+            // This name can be stored, then the long-running operation retrieved later by name
+            Operation<LroResponse, LroMetadata> retrievedResponse = snippetsClient.PollOnceMethodLroResourceSignature(operationName);
+            // Check if the retrieved long-running operation has completed
+            if (retrievedResponse.IsCompleted)
+            {
+                // If it has completed, then access the result
+                LroResponse retrievedResult = retrievedResponse.Result;
+            }
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroSignaturesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroSignaturesAsyncSnippet.g.cs
@@ -1,0 +1,56 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using Google.LongRunning;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodLroSignaturesAsync</summary>
+        public async Task MethodLroSignaturesAsync()
+        {
+            // Snippet: MethodLroSignaturesAsync(string, int, bool, CallSettings)
+            // Additional: MethodLroSignaturesAsync(string, int, bool, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            string aString = "";
+            int anInt = 0;
+            bool aBool = false;
+            // Make the request
+            Operation<LroResponse, LroMetadata> response = await snippetsClient.MethodLroSignaturesAsync(aString, anInt, aBool);
+
+            // Poll until the returned long-running operation is complete
+            Operation<LroResponse, LroMetadata> completedResponse = await response.PollUntilCompletedAsync();
+            // Retrieve the operation result
+            LroResponse result = completedResponse.Result;
+
+            // Or get the name of the operation
+            string operationName = response.Name;
+            // This name can be stored, then the long-running operation retrieved later by name
+            Operation<LroResponse, LroMetadata> retrievedResponse = await snippetsClient.PollOnceMethodLroSignaturesAsync(operationName);
+            // Check if the retrieved long-running operation has completed
+            if (retrievedResponse.IsCompleted)
+            {
+                // If it has completed, then access the result
+                LroResponse retrievedResult = retrievedResponse.Result;
+            }
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroSignaturesRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroSignaturesRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,60 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using Google.LongRunning;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodLroSignaturesAsync</summary>
+        public async Task MethodLroSignaturesRequestObjectAsync()
+        {
+            // Snippet: MethodLroSignaturesAsync(SignatureRequest, CallSettings)
+            // Additional: MethodLroSignaturesAsync(SignatureRequest, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            SignatureRequest request = new SignatureRequest
+            {
+                AString = "",
+                AnInt = 0,
+                ABool = false,
+                MapIntString = { { 0, "" }, },
+            };
+            // Make the request
+            Operation<LroResponse, LroMetadata> response = await snippetsClient.MethodLroSignaturesAsync(request);
+
+            // Poll until the returned long-running operation is complete
+            Operation<LroResponse, LroMetadata> completedResponse = await response.PollUntilCompletedAsync();
+            // Retrieve the operation result
+            LroResponse result = completedResponse.Result;
+
+            // Or get the name of the operation
+            string operationName = response.Name;
+            // This name can be stored, then the long-running operation retrieved later by name
+            Operation<LroResponse, LroMetadata> retrievedResponse = await snippetsClient.PollOnceMethodLroSignaturesAsync(operationName);
+            // Check if the retrieved long-running operation has completed
+            if (retrievedResponse.IsCompleted)
+            {
+                // If it has completed, then access the result
+                LroResponse retrievedResult = retrievedResponse.Result;
+            }
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroSignaturesRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroSignaturesRequestObjectSnippet.g.cs
@@ -1,0 +1,58 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using Google.LongRunning;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodLroSignatures</summary>
+        public void MethodLroSignaturesRequestObject()
+        {
+            // Snippet: MethodLroSignatures(SignatureRequest, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            SignatureRequest request = new SignatureRequest
+            {
+                AString = "",
+                AnInt = 0,
+                ABool = false,
+                MapIntString = { { 0, "" }, },
+            };
+            // Make the request
+            Operation<LroResponse, LroMetadata> response = snippetsClient.MethodLroSignatures(request);
+
+            // Poll until the returned long-running operation is complete
+            Operation<LroResponse, LroMetadata> completedResponse = response.PollUntilCompleted();
+            // Retrieve the operation result
+            LroResponse result = completedResponse.Result;
+
+            // Or get the name of the operation
+            string operationName = response.Name;
+            // This name can be stored, then the long-running operation retrieved later by name
+            Operation<LroResponse, LroMetadata> retrievedResponse = snippetsClient.PollOnceMethodLroSignatures(operationName);
+            // Check if the retrieved long-running operation has completed
+            if (retrievedResponse.IsCompleted)
+            {
+                // If it has completed, then access the result
+                LroResponse retrievedResult = retrievedResponse.Result;
+            }
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroSignaturesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroSignaturesSnippet.g.cs
@@ -1,0 +1,54 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using Google.LongRunning;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodLroSignatures</summary>
+        public void MethodLroSignatures()
+        {
+            // Snippet: MethodLroSignatures(string, int, bool, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            string aString = "";
+            int anInt = 0;
+            bool aBool = false;
+            // Make the request
+            Operation<LroResponse, LroMetadata> response = snippetsClient.MethodLroSignatures(aString, anInt, aBool);
+
+            // Poll until the returned long-running operation is complete
+            Operation<LroResponse, LroMetadata> completedResponse = response.PollUntilCompleted();
+            // Retrieve the operation result
+            LroResponse result = completedResponse.Result;
+
+            // Or get the name of the operation
+            string operationName = response.Name;
+            // This name can be stored, then the long-running operation retrieved later by name
+            Operation<LroResponse, LroMetadata> retrievedResponse = snippetsClient.PollOnceMethodLroSignatures(operationName);
+            // Check if the retrieved long-running operation has completed
+            if (retrievedResponse.IsCompleted)
+            {
+                // If it has completed, then access the result
+                LroResponse retrievedResult = retrievedResponse.Result;
+            }
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodMapSignatureAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodMapSignatureAsyncSnippet.g.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodMapSignatureAsync</summary>
+        public async Task MethodMapSignatureAsync()
+        {
+            // Snippet: MethodMapSignatureAsync(IDictionary<int,string>, CallSettings)
+            // Additional: MethodMapSignatureAsync(IDictionary<int,string>, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            IDictionary<int, string> mapIntString = new Dictionary<int, string> { { 0, "" }, };
+            // Make the request
+            Response response = await snippetsClient.MethodMapSignatureAsync(mapIntString);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodMapSignatureRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodMapSignatureRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodMapSignatureAsync</summary>
+        public async Task MethodMapSignatureRequestObjectAsync()
+        {
+            // Snippet: MethodMapSignatureAsync(SignatureRequest, CallSettings)
+            // Additional: MethodMapSignatureAsync(SignatureRequest, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            SignatureRequest request = new SignatureRequest
+            {
+                AString = "",
+                AnInt = 0,
+                ABool = false,
+                MapIntString = { { 0, "" }, },
+            };
+            // Make the request
+            Response response = await snippetsClient.MethodMapSignatureAsync(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodMapSignatureRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodMapSignatureRequestObjectSnippet.g.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodMapSignature</summary>
+        public void MethodMapSignatureRequestObject()
+        {
+            // Snippet: MethodMapSignature(SignatureRequest, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            SignatureRequest request = new SignatureRequest
+            {
+                AString = "",
+                AnInt = 0,
+                ABool = false,
+                MapIntString = { { 0, "" }, },
+            };
+            // Make the request
+            Response response = snippetsClient.MethodMapSignature(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodMapSignatureSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodMapSignatureSnippet.g.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using System.Collections.Generic;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodMapSignature</summary>
+        public void MethodMapSignature()
+        {
+            // Snippet: MethodMapSignature(IDictionary<int,string>, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            IDictionary<int, string> mapIntString = new Dictionary<int, string> { { 0, "" }, };
+            // Make the request
+            Response response = snippetsClient.MethodMapSignature(mapIntString);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodOneSignatureAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodOneSignatureAsyncSnippet.g.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodOneSignatureAsync</summary>
+        public async Task MethodOneSignatureAsync()
+        {
+            // Snippet: MethodOneSignatureAsync(string, int, bool, CallSettings)
+            // Additional: MethodOneSignatureAsync(string, int, bool, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            string aString = "";
+            int anInt = 0;
+            bool aBool = false;
+            // Make the request
+            Response response = await snippetsClient.MethodOneSignatureAsync(aString, anInt, aBool);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodOneSignatureRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodOneSignatureRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodOneSignatureAsync</summary>
+        public async Task MethodOneSignatureRequestObjectAsync()
+        {
+            // Snippet: MethodOneSignatureAsync(SignatureRequest, CallSettings)
+            // Additional: MethodOneSignatureAsync(SignatureRequest, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            SignatureRequest request = new SignatureRequest
+            {
+                AString = "",
+                AnInt = 0,
+                ABool = false,
+                MapIntString = { { 0, "" }, },
+            };
+            // Make the request
+            Response response = await snippetsClient.MethodOneSignatureAsync(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodOneSignatureRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodOneSignatureRequestObjectSnippet.g.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodOneSignature</summary>
+        public void MethodOneSignatureRequestObject()
+        {
+            // Snippet: MethodOneSignature(SignatureRequest, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            SignatureRequest request = new SignatureRequest
+            {
+                AString = "",
+                AnInt = 0,
+                ABool = false,
+                MapIntString = { { 0, "" }, },
+            };
+            // Make the request
+            Response response = snippetsClient.MethodOneSignature(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodOneSignatureSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodOneSignatureSnippet.g.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodOneSignature</summary>
+        public void MethodOneSignature()
+        {
+            // Snippet: MethodOneSignature(string, int, bool, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            string aString = "";
+            int anInt = 0;
+            bool aBool = false;
+            // Make the request
+            Response response = snippetsClient.MethodOneSignature(aString, anInt, aBool);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureAsyncSnippet.g.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodRepeatedResourceSignatureAsync</summary>
+        public async Task MethodRepeatedResourceSignatureAsync()
+        {
+            // Snippet: MethodRepeatedResourceSignatureAsync(IEnumerable<string>, CallSettings)
+            // Additional: MethodRepeatedResourceSignatureAsync(IEnumerable<string>, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            IEnumerable<string> names = new string[] { "items/[ITEM_ID]", };
+            // Make the request
+            Response response = await snippetsClient.MethodRepeatedResourceSignatureAsync(names);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodRepeatedResourceSignatureAsync</summary>
+        public async Task MethodRepeatedResourceSignatureRequestObjectAsync()
+        {
+            // Snippet: MethodRepeatedResourceSignatureAsync(RepeatedResourceSignatureRequest, CallSettings)
+            // Additional: MethodRepeatedResourceSignatureAsync(RepeatedResourceSignatureRequest, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            RepeatedResourceSignatureRequest request = new RepeatedResourceSignatureRequest
+            {
+                SimpleResourceNames =
+                {
+                    SimpleResourceName.FromItem("[ITEM_ID]"),
+                },
+            };
+            // Make the request
+            Response response = await snippetsClient.MethodRepeatedResourceSignatureAsync(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureRequestObjectSnippet.g.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodRepeatedResourceSignature</summary>
+        public void MethodRepeatedResourceSignatureRequestObject()
+        {
+            // Snippet: MethodRepeatedResourceSignature(RepeatedResourceSignatureRequest, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            RepeatedResourceSignatureRequest request = new RepeatedResourceSignatureRequest
+            {
+                SimpleResourceNames =
+                {
+                    SimpleResourceName.FromItem("[ITEM_ID]"),
+                },
+            };
+            // Make the request
+            Response response = snippetsClient.MethodRepeatedResourceSignature(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureResourceNamesAsyncSnippet.g.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodRepeatedResourceSignatureAsync</summary>
+        public async Task MethodRepeatedResourceSignatureResourceNamesAsync()
+        {
+            // Snippet: MethodRepeatedResourceSignatureAsync(IEnumerable<SimpleResourceName>, CallSettings)
+            // Additional: MethodRepeatedResourceSignatureAsync(IEnumerable<SimpleResourceName>, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            IEnumerable<SimpleResourceName> names = new SimpleResourceName[]
+            {
+                SimpleResourceName.FromItem("[ITEM_ID]"),
+            };
+            // Make the request
+            Response response = await snippetsClient.MethodRepeatedResourceSignatureAsync(names);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureResourceNamesSnippet.g.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using System.Collections.Generic;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodRepeatedResourceSignature</summary>
+        public void MethodRepeatedResourceSignatureResourceNames()
+        {
+            // Snippet: MethodRepeatedResourceSignature(IEnumerable<SimpleResourceName>, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            IEnumerable<SimpleResourceName> names = new SimpleResourceName[]
+            {
+                SimpleResourceName.FromItem("[ITEM_ID]"),
+            };
+            // Make the request
+            Response response = snippetsClient.MethodRepeatedResourceSignature(names);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureSnippet.g.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using System.Collections.Generic;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodRepeatedResourceSignature</summary>
+        public void MethodRepeatedResourceSignature()
+        {
+            // Snippet: MethodRepeatedResourceSignature(IEnumerable<string>, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            IEnumerable<string> names = new string[] { "items/[ITEM_ID]", };
+            // Make the request
+            Response response = snippetsClient.MethodRepeatedResourceSignature(names);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature1AsyncSnippet.g.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodResourceSignatureAsync</summary>
+        public async Task MethodResourceSignature1Async()
+        {
+            // Snippet: MethodResourceSignatureAsync(string, string, string, CallSettings)
+            // Additional: MethodResourceSignatureAsync(string, string, string, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            string firstName = "items/[ITEM_ID]";
+            string secondName = "items/[ITEM_ID]";
+            string thirdName = "items/[ITEM_ID]";
+            // Make the request
+            Response response = await snippetsClient.MethodResourceSignatureAsync(firstName, secondName, thirdName);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature1ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature1ResourceNamesAsyncSnippet.g.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodResourceSignatureAsync</summary>
+        public async Task MethodResourceSignature1ResourceNamesAsync()
+        {
+            // Snippet: MethodResourceSignatureAsync(SimpleResourceName, SimpleResourceName, SimpleResourceName, CallSettings)
+            // Additional: MethodResourceSignatureAsync(SimpleResourceName, SimpleResourceName, SimpleResourceName, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
+            SimpleResourceName secondName = SimpleResourceName.FromItem("[ITEM_ID]");
+            SimpleResourceName thirdName = SimpleResourceName.FromItem("[ITEM_ID]");
+            // Make the request
+            Response response = await snippetsClient.MethodResourceSignatureAsync(firstName, secondName, thirdName);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature1ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature1ResourceNamesSnippet.g.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodResourceSignature</summary>
+        public void MethodResourceSignature1ResourceNames()
+        {
+            // Snippet: MethodResourceSignature(SimpleResourceName, SimpleResourceName, SimpleResourceName, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
+            SimpleResourceName secondName = SimpleResourceName.FromItem("[ITEM_ID]");
+            SimpleResourceName thirdName = SimpleResourceName.FromItem("[ITEM_ID]");
+            // Make the request
+            Response response = snippetsClient.MethodResourceSignature(firstName, secondName, thirdName);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature1Snippet.g.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodResourceSignature</summary>
+        public void MethodResourceSignature1()
+        {
+            // Snippet: MethodResourceSignature(string, string, string, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            string firstName = "items/[ITEM_ID]";
+            string secondName = "items/[ITEM_ID]";
+            string thirdName = "items/[ITEM_ID]";
+            // Make the request
+            Response response = snippetsClient.MethodResourceSignature(firstName, secondName, thirdName);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature2AsyncSnippet.g.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodResourceSignatureAsync</summary>
+        public async Task MethodResourceSignature2Async()
+        {
+            // Snippet: MethodResourceSignatureAsync(string, CallSettings)
+            // Additional: MethodResourceSignatureAsync(string, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            string firstName = "items/[ITEM_ID]";
+            // Make the request
+            Response response = await snippetsClient.MethodResourceSignatureAsync(firstName);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature2ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature2ResourceNamesAsyncSnippet.g.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodResourceSignatureAsync</summary>
+        public async Task MethodResourceSignature2ResourceNamesAsync()
+        {
+            // Snippet: MethodResourceSignatureAsync(SimpleResourceName, CallSettings)
+            // Additional: MethodResourceSignatureAsync(SimpleResourceName, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
+            // Make the request
+            Response response = await snippetsClient.MethodResourceSignatureAsync(firstName);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature2ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature2ResourceNamesSnippet.g.cs
@@ -1,0 +1,34 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodResourceSignature</summary>
+        public void MethodResourceSignature2ResourceNames()
+        {
+            // Snippet: MethodResourceSignature(SimpleResourceName, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
+            // Make the request
+            Response response = snippetsClient.MethodResourceSignature(firstName);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature2Snippet.g.cs
@@ -1,0 +1,34 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodResourceSignature</summary>
+        public void MethodResourceSignature2()
+        {
+            // Snippet: MethodResourceSignature(string, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            string firstName = "items/[ITEM_ID]";
+            // Make the request
+            Response response = snippetsClient.MethodResourceSignature(firstName);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignatureRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignatureRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodResourceSignatureAsync</summary>
+        public async Task MethodResourceSignatureRequestObjectAsync()
+        {
+            // Snippet: MethodResourceSignatureAsync(ResourceSignatureRequest, CallSettings)
+            // Additional: MethodResourceSignatureAsync(ResourceSignatureRequest, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            ResourceSignatureRequest request = new ResourceSignatureRequest
+            {
+                FirstNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                SecondNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                ThirdNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+            };
+            // Make the request
+            Response response = await snippetsClient.MethodResourceSignatureAsync(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignatureRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignatureRequestObjectSnippet.g.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodResourceSignature</summary>
+        public void MethodResourceSignatureRequestObject()
+        {
+            // Snippet: MethodResourceSignature(ResourceSignatureRequest, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            ResourceSignatureRequest request = new ResourceSignatureRequest
+            {
+                FirstNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                SecondNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                ThirdNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+            };
+            // Make the request
+            Response response = snippetsClient.MethodResourceSignature(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreaming1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreaming1Snippet.g.cs
@@ -1,0 +1,48 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using Google.Api.Gax.Grpc;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodServerStreaming</summary>
+        public async Task MethodServerStreaming1()
+        {
+            // Snippet: MethodServerStreaming(string, bool, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            string aString = "";
+            bool aBool = false;
+            // Make the request, returning a streaming response
+            SnippetsClient.MethodServerStreamingStream response = snippetsClient.MethodServerStreaming(aString, aBool);
+
+            // Read streaming responses from server until complete
+            // Note that C# 8 code can use await foreach
+            AsyncResponseStream<Response> responseStream = response.GetResponseStream();
+            while (await responseStream.MoveNextAsync())
+            {
+                Response responseItem = responseStream.Current;
+                // Do something with streamed response
+            }
+            // The response stream has completed
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreaming2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreaming2Snippet.g.cs
@@ -1,0 +1,45 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using Google.Api.Gax.Grpc;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodServerStreaming</summary>
+        public async Task MethodServerStreaming2()
+        {
+            // Snippet: MethodServerStreaming(CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Make the request, returning a streaming response
+            SnippetsClient.MethodServerStreamingStream response = snippetsClient.MethodServerStreaming();
+
+            // Read streaming responses from server until complete
+            // Note that C# 8 code can use await foreach
+            AsyncResponseStream<Response> responseStream = response.GetResponseStream();
+            while (await responseStream.MoveNextAsync())
+            {
+                Response responseItem = responseStream.Current;
+                // Do something with streamed response
+            }
+            // The response stream has completed
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreamingRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreamingRequestObjectSnippet.g.cs
@@ -1,0 +1,53 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using Google.Api.Gax.Grpc;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodServerStreaming</summary>
+        public async Task MethodServerStreamingRequestObject()
+        {
+            // Snippet: MethodServerStreaming(SignatureRequest, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            SignatureRequest request = new SignatureRequest
+            {
+                AString = "",
+                AnInt = 0,
+                ABool = false,
+                MapIntString = { { 0, "" }, },
+            };
+            // Make the request, returning a streaming response
+            SnippetsClient.MethodServerStreamingStream response = snippetsClient.MethodServerStreaming(request);
+
+            // Read streaming responses from server until complete
+            // Note that C# 8 code can use await foreach
+            AsyncResponseStream<Response> responseStream = response.GetResponseStream();
+            while (await responseStream.MoveNextAsync())
+            {
+                Response responseItem = responseStream.Current;
+                // Do something with streamed response
+            }
+            // The response stream has completed
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreamingResourcesRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreamingResourcesRequestObjectSnippet.g.cs
@@ -1,0 +1,52 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using Google.Api.Gax.Grpc;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodServerStreamingResources</summary>
+        public async Task MethodServerStreamingResourcesRequestObject()
+        {
+            // Snippet: MethodServerStreamingResources(ResourceSignatureRequest, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            ResourceSignatureRequest request = new ResourceSignatureRequest
+            {
+                FirstNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                SecondNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                ThirdNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+            };
+            // Make the request, returning a streaming response
+            SnippetsClient.MethodServerStreamingResourcesStream response = snippetsClient.MethodServerStreamingResources(request);
+
+            // Read streaming responses from server until complete
+            // Note that C# 8 code can use await foreach
+            AsyncResponseStream<Response> responseStream = response.GetResponseStream();
+            while (await responseStream.MoveNextAsync())
+            {
+                Response responseItem = responseStream.Current;
+                // Do something with streamed response
+            }
+            // The response stream has completed
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreamingResourcesResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreamingResourcesResourceNamesSnippet.g.cs
@@ -1,0 +1,49 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using Google.Api.Gax.Grpc;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodServerStreamingResources</summary>
+        public async Task MethodServerStreamingResourcesResourceNames()
+        {
+            // Snippet: MethodServerStreamingResources(SimpleResourceName, SimpleResourceName, SimpleResourceName, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
+            SimpleResourceName secondName = SimpleResourceName.FromItem("[ITEM_ID]");
+            SimpleResourceName thirdName = SimpleResourceName.FromItem("[ITEM_ID]");
+            // Make the request, returning a streaming response
+            SnippetsClient.MethodServerStreamingResourcesStream response = snippetsClient.MethodServerStreamingResources(firstName, secondName, thirdName);
+
+            // Read streaming responses from server until complete
+            // Note that C# 8 code can use await foreach
+            AsyncResponseStream<Response> responseStream = response.GetResponseStream();
+            while (await responseStream.MoveNextAsync())
+            {
+                Response responseItem = responseStream.Current;
+                // Do something with streamed response
+            }
+            // The response stream has completed
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreamingResourcesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreamingResourcesSnippet.g.cs
@@ -1,0 +1,49 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using Google.Api.Gax.Grpc;
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodServerStreamingResources</summary>
+        public async Task MethodServerStreamingResources()
+        {
+            // Snippet: MethodServerStreamingResources(string, string, string, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            string firstName = "items/[ITEM_ID]";
+            string secondName = "items/[ITEM_ID]";
+            string thirdName = "items/[ITEM_ID]";
+            // Make the request, returning a streaming response
+            SnippetsClient.MethodServerStreamingResourcesStream response = snippetsClient.MethodServerStreamingResources(firstName, secondName, thirdName);
+
+            // Read streaming responses from server until complete
+            // Note that C# 8 code can use await foreach
+            AsyncResponseStream<Response> responseStream = response.GetResponseStream();
+            while (await responseStream.MoveNextAsync())
+            {
+                Response responseItem = responseStream.Current;
+                // Do something with streamed response
+            }
+            // The response stream has completed
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures1AsyncSnippet.g.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodThreeSignaturesAsync</summary>
+        public async Task MethodThreeSignatures1Async()
+        {
+            // Snippet: MethodThreeSignaturesAsync(string, int, bool, CallSettings)
+            // Additional: MethodThreeSignaturesAsync(string, int, bool, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            string aString = "";
+            int anInt = 0;
+            bool aBool = false;
+            // Make the request
+            Response response = await snippetsClient.MethodThreeSignaturesAsync(aString, anInt, aBool);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures1Snippet.g.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodThreeSignatures</summary>
+        public void MethodThreeSignatures1()
+        {
+            // Snippet: MethodThreeSignatures(string, int, bool, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            string aString = "";
+            int anInt = 0;
+            bool aBool = false;
+            // Make the request
+            Response response = snippetsClient.MethodThreeSignatures(aString, anInt, aBool);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures2AsyncSnippet.g.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodThreeSignaturesAsync</summary>
+        public async Task MethodThreeSignatures2Async()
+        {
+            // Snippet: MethodThreeSignaturesAsync(string, bool, CallSettings)
+            // Additional: MethodThreeSignaturesAsync(string, bool, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            string aString = "";
+            bool aBool = false;
+            // Make the request
+            Response response = await snippetsClient.MethodThreeSignaturesAsync(aString, aBool);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures2Snippet.g.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodThreeSignatures</summary>
+        public void MethodThreeSignatures2()
+        {
+            // Snippet: MethodThreeSignatures(string, bool, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            string aString = "";
+            bool aBool = false;
+            // Make the request
+            Response response = snippetsClient.MethodThreeSignatures(aString, aBool);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures3AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures3AsyncSnippet.g.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodThreeSignaturesAsync</summary>
+        public async Task MethodThreeSignatures3Async()
+        {
+            // Snippet: MethodThreeSignaturesAsync(CallSettings)
+            // Additional: MethodThreeSignaturesAsync(CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Make the request
+            Response response = await snippetsClient.MethodThreeSignaturesAsync();
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures3Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures3Snippet.g.cs
@@ -1,0 +1,32 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodThreeSignatures</summary>
+        public void MethodThreeSignatures3()
+        {
+            // Snippet: MethodThreeSignatures(CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Make the request
+            Response response = snippetsClient.MethodThreeSignatures();
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignaturesRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignaturesRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodThreeSignaturesAsync</summary>
+        public async Task MethodThreeSignaturesRequestObjectAsync()
+        {
+            // Snippet: MethodThreeSignaturesAsync(SignatureRequest, CallSettings)
+            // Additional: MethodThreeSignaturesAsync(SignatureRequest, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            SignatureRequest request = new SignatureRequest
+            {
+                AString = "",
+                AnInt = 0,
+                ABool = false,
+                MapIntString = { { 0, "" }, },
+            };
+            // Make the request
+            Response response = await snippetsClient.MethodThreeSignaturesAsync(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignaturesRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignaturesRequestObjectSnippet.g.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for MethodThreeSignatures</summary>
+        public void MethodThreeSignaturesRequestObject()
+        {
+            // Snippet: MethodThreeSignatures(SignatureRequest, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            SignatureRequest request = new SignatureRequest
+            {
+                AString = "",
+                AnInt = 0,
+                ABool = false,
+                MapIntString = { { 0, "" }, },
+            };
+            // Make the request
+            Response response = snippetsClient.MethodThreeSignatures(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.TaskMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.TaskMethodRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    using System.Threading.Tasks;
+    using ts = Testing.Snippets;
+
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for TaskMethodAsync</summary>
+        public async Task TaskMethodRequestObjectAsync()
+        {
+            // Snippet: TaskMethodAsync(Task, CallSettings)
+            // Additional: TaskMethodAsync(Task, CancellationToken)
+            // Create client
+            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            // Initialize request argument(s)
+            ts::Task request = new ts::Task { };
+            // Make the request
+            ts::Task response = await snippetsClient.TaskMethodAsync(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.TaskMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.TaskMethodRequestObjectSnippet.g.cs
@@ -1,0 +1,34 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.Snippets.Snippets
+{
+    public sealed partial class GeneratedSnippetsClientStandaloneSnippets
+    {
+        /// <summary>Snippet for TaskMethod</summary>
+        public void TaskMethodRequestObject()
+        {
+            // Snippet: TaskMethod(Task, CallSettings)
+            // Create client
+            SnippetsClient snippetsClient = SnippetsClient.Create();
+            // Initialize request argument(s)
+            Task request = new Task { };
+            // Make the request
+            Task response = snippetsClient.TaskMethod(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodAsyncSnippet.g.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.VoidReturn.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedVoidReturnClientStandaloneSnippets
+    {
+        /// <summary>Snippet for VoidMethodAsync</summary>
+        public async Task VoidMethodAsync()
+        {
+            // Snippet: VoidMethodAsync(string, CallSettings)
+            // Additional: VoidMethodAsync(string, CancellationToken)
+            // Create client
+            VoidReturnClient voidReturnClient = await VoidReturnClient.CreateAsync();
+            // Initialize request argument(s)
+            string name = "items/[ITEM_ID]";
+            // Make the request
+            await voidReturnClient.VoidMethodAsync(name);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.VoidReturn.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedVoidReturnClientStandaloneSnippets
+    {
+        /// <summary>Snippet for VoidMethodAsync</summary>
+        public async Task VoidMethodRequestObjectAsync()
+        {
+            // Snippet: VoidMethodAsync(Request, CallSettings)
+            // Additional: VoidMethodAsync(Request, CancellationToken)
+            // Create client
+            VoidReturnClient voidReturnClient = await VoidReturnClient.CreateAsync();
+            // Initialize request argument(s)
+            Request request = new Request
+            {
+                ResourceName = ResourceName.FromItem("[ITEM_ID]"),
+            };
+            // Make the request
+            await voidReturnClient.VoidMethodAsync(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodRequestObjectSnippet.g.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.VoidReturn.Snippets
+{
+    public sealed partial class GeneratedVoidReturnClientStandaloneSnippets
+    {
+        /// <summary>Snippet for VoidMethod</summary>
+        public void VoidMethodRequestObject()
+        {
+            // Snippet: VoidMethod(Request, CallSettings)
+            // Create client
+            VoidReturnClient voidReturnClient = VoidReturnClient.Create();
+            // Initialize request argument(s)
+            Request request = new Request
+            {
+                ResourceName = ResourceName.FromItem("[ITEM_ID]"),
+            };
+            // Make the request
+            voidReturnClient.VoidMethod(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodResourceNamesAsyncSnippet.g.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.VoidReturn.Snippets
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class GeneratedVoidReturnClientStandaloneSnippets
+    {
+        /// <summary>Snippet for VoidMethodAsync</summary>
+        public async Task VoidMethodResourceNamesAsync()
+        {
+            // Snippet: VoidMethodAsync(ResourceName, CallSettings)
+            // Additional: VoidMethodAsync(ResourceName, CancellationToken)
+            // Create client
+            VoidReturnClient voidReturnClient = await VoidReturnClient.CreateAsync();
+            // Initialize request argument(s)
+            ResourceName name = ResourceName.FromItem("[ITEM_ID]");
+            // Make the request
+            await voidReturnClient.VoidMethodAsync(name);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodResourceNamesSnippet.g.cs
@@ -1,0 +1,34 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.VoidReturn.Snippets
+{
+    public sealed partial class GeneratedVoidReturnClientStandaloneSnippets
+    {
+        /// <summary>Snippet for VoidMethod</summary>
+        public void VoidMethodResourceNames()
+        {
+            // Snippet: VoidMethod(ResourceName, CallSettings)
+            // Create client
+            VoidReturnClient voidReturnClient = VoidReturnClient.Create();
+            // Initialize request argument(s)
+            ResourceName name = ResourceName.FromItem("[ITEM_ID]");
+            // Make the request
+            voidReturnClient.VoidMethod(name);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodSnippet.g.cs
@@ -1,0 +1,34 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.VoidReturn.Snippets
+{
+    public sealed partial class GeneratedVoidReturnClientStandaloneSnippets
+    {
+        /// <summary>Snippet for VoidMethod</summary>
+        public void VoidMethod()
+        {
+            // Snippet: VoidMethod(string, CallSettings)
+            // Create client
+            VoidReturnClient voidReturnClient = VoidReturnClient.Create();
+            // Initialize request argument(s)
+            string name = "items/[ITEM_ID]";
+            // Make the request
+            voidReturnClient.VoidMethod(name);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator/Generation/ServiceDetails.cs
+++ b/Google.Api.Generator/Generation/ServiceDetails.cs
@@ -54,6 +54,7 @@ namespace Google.Api.Generator.Generation
             DefaultScopes = string.IsNullOrEmpty(oauthScopes) ? Enumerable.Empty<string>() : oauthScopes.Split(',', ' ');
             Methods = desc.Methods.Select(x => MethodDetails.Create(this, x)).ToList();
             SnippetsTyp = Typ.Manual(SnippetsNamespace, $"Generated{desc.Name}ClientSnippets");
+            StandaloneSnippetsTyp = Typ.Manual(SnippetsNamespace, $"Generated{desc.Name}ClientStandaloneSnippets");
             SnippetsClientName = $"{desc.Name.ToLowerCamelCase()}Client";
             UnitTestsTyp = Typ.Manual(UnitTestsNamespace, $"Generated{desc.Name}ClientTest");
         }
@@ -104,6 +105,9 @@ namespace Google.Api.Generator.Generation
 
         /// <summary>The typ of the snippets class for this service.</summary>
         public Typ SnippetsTyp { get; }
+
+        /// <summary>The typ of the standalone snippets class for this service.</summary>
+        public Typ StandaloneSnippetsTyp { get; }
 
         /// <summary>The name of the variable to hold the client instance.</summary>
         public string SnippetsClientName { get; }


### PR DESCRIPTION
Existing, single file generation continues until standalone generation is cleanned and standalone snippets are the ones used for docs.
The second commit is big, but it consists mainly of splitting the existing expected output files for snippet into single files, the generate method code hasn't changed. It's probably worth it to review just a sample of those files.
More PRs are comming after this one for adding region tags, some comments, etc. But better to review this one on its own, which is the one doing the per file splitting.
I'll share internally the design doc shortly.
