### PR TITLE
fix: Fixes the XML doc for paginated async snippets.

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.Snippets/PaginatedClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.Snippets/PaginatedClientSnippets.g.cs
@@ -73,7 +73,7 @@ namespace Testing.Paginated.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for SignatureMethod</summary>
+        /// <summary>Snippet for SignatureMethodAsync</summary>
         public async Task SignatureMethodRequestObjectAsync()
         {
             // Snippet: SignatureMethodAsync(Request, CallSettings)
@@ -168,7 +168,7 @@ namespace Testing.Paginated.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for SignatureMethod</summary>
+        /// <summary>Snippet for SignatureMethodAsync</summary>
         public async Task SignatureMethod1Async()
         {
             // Snippet: SignatureMethodAsync(string, int, string, int?, CallSettings)
@@ -259,7 +259,7 @@ namespace Testing.Paginated.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for SignatureMethod</summary>
+        /// <summary>Snippet for SignatureMethodAsync</summary>
         public async Task SignatureMethod2Async()
         {
             // Snippet: SignatureMethodAsync(string, string, int?, CallSettings)
@@ -347,7 +347,7 @@ namespace Testing.Paginated.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for SignatureMethod</summary>
+        /// <summary>Snippet for SignatureMethodAsync</summary>
         public async Task SignatureMethod3Async()
         {
             // Snippet: SignatureMethodAsync(string, int?, CallSettings)
@@ -439,7 +439,7 @@ namespace Testing.Paginated.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for SignatureMethod2</summary>
+        /// <summary>Snippet for SignatureMethod2Async</summary>
         public async Task SignatureMethod2RequestObjectAsync()
         {
             // Snippet: SignatureMethod2Async(Request, CallSettings)
@@ -537,7 +537,7 @@ namespace Testing.Paginated.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ResourcedMethod</summary>
+        /// <summary>Snippet for ResourcedMethodAsync</summary>
         public async Task ResourcedMethodRequestObjectAsync()
         {
             // Snippet: ResourcedMethodAsync(ResourceRequest, CallSettings)
@@ -631,7 +631,7 @@ namespace Testing.Paginated.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ResourcedMethod</summary>
+        /// <summary>Snippet for ResourcedMethodAsync</summary>
         public async Task ResourcedMethod1Async()
         {
             // Snippet: ResourcedMethodAsync(string, string, int?, CallSettings)
@@ -721,7 +721,7 @@ namespace Testing.Paginated.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ResourcedMethod</summary>
+        /// <summary>Snippet for ResourcedMethodAsync</summary>
         public async Task ResourcedMethod1ResourceNamesAsync()
         {
             // Snippet: ResourcedMethodAsync(ResourceName, string, int?, CallSettings)
@@ -812,7 +812,7 @@ namespace Testing.Paginated.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ResourcedMethod</summary>
+        /// <summary>Snippet for ResourcedMethodAsync</summary>
         public async Task ResourcedMethod2Async()
         {
             // Snippet: ResourcedMethodAsync(string, string, string, int?, CallSettings)
@@ -904,7 +904,7 @@ namespace Testing.Paginated.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ResourcedMethod</summary>
+        /// <summary>Snippet for ResourcedMethodAsync</summary>
         public async Task ResourcedMethod2ResourceNamesAsync()
         {
             // Snippet: ResourcedMethodAsync(ResourceName, string, string, int?, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1AsyncSnippet.g.cs
@@ -24,7 +24,7 @@ namespace Testing.Paginated.Snippets
 
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
-        /// <summary>Snippet for ResourcedMethod</summary>
+        /// <summary>Snippet for ResourcedMethodAsync</summary>
         public async Task ResourcedMethod1Async()
         {
             // Snippet: ResourcedMethodAsync(string, string, int?, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1ResourceNamesAsyncSnippet.g.cs
@@ -24,7 +24,7 @@ namespace Testing.Paginated.Snippets
 
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
-        /// <summary>Snippet for ResourcedMethod</summary>
+        /// <summary>Snippet for ResourcedMethodAsync</summary>
         public async Task ResourcedMethod1ResourceNamesAsync()
         {
             // Snippet: ResourcedMethodAsync(ResourceName, string, int?, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2AsyncSnippet.g.cs
@@ -24,7 +24,7 @@ namespace Testing.Paginated.Snippets
 
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
-        /// <summary>Snippet for ResourcedMethod</summary>
+        /// <summary>Snippet for ResourcedMethodAsync</summary>
         public async Task ResourcedMethod2Async()
         {
             // Snippet: ResourcedMethodAsync(string, string, string, int?, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2ResourceNamesAsyncSnippet.g.cs
@@ -24,7 +24,7 @@ namespace Testing.Paginated.Snippets
 
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
-        /// <summary>Snippet for ResourcedMethod</summary>
+        /// <summary>Snippet for ResourcedMethodAsync</summary>
         public async Task ResourcedMethod2ResourceNamesAsync()
         {
             // Snippet: ResourcedMethodAsync(ResourceName, string, string, int?, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethodRequestObjectAsyncSnippet.g.cs
@@ -24,7 +24,7 @@ namespace Testing.Paginated.Snippets
 
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
-        /// <summary>Snippet for ResourcedMethod</summary>
+        /// <summary>Snippet for ResourcedMethodAsync</summary>
         public async Task ResourcedMethodRequestObjectAsync()
         {
             // Snippet: ResourcedMethodAsync(ResourceRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod1AsyncSnippet.g.cs
@@ -24,7 +24,7 @@ namespace Testing.Paginated.Snippets
 
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
-        /// <summary>Snippet for SignatureMethod</summary>
+        /// <summary>Snippet for SignatureMethodAsync</summary>
         public async Task SignatureMethod1Async()
         {
             // Snippet: SignatureMethodAsync(string, int, string, int?, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2AsyncSnippet.g.cs
@@ -24,7 +24,7 @@ namespace Testing.Paginated.Snippets
 
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
-        /// <summary>Snippet for SignatureMethod</summary>
+        /// <summary>Snippet for SignatureMethodAsync</summary>
         public async Task SignatureMethod2Async()
         {
             // Snippet: SignatureMethodAsync(string, string, int?, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2RequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2RequestObjectAsyncSnippet.g.cs
@@ -24,7 +24,7 @@ namespace Testing.Paginated.Snippets
 
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
-        /// <summary>Snippet for SignatureMethod2</summary>
+        /// <summary>Snippet for SignatureMethod2Async</summary>
         public async Task SignatureMethod2RequestObjectAsync()
         {
             // Snippet: SignatureMethod2Async(Request, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod3AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod3AsyncSnippet.g.cs
@@ -24,7 +24,7 @@ namespace Testing.Paginated.Snippets
 
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
-        /// <summary>Snippet for SignatureMethod</summary>
+        /// <summary>Snippet for SignatureMethodAsync</summary>
         public async Task SignatureMethod3Async()
         {
             // Snippet: SignatureMethodAsync(string, int?, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethodRequestObjectAsyncSnippet.g.cs
@@ -24,7 +24,7 @@ namespace Testing.Paginated.Snippets
 
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
-        /// <summary>Snippet for SignatureMethod</summary>
+        /// <summary>Snippet for SignatureMethodAsync</summary>
         public async Task SignatureMethodRequestObjectAsync()
         {
             // Snippet: SignatureMethodAsync(Request, CallSettings)

--- a/Google.Api.Generator/Generation/SnippetCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/SnippetCodeGenerator.cs
@@ -470,7 +470,7 @@ namespace Google.Api.Generator.Generation
                         "// Store the pageToken, for when the next page is required.",
                         NextPageToken.WithInitializer(SinglePage.Access(nameof(Page<int>.NextPageToken))),
                         "// End snippet")
-                    .WithXmlDoc(XmlDoc.Summary($"Snippet for {Method.SyncMethodName}"));
+                    .WithXmlDoc(XmlDoc.Summary($"Snippet for {Method.AsyncMethodName}"));
 
             private MethodDeclarationSyntax ServerStreaming(string methodName, IEnumerable<Typ> snippetTyps, object initRequest, object makeRequest) =>
                 Method(Public | Modifier.Async, Ctx.Type<Task>(), methodName)()


### PR DESCRIPTION
This is ready for review, but it should be merged once the changes that this introduces in library generated code are in another PR in [googleapis/google-cloud-dotnet](https://github.com/googleapis/google-cloud-dotnet). I'm generating that PR just now.