### PR TITLE
REST: Persist enum values in a JSON file

### DIFF
--- a/Google.Api.Generator.Rest.Tests/PackageEnumStorageTest.cs
+++ b/Google.Api.Generator.Rest.Tests/PackageEnumStorageTest.cs
@@ -1,0 +1,61 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Xunit;
+
+namespace Google.Api.Generator.Rest.Tests
+{
+    public class PackageEnumStorageTest
+    {
+        [Fact]
+        public void SimulatedOrderingChange()
+        {
+            string key = Guid.NewGuid().ToString();
+
+            // First run: values [ "zero", "one", "two" ]
+            var storage = PackageEnumStorage.FromJson("{}");
+            Assert.Equal(0, storage.GetOrAddEnumValue(key, "zero"));
+            Assert.Equal(1, storage.GetOrAddEnumValue(key, "one"));
+            Assert.Equal(2, storage.GetOrAddEnumValue(key, "two"));
+            string json = storage.ToJson();
+
+            // Second run: values [ "two", "zero", "one", "three" ]
+            storage = PackageEnumStorage.FromJson(json);
+            Assert.Equal(2, storage.GetOrAddEnumValue(key, "two"));
+            Assert.Equal(0, storage.GetOrAddEnumValue(key, "zero"));
+            Assert.Equal(1, storage.GetOrAddEnumValue(key, "one"));
+            Assert.Equal(3, storage.GetOrAddEnumValue(key, "three"));
+        }
+
+        [Fact]
+        public void KeysAreIndependent()
+        {
+            string key1 = Guid.NewGuid().ToString();
+            string key2 = Guid.NewGuid().ToString();
+
+            var storage = PackageEnumStorage.FromJson("{}");
+            Assert.Equal(0, storage.GetOrAddEnumValue(key1, "x"));
+            Assert.Equal(1, storage.GetOrAddEnumValue(key1, "y"));
+
+            // The "y" value from key 1 shouldn't affect key 2
+            Assert.Equal(0, storage.GetOrAddEnumValue(key2, "y"));
+            Assert.Equal(1, storage.GetOrAddEnumValue(key2, "z"));
+
+            // Back to key 1, where the "z" value from key 2 shouldn't
+            // affect it
+            Assert.Equal(2, storage.GetOrAddEnumValue(key1, "z"));
+        }
+    }
+}

--- a/Google.Api.Generator.Rest.Tests/TestResources.cs
+++ b/Google.Api.Generator.Rest.Tests/TestResources.cs
@@ -49,7 +49,8 @@ namespace Google.Api.Generator.Rest.Tests
                 Net40SupportVersion = "1.25.0",
                 PclSupportVersion = "1.10.0"
             };
-            var files = CodeGenerator.Generate(json, features).ToList();
+            PackageEnumStorage enumStorage = PackageEnumStorage.FromJson("{}");
+            var files = CodeGenerator.Generate(json, features, enumStorage).ToList();
             // Check output is present.
             Assert.NotEmpty(files);
 
@@ -64,6 +65,8 @@ namespace Google.Api.Generator.Rest.Tests
 
                 TextComparer.CompareText(expectedFilePath, file);
             }
+
+            // TODO: Validate enum storage
         }
     }
 }

--- a/Google.Api.Generator.Rest/CodeGenerator.cs
+++ b/Google.Api.Generator.Rest/CodeGenerator.cs
@@ -27,13 +27,13 @@ namespace Google.Api.Generator.Rest
 {
     internal class CodeGenerator
     {
-        public static IEnumerable<ResultFile> Generate(string discoveryJson, Features features)
+        public static IEnumerable<ResultFile> Generate(string discoveryJson, Features features, PackageEnumStorage enumStorage)
         {
             discoveryJson = NormalizeDescriptions(discoveryJson);
 
             var discoveryDescription = NewtonsoftJsonSerializer.Instance.Deserialize<RestDescription>(discoveryJson);
 
-            var package = new PackageModel(discoveryDescription, features);
+            var package = new PackageModel(discoveryDescription, features, enumStorage);
             yield return GenerateCSharpCode(package);
             yield return GenerateProjectFile(package);
             yield return GenerateNet40Config(package);

--- a/Google.Api.Generator.Rest/Models/EnumMemberModel.cs
+++ b/Google.Api.Generator.Rest/Models/EnumMemberModel.cs
@@ -40,17 +40,22 @@ namespace Google.Api.Generator.Rest.Models
         /// </summary>
         private string Description { get; }
 
-        public EnumMemberModel(string value, string description)
+        /// <summary>
+        /// The integer value of the enum.
+        /// </summary>
+        private int NumericValue { get; }
+
+        public EnumMemberModel(string textValue, string description, int numericValue)
         {
-            OriginalValue = value;
-            MemberName = value.ToMemberName();
+            OriginalValue = textValue;
+            MemberName = textValue.ToMemberName();
             Description = description;
+            NumericValue = numericValue;
         }
 
         public EnumMemberDeclarationSyntax GenerateDeclaration(SourceFileContext ctx)
         {
-            var declaration =
-            EnumMember(MemberName)
+            var declaration = EnumMember(MemberName, NumericValue)
                 .WithAttribute(ctx.Type<StringValueAttribute>())(OriginalValue);
             if (Description is object)
             {

--- a/Google.Api.Generator.Rest/Models/EnumModel.cs
+++ b/Google.Api.Generator.Rest/Models/EnumModel.cs
@@ -42,15 +42,18 @@ namespace Google.Api.Generator.Rest.Models
         /// </summary>
         private string TypeName { get; }
 
-        public EnumModel(string name, JsonSchema schema)
+        public EnumModel(PackageModel package, Typ parentTyp, string name, JsonSchema schema)
         {
             IList<string> values = schema.Enum__;
             IList<string> description = schema.EnumDescriptions;
             Description = schema.Description;
             TypeName = name.ToMemberName() + "Enum";
+            // The exact value of the key doesn't particularly matter, so long as it's unique.
+            // This should be fine.
+            string enumStorageKey = $"{parentTyp.FullName}.{TypeName}";
             Members = schema.Enum__
-                .Zip(schema.EnumDescriptions ?? Enumerable.Repeat((string) null, schema.Enum__.Count))
-                .ToReadOnlyList(pair => new EnumMemberModel(pair.First, pair.Second));
+                .Zip(schema.EnumDescriptions ?? Enumerable.Repeat((string) null, schema.Enum__.Count), (text, description) => (text, description))
+                .ToReadOnlyList(pair => new EnumMemberModel(pair.text, pair.description, package.PackageEnumStorage.GetOrAddEnumValue(enumStorageKey, pair.text)));
         }
 
         public EnumDeclarationSyntax GenerateDeclaration(SourceFileContext ctx)

--- a/Google.Api.Generator.Rest/Models/PackageModel.cs
+++ b/Google.Api.Generator.Rest/Models/PackageModel.cs
@@ -93,7 +93,12 @@ namespace Google.Api.Generator.Rest.Models
         /// </summary>
         internal Typ ServiceTyp { get; }
 
-        public PackageModel(RestDescription discoveryDoc, Features features)
+        /// <summary>
+        /// Persistent storage for the package.
+        /// </summary>
+        internal PackageEnumStorage PackageEnumStorage { get; }
+
+        public PackageModel(RestDescription discoveryDoc, Features features, PackageEnumStorage enumStorage)
         {
             _features = features;
             _discoveryDoc = discoveryDoc;
@@ -122,6 +127,7 @@ namespace Google.Api.Generator.Rest.Models
             ServiceTyp = Typ.Manual(PackageName, $"{ClassName}Service");
             GenericBaseRequestTypDef = Typ.Manual(PackageName, $"{ClassName}BaseServiceRequest");
             Methods = discoveryDoc.Methods.ToReadOnlyList(pair => new MethodModel(this, null, pair.Key, pair.Value));
+            PackageEnumStorage = enumStorage;
         }
 
         internal CompilationUnitSyntax GenerateCompilationUnit()

--- a/Google.Api.Generator.Rest/Models/ParameterModel.cs
+++ b/Google.Api.Generator.Rest/Models/ParameterModel.cs
@@ -78,7 +78,7 @@ namespace Google.Api.Generator.Rest.Models
                 "path" => RequestParameterType.Path,
                 _ => throw new InvalidOperationException($"Unhandled parameter location: '{_schema.Location}'")
             };
-            EnumModel = schema.Enum__ is object ? new EnumModel(name, schema) : null;
+            EnumModel = schema.Enum__ is object ? new EnumModel(package, parentTyp, name, schema) : null;
             _schema = schema;
             Typ = SchemaTypes.GetTypFromSchema(package, schema, name, currentTyp: parentTyp, inParameter: true);
         }

--- a/Google.Api.Generator.Rest/PackageEnumStorage.cs
+++ b/Google.Api.Generator.Rest/PackageEnumStorage.cs
@@ -1,0 +1,65 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Google.Api.Generator.Rest
+{
+    /// <summary>
+    /// The stored values of enums for parameters within a package model.
+    /// These need to be persisted so that we can avoid taking breaking changes if the Discovery doc
+    /// reorders enum values over time.
+    /// </summary>
+    public class PackageEnumStorage
+    {
+        // Note: this is sorted just to keep things idempotent.
+        private readonly SortedDictionary<string, List<string>> _nameToValuesMap;
+
+        private PackageEnumStorage(SortedDictionary<string, List<string>> nameToValuesMap) =>
+            _nameToValuesMap = nameToValuesMap;
+
+        /// <summary>
+        /// Returns the numeric value to use for the given text value. This is drawn from the existing
+        /// values if the text value is already present, or added to the internal representation and
+        /// given the next available numeric value otherwise.
+        /// </summary>
+        /// <param name="key">The key associated with the enum. This must be unique (and always generated in the same way)
+        /// but otherwise has no specific meaning.</param>
+        /// <param name="originalTextValue">The original text value in the Discovery doc</param>
+        /// <returns>The value to assign to the enum member.</returns>
+        internal int GetOrAddEnumValue(string key, string originalTextValue)
+        {
+            if (!_nameToValuesMap.TryGetValue(key, out var list))
+            {
+                _nameToValuesMap[key] = list = new List<string>();
+            }
+            int index = list.IndexOf(originalTextValue);
+            if (index != -1)
+            {
+                return index;
+            }
+            list.Add(originalTextValue);
+            return list.Count - 1;
+        }
+
+        internal static PackageEnumStorage FromJson(string json)
+        {
+            var dictionary = JsonConvert.DeserializeObject<SortedDictionary<string, List<string>>>(json);
+            return new PackageEnumStorage(dictionary);
+        }
+
+        internal string ToJson() => JsonConvert.SerializeObject(_nameToValuesMap, Formatting.Indented);
+    }
+}

--- a/Google.Api.Generator.Rest/Program.cs
+++ b/Google.Api.Generator.Rest/Program.cs
@@ -23,22 +23,29 @@ namespace Google.Api.Generator.Rest
     {
         static int Main(string[] args)
         {
-            if (args.Length != 3)
+            if (args.Length != 4)
             {
-                Console.WriteLine("Expected arguments: <JSON file> <output directory> <features file>");
+                Console.WriteLine("Expected arguments: <JSON file> <output directory> <features file> <enum storage file>");
                 return 1;
             }
             string json = File.ReadAllText(args[0]);
             string outputDirectory = args[1];
             string featuresJson = File.ReadAllText(args[2]);
+            
+            string enumStorageFile = args[3];
+            string enumStorageJson = File.Exists(enumStorageFile) ? File.ReadAllText(enumStorageFile) : "{}";
+            var enumStorage = PackageEnumStorage.FromJson(enumStorageJson);
+
             var features = JsonConvert.DeserializeObject<Features>(featuresJson);
-            var files = CodeGenerator.Generate(json, features);
+            var files = CodeGenerator.Generate(json, features, enumStorage);
             foreach (var file in files)
             {
                 var path = Path.Combine(outputDirectory, file.RelativePath);
                 Directory.CreateDirectory(Path.GetDirectoryName(path));
                 File.WriteAllText(path, file.Content);
             }
+
+            File.WriteAllText(enumStorageFile, enumStorage.ToJson());
             return 0;
         }
     }


### PR DESCRIPTION
This prevents enum value reorderings in the Discovery doc from being breaking changes