### PR TITLE
(REST) Make DownloadRange use the MediaDownloader

### DIFF
--- a/Google.Api.Generator.Rest/CodeGenerator.cs
+++ b/Google.Api.Generator.Rest/CodeGenerator.cs
@@ -85,10 +85,15 @@ namespace Google.Api.Generator.Rest
             InsertLine("/// <summary>Gets the batch base URI; <c>null</c> if unspecified.</summary>", 0, "#if !NET40");
             InsertLine("public override string BatchPath =>", 1, "#endif");
 
+            // We clear the range in all download methods for non-obsolete platforms, but the old support library
+            // doesn't have the Range property.
+            InsertLine("mediaDownloader.Range = null;", 0, "#if !NET40");
+            InsertLine("mediaDownloader.Range = null;", 1, "#endif");
+
             InsertLine("/// <summary>Synchronously download a range of the media into the given stream.</summary>", 0, "#if !NET40");
-            // We need to insert the line two lines lower, after the closing } of the method
-            // Note that the additional spaces here are to ensure that the #endif lines up with the brace instead of the return statement.
-            InsertLine("    return mediaDownloader.DownloadAsync(this.GenerateRequestUri(), stream, cancellationToken);", 2, "#endif");
+            // We need to insert the line, after the closing } of the method. We can't use the code to detect the method, as
+            // the same statements are used in multiple methods.
+            InsertLine("public virtual System.Threading.Tasks.Task<Google.Apis.Download.IDownloadProgress> DownloadRangeAsync", 8, "#endif");
 
             string separator = usesCarriageReturn ? "\r\n" : "\n";
             return string.Join(separator, lines);


### PR DESCRIPTION
This will allow users to subscribe to progress (and make other
configuration changes) when performing ranged downloads.

Tested by:

- Regenerating all APIs in google-api-dotnet-client (succeeds)
- Rebuilding them all (succeeds)
- Checking the changes (all MediaDownloader-related)
- Building a local Storage package
- Using the ProgressChanged event handler as expected:

```csharp
var obj = client.Objects.Get(bucketName, objectName);
obj.MediaDownloader.ProgressChanged += MediaDownloader_ProgressChanged;
obj.MediaDownloader.ChunkSize = 5000;
obj.DownloadRange(new MemoryStream(), new System.Net.Http.Headers.RangeHeaderValue(100, 50_000_000));
```

This will address https://github.com/googleapis/google-api-dotnet-client/issues/1784

Strictly speaking it's a breaking change in that if someone were already modifying the MediaDownloader then using the DownloadRange method, they'll see the difference - but it's much more consistent than before, and I'd be very surprised to see it cause an issue.