### PR TITLE
feat: Adds a "generated" notice on standalone snippets

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTests/Basic/Testing.Basic.StandaloneSnippets/BasicClient.AMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic/Testing.Basic.StandaloneSnippets/BasicClient.AMethodRequestObjectAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Basic.Snippets
     public sealed partial class GeneratedBasicClientStandaloneSnippets
     {
         /// <summary>Snippet for AMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task AMethodRequestObjectAsync()
         {
             // Snippet: AMethodAsync(Request, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Basic/Testing.Basic.StandaloneSnippets/BasicClient.AMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic/Testing.Basic.StandaloneSnippets/BasicClient.AMethodRequestObjectSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Basic.Snippets
     public sealed partial class GeneratedBasicClientStandaloneSnippets
     {
         /// <summary>Snippet for AMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void AMethodRequestObject()
         {
             // Snippet: AMethod(Request, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/BasicLro/Testing.BasicLro.StandaloneSnippets/BasicLroClient.Method1RequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/BasicLro/Testing.BasicLro.StandaloneSnippets/BasicLroClient.Method1RequestObjectAsyncSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.BasicLro.Snippets
     public sealed partial class GeneratedBasicLroClientStandaloneSnippets
     {
         /// <summary>Snippet for Method1Async</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task Method1RequestObjectAsync()
         {
             // Snippet: Method1Async(Request, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/BasicLro/Testing.BasicLro.StandaloneSnippets/BasicLroClient.Method1RequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/BasicLro/Testing.BasicLro.StandaloneSnippets/BasicLroClient.Method1RequestObjectSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.BasicLro.Snippets
     public sealed partial class GeneratedBasicLroClientStandaloneSnippets
     {
         /// <summary>Snippet for Method1</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void Method1RequestObject()
         {
             // Snippet: Method1(Request, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedFieldMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedFieldMethodAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Deprecated.Snippets
     public sealed partial class GeneratedDeprecatedClientStandaloneSnippets
     {
         /// <summary>Snippet for DeprecatedFieldMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task DeprecatedFieldMethodAsync()
         {
             // Snippet: DeprecatedFieldMethodAsync(string, string, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedFieldMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedFieldMethodRequestObjectAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Deprecated.Snippets
     public sealed partial class GeneratedDeprecatedClientStandaloneSnippets
     {
         /// <summary>Snippet for DeprecatedFieldMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task DeprecatedFieldMethodRequestObjectAsync()
         {
             // Snippet: DeprecatedFieldMethodAsync(DeprecatedFieldRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedFieldMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedFieldMethodRequestObjectSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Deprecated.Snippets
     public sealed partial class GeneratedDeprecatedClientStandaloneSnippets
     {
         /// <summary>Snippet for DeprecatedFieldMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void DeprecatedFieldMethodRequestObject()
         {
             // Snippet: DeprecatedFieldMethod(DeprecatedFieldRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedFieldMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedFieldMethodSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Deprecated.Snippets
     public sealed partial class GeneratedDeprecatedClientStandaloneSnippets
     {
         /// <summary>Snippet for DeprecatedFieldMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void DeprecatedFieldMethod()
         {
             // Snippet: DeprecatedFieldMethod(string, string, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedMessageMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedMessageMethodRequestObjectAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Deprecated.Snippets
     public sealed partial class GeneratedDeprecatedClientStandaloneSnippets
     {
         /// <summary>Snippet for DeprecatedMessageMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task DeprecatedMessageMethodRequestObjectAsync()
         {
             // Snippet: DeprecatedMessageMethodAsync(DeprecatedMessageRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedMessageMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedMessageMethodRequestObjectSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Deprecated.Snippets
     public sealed partial class GeneratedDeprecatedClientStandaloneSnippets
     {
         /// <summary>Snippet for DeprecatedMessageMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void DeprecatedMessageMethodRequestObject()
         {
             // Snippet: DeprecatedMessageMethod(DeprecatedMessageRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedMethodRequestObjectAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Deprecated.Snippets
     public sealed partial class GeneratedDeprecatedClientStandaloneSnippets
     {
         /// <summary>Snippet for DeprecatedMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task DeprecatedMethodRequestObjectAsync()
         {
             // Snippet: DeprecatedMethodAsync(Request, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedMethodRequestObjectSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Deprecated.Snippets
     public sealed partial class GeneratedDeprecatedClientStandaloneSnippets
     {
         /// <summary>Snippet for DeprecatedMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void DeprecatedMethodRequestObject()
         {
             // Snippet: DeprecatedMethod(Request, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedResponseMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedResponseMethodRequestObjectAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Deprecated.Snippets
     public sealed partial class GeneratedDeprecatedClientStandaloneSnippets
     {
         /// <summary>Snippet for DeprecatedResponseMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task DeprecatedResponseMethodRequestObjectAsync()
         {
             // Snippet: DeprecatedResponseMethodAsync(Request, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedResponseMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedResponseMethodRequestObjectSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Deprecated.Snippets
     public sealed partial class GeneratedDeprecatedClientStandaloneSnippets
     {
         /// <summary>Snippet for DeprecatedResponseMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void DeprecatedResponseMethodRequestObject()
         {
             // Snippet: DeprecatedResponseMethod(Request, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1AsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Keywords.Snippets
     public sealed partial class GeneratedKeywordsClientStandaloneSnippets
     {
         /// <summary>Snippet for Method1Async</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task Method1Async()
         {
             // Snippet: Method1Async(string, int, Enum, string, string, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1RequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1RequestObjectAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Keywords.Snippets
     public sealed partial class GeneratedKeywordsClientStandaloneSnippets
     {
         /// <summary>Snippet for Method1Async</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task Method1RequestObjectAsync()
         {
             // Snippet: Method1Async(Request, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1RequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1RequestObjectSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Keywords.Snippets
     public sealed partial class GeneratedKeywordsClientStandaloneSnippets
     {
         /// <summary>Snippet for Method1</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void Method1RequestObject()
         {
             // Snippet: Method1(Request, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1ResourceNamesAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Keywords.Snippets
     public sealed partial class GeneratedKeywordsClientStandaloneSnippets
     {
         /// <summary>Snippet for Method1Async</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task Method1ResourceNamesAsync()
         {
             // Snippet: Method1Async(ResourceName, int, Enum, string, string, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1ResourceNamesSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Keywords.Snippets
     public sealed partial class GeneratedKeywordsClientStandaloneSnippets
     {
         /// <summary>Snippet for Method1</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void Method1ResourceNames()
         {
             // Snippet: Method1(ResourceName, int, Enum, string, string, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1Snippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Keywords.Snippets
     public sealed partial class GeneratedKeywordsClientStandaloneSnippets
     {
         /// <summary>Snippet for Method1</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void Method1()
         {
             // Snippet: Method1(string, int, Enum, string, string, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2AsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Keywords.Snippets
     public sealed partial class GeneratedKeywordsClientStandaloneSnippets
     {
         /// <summary>Snippet for Method2Async</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task Method2Async()
         {
             // Snippet: Method2Async(string, Enum, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2RequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2RequestObjectAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Keywords.Snippets
     public sealed partial class GeneratedKeywordsClientStandaloneSnippets
     {
         /// <summary>Snippet for Method2Async</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task Method2RequestObjectAsync()
         {
             // Snippet: Method2Async(Resource, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2RequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2RequestObjectSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Keywords.Snippets
     public sealed partial class GeneratedKeywordsClientStandaloneSnippets
     {
         /// <summary>Snippet for Method2</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void Method2RequestObject()
         {
             // Snippet: Method2(Resource, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2ResourceNamesAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Keywords.Snippets
     public sealed partial class GeneratedKeywordsClientStandaloneSnippets
     {
         /// <summary>Snippet for Method2Async</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task Method2ResourceNamesAsync()
         {
             // Snippet: Method2Async(ResourceName, Enum, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2ResourceNamesSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Keywords.Snippets
     public sealed partial class GeneratedKeywordsClientStandaloneSnippets
     {
         /// <summary>Snippet for Method2</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void Method2ResourceNames()
         {
             // Snippet: Method2(ResourceName, Enum, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2Snippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Keywords.Snippets
     public sealed partial class GeneratedKeywordsClientStandaloneSnippets
     {
         /// <summary>Snippet for Method2</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void Method2()
         {
             // Snippet: Method2(string, Enum, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1AsyncSnippet.g.cs
@@ -25,6 +25,10 @@ namespace Testing.Paginated.Snippets
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
         /// <summary>Snippet for ResourcedMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task ResourcedMethod1Async()
         {
             // Snippet: ResourcedMethodAsync(string, string, int?, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1ResourceNamesAsyncSnippet.g.cs
@@ -25,6 +25,10 @@ namespace Testing.Paginated.Snippets
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
         /// <summary>Snippet for ResourcedMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task ResourcedMethod1ResourceNamesAsync()
         {
             // Snippet: ResourcedMethodAsync(ResourceName, string, int?, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1ResourceNamesSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Paginated.Snippets
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
         /// <summary>Snippet for ResourcedMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void ResourcedMethod1ResourceNames()
         {
             // Snippet: ResourcedMethod(ResourceName, string, int?, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1Snippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Paginated.Snippets
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
         /// <summary>Snippet for ResourcedMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void ResourcedMethod1()
         {
             // Snippet: ResourcedMethod(string, string, int?, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2AsyncSnippet.g.cs
@@ -25,6 +25,10 @@ namespace Testing.Paginated.Snippets
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
         /// <summary>Snippet for ResourcedMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task ResourcedMethod2Async()
         {
             // Snippet: ResourcedMethodAsync(string, string, string, int?, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2ResourceNamesAsyncSnippet.g.cs
@@ -25,6 +25,10 @@ namespace Testing.Paginated.Snippets
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
         /// <summary>Snippet for ResourcedMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task ResourcedMethod2ResourceNamesAsync()
         {
             // Snippet: ResourcedMethodAsync(ResourceName, string, string, int?, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2ResourceNamesSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Paginated.Snippets
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
         /// <summary>Snippet for ResourcedMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void ResourcedMethod2ResourceNames()
         {
             // Snippet: ResourcedMethod(ResourceName, string, string, int?, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2Snippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Paginated.Snippets
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
         /// <summary>Snippet for ResourcedMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void ResourcedMethod2()
         {
             // Snippet: ResourcedMethod(string, string, string, int?, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethodRequestObjectAsyncSnippet.g.cs
@@ -25,6 +25,10 @@ namespace Testing.Paginated.Snippets
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
         /// <summary>Snippet for ResourcedMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task ResourcedMethodRequestObjectAsync()
         {
             // Snippet: ResourcedMethodAsync(ResourceRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethodRequestObjectSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Paginated.Snippets
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
         /// <summary>Snippet for ResourcedMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void ResourcedMethodRequestObject()
         {
             // Snippet: ResourcedMethod(ResourceRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod1AsyncSnippet.g.cs
@@ -25,6 +25,10 @@ namespace Testing.Paginated.Snippets
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
         /// <summary>Snippet for SignatureMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task SignatureMethod1Async()
         {
             // Snippet: SignatureMethodAsync(string, int, string, int?, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod1Snippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Paginated.Snippets
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
         /// <summary>Snippet for SignatureMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void SignatureMethod1()
         {
             // Snippet: SignatureMethod(string, int, string, int?, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2AsyncSnippet.g.cs
@@ -25,6 +25,10 @@ namespace Testing.Paginated.Snippets
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
         /// <summary>Snippet for SignatureMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task SignatureMethod2Async()
         {
             // Snippet: SignatureMethodAsync(string, string, int?, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2RequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2RequestObjectAsyncSnippet.g.cs
@@ -25,6 +25,10 @@ namespace Testing.Paginated.Snippets
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
         /// <summary>Snippet for SignatureMethod2Async</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task SignatureMethod2RequestObjectAsync()
         {
             // Snippet: SignatureMethod2Async(Request, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2RequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2RequestObjectSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Paginated.Snippets
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
         /// <summary>Snippet for SignatureMethod2</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void SignatureMethod2RequestObject()
         {
             // Snippet: SignatureMethod2(Request, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2Snippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Paginated.Snippets
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
         /// <summary>Snippet for SignatureMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void SignatureMethod2()
         {
             // Snippet: SignatureMethod(string, string, int?, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod3AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod3AsyncSnippet.g.cs
@@ -25,6 +25,10 @@ namespace Testing.Paginated.Snippets
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
         /// <summary>Snippet for SignatureMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task SignatureMethod3Async()
         {
             // Snippet: SignatureMethodAsync(string, int?, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod3Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod3Snippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Paginated.Snippets
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
         /// <summary>Snippet for SignatureMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void SignatureMethod3()
         {
             // Snippet: SignatureMethod(string, int?, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethodRequestObjectAsyncSnippet.g.cs
@@ -25,6 +25,10 @@ namespace Testing.Paginated.Snippets
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
         /// <summary>Snippet for SignatureMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task SignatureMethodRequestObjectAsync()
         {
             // Snippet: SignatureMethodAsync(Request, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethodRequestObjectSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Paginated.Snippets
     public sealed partial class GeneratedPaginatedClientStandaloneSnippets
     {
         /// <summary>Snippet for SignatureMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void SignatureMethodRequestObject()
         {
             // Snippet: SignatureMethod(Request, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1AsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.ResourceNameSeparator.Snippets
     public sealed partial class GeneratedResourceNameSeparatorClientStandaloneSnippets
     {
         /// <summary>Snippet for Method1Async</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task Method1Async()
         {
             // Snippet: Method1Async(string, string, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1RequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1RequestObjectAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.ResourceNameSeparator.Snippets
     public sealed partial class GeneratedResourceNameSeparatorClientStandaloneSnippets
     {
         /// <summary>Snippet for Method1Async</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task Method1RequestObjectAsync()
         {
             // Snippet: Method1Async(Request, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1RequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1RequestObjectSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.ResourceNameSeparator.Snippets
     public sealed partial class GeneratedResourceNameSeparatorClientStandaloneSnippets
     {
         /// <summary>Snippet for Method1</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void Method1RequestObject()
         {
             // Snippet: Method1(Request, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1ResourceNamesAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.ResourceNameSeparator.Snippets
     public sealed partial class GeneratedResourceNameSeparatorClientStandaloneSnippets
     {
         /// <summary>Snippet for Method1Async</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task Method1ResourceNamesAsync()
         {
             // Snippet: Method1Async(RequestName, RequestName, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1ResourceNamesSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.ResourceNameSeparator.Snippets
     public sealed partial class GeneratedResourceNameSeparatorClientStandaloneSnippets
     {
         /// <summary>Snippet for Method1</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void Method1ResourceNames()
         {
             // Snippet: Method1(RequestName, RequestName, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1Snippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.ResourceNameSeparator.Snippets
     public sealed partial class GeneratedResourceNameSeparatorClientStandaloneSnippets
     {
         /// <summary>Snippet for Method1</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void Method1()
         {
             // Snippet: Method1(string, string, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodAsyncSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for SinglePatternMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task SinglePatternMethodAsync()
         {
             // Snippet: SinglePatternMethodAsync(string, string, IEnumerable<string>, string, IEnumerable<string>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodRequestObjectAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for SinglePatternMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task SinglePatternMethodRequestObjectAsync()
         {
             // Snippet: SinglePatternMethodAsync(SinglePattern, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodRequestObjectSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for SinglePatternMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void SinglePatternMethodRequestObject()
         {
             // Snippet: SinglePatternMethod(SinglePattern, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodResourceNamesAsyncSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for SinglePatternMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task SinglePatternMethodResourceNamesAsync()
         {
             // Snippet: SinglePatternMethodAsync(SinglePatternName, SinglePatternName, IEnumerable<SinglePatternName>, SinglePatternName, IEnumerable<SinglePatternName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodResourceNamesSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for SinglePatternMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void SinglePatternMethodResourceNames()
         {
             // Snippet: SinglePatternMethod(SinglePatternName, SinglePatternName, IEnumerable<SinglePatternName>, SinglePatternName, IEnumerable<SinglePatternName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for SinglePatternMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void SinglePatternMethod()
         {
             // Snippet: SinglePatternMethod(string, string, IEnumerable<string>, string, IEnumerable<string>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodAsyncSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task WildcardMultiPatternMethodAsync()
         {
             // Snippet: WildcardMultiPatternMethodAsync(string, string, IEnumerable<string>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodRequestObjectAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task WildcardMultiPatternMethodRequestObjectAsync()
         {
             // Snippet: WildcardMultiPatternMethodAsync(WildcardMultiPattern, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodRequestObjectSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void WildcardMultiPatternMethodRequestObject()
         {
             // Snippet: WildcardMultiPatternMethod(WildcardMultiPattern, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames1AsyncSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task WildcardMultiPatternMethodResourceNames1Async()
         {
             // Snippet: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, WildcardMultiPatternName, IEnumerable<WildcardMultiPatternName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames1Snippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void WildcardMultiPatternMethodResourceNames1()
         {
             // Snippet: WildcardMultiPatternMethod(WildcardMultiPatternName, WildcardMultiPatternName, IEnumerable<WildcardMultiPatternName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames2AsyncSnippet.g.cs
@@ -24,6 +24,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task WildcardMultiPatternMethodResourceNames2Async()
         {
             // Snippet: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, WildcardMultiPatternName, IEnumerable<IResourceName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames2Snippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void WildcardMultiPatternMethodResourceNames2()
         {
             // Snippet: WildcardMultiPatternMethod(WildcardMultiPatternName, WildcardMultiPatternName, IEnumerable<IResourceName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames3AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames3AsyncSnippet.g.cs
@@ -24,6 +24,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task WildcardMultiPatternMethodResourceNames3Async()
         {
             // Snippet: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, IResourceName, IEnumerable<WildcardMultiPatternName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames3Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames3Snippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void WildcardMultiPatternMethodResourceNames3()
         {
             // Snippet: WildcardMultiPatternMethod(WildcardMultiPatternName, IResourceName, IEnumerable<WildcardMultiPatternName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames4AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames4AsyncSnippet.g.cs
@@ -24,6 +24,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task WildcardMultiPatternMethodResourceNames4Async()
         {
             // Snippet: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, IResourceName, IEnumerable<IResourceName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames4Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames4Snippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void WildcardMultiPatternMethodResourceNames4()
         {
             // Snippet: WildcardMultiPatternMethod(WildcardMultiPatternName, IResourceName, IEnumerable<IResourceName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames5AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames5AsyncSnippet.g.cs
@@ -24,6 +24,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task WildcardMultiPatternMethodResourceNames5Async()
         {
             // Snippet: WildcardMultiPatternMethodAsync(IResourceName, WildcardMultiPatternName, IEnumerable<WildcardMultiPatternName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames5Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames5Snippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void WildcardMultiPatternMethodResourceNames5()
         {
             // Snippet: WildcardMultiPatternMethod(IResourceName, WildcardMultiPatternName, IEnumerable<WildcardMultiPatternName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames6AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames6AsyncSnippet.g.cs
@@ -24,6 +24,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task WildcardMultiPatternMethodResourceNames6Async()
         {
             // Snippet: WildcardMultiPatternMethodAsync(IResourceName, WildcardMultiPatternName, IEnumerable<IResourceName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames6Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames6Snippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void WildcardMultiPatternMethodResourceNames6()
         {
             // Snippet: WildcardMultiPatternMethod(IResourceName, WildcardMultiPatternName, IEnumerable<IResourceName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames7AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames7AsyncSnippet.g.cs
@@ -24,6 +24,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task WildcardMultiPatternMethodResourceNames7Async()
         {
             // Snippet: WildcardMultiPatternMethodAsync(IResourceName, IResourceName, IEnumerable<WildcardMultiPatternName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames7Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames7Snippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void WildcardMultiPatternMethodResourceNames7()
         {
             // Snippet: WildcardMultiPatternMethod(IResourceName, IResourceName, IEnumerable<WildcardMultiPatternName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames8AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames8AsyncSnippet.g.cs
@@ -24,6 +24,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task WildcardMultiPatternMethodResourceNames8Async()
         {
             // Snippet: WildcardMultiPatternMethodAsync(IResourceName, IResourceName, IEnumerable<IResourceName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames8Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames8Snippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void WildcardMultiPatternMethodResourceNames8()
         {
             // Snippet: WildcardMultiPatternMethod(IResourceName, IResourceName, IEnumerable<IResourceName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void WildcardMultiPatternMethod()
         {
             // Snippet: WildcardMultiPatternMethod(string, string, IEnumerable<string>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodAsyncSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMultipleMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task WildcardMultiPatternMultipleMethodAsync()
         {
             // Snippet: WildcardMultiPatternMultipleMethodAsync(string, IEnumerable<string>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodRequestObjectAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMultipleMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task WildcardMultiPatternMultipleMethodRequestObjectAsync()
         {
             // Snippet: WildcardMultiPatternMultipleMethodAsync(WildcardMultiPatternMultiple, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodRequestObjectSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMultipleMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void WildcardMultiPatternMultipleMethodRequestObject()
         {
             // Snippet: WildcardMultiPatternMultipleMethod(WildcardMultiPatternMultiple, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames1AsyncSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMultipleMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task WildcardMultiPatternMultipleMethodResourceNames1Async()
         {
             // Snippet: WildcardMultiPatternMultipleMethodAsync(WildcardMultiPatternMultipleName, IEnumerable<WildcardMultiPatternMultipleName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames1Snippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMultipleMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void WildcardMultiPatternMultipleMethodResourceNames1()
         {
             // Snippet: WildcardMultiPatternMultipleMethod(WildcardMultiPatternMultipleName, IEnumerable<WildcardMultiPatternMultipleName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames2AsyncSnippet.g.cs
@@ -24,6 +24,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMultipleMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task WildcardMultiPatternMultipleMethodResourceNames2Async()
         {
             // Snippet: WildcardMultiPatternMultipleMethodAsync(WildcardMultiPatternMultipleName, IEnumerable<IResourceName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames2Snippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMultipleMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void WildcardMultiPatternMultipleMethodResourceNames2()
         {
             // Snippet: WildcardMultiPatternMultipleMethod(WildcardMultiPatternMultipleName, IEnumerable<IResourceName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames3AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames3AsyncSnippet.g.cs
@@ -24,6 +24,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMultipleMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task WildcardMultiPatternMultipleMethodResourceNames3Async()
         {
             // Snippet: WildcardMultiPatternMultipleMethodAsync(IResourceName, IEnumerable<WildcardMultiPatternMultipleName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames3Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames3Snippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMultipleMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void WildcardMultiPatternMultipleMethodResourceNames3()
         {
             // Snippet: WildcardMultiPatternMultipleMethod(IResourceName, IEnumerable<WildcardMultiPatternMultipleName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames4AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames4AsyncSnippet.g.cs
@@ -24,6 +24,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMultipleMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task WildcardMultiPatternMultipleMethodResourceNames4Async()
         {
             // Snippet: WildcardMultiPatternMultipleMethodAsync(IResourceName, IEnumerable<IResourceName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames4Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames4Snippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMultipleMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void WildcardMultiPatternMultipleMethodResourceNames4()
         {
             // Snippet: WildcardMultiPatternMultipleMethod(IResourceName, IEnumerable<IResourceName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardMultiPatternMultipleMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void WildcardMultiPatternMultipleMethod()
         {
             // Snippet: WildcardMultiPatternMultipleMethod(string, IEnumerable<string>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodAsyncSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardOnlyPatternMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task WildcardOnlyPatternMethodAsync()
         {
             // Snippet: WildcardOnlyPatternMethodAsync(string, string, IEnumerable<string>, string, IEnumerable<string>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodRequestObjectAsyncSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardOnlyPatternMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task WildcardOnlyPatternMethodRequestObjectAsync()
         {
             // Snippet: WildcardOnlyPatternMethodAsync(WildcardOnlyPattern, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodRequestObjectSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardOnlyPatternMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void WildcardOnlyPatternMethodRequestObject()
         {
             // Snippet: WildcardOnlyPatternMethod(WildcardOnlyPattern, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodResourceNamesAsyncSnippet.g.cs
@@ -24,6 +24,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardOnlyPatternMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task WildcardOnlyPatternMethodResourceNamesAsync()
         {
             // Snippet: WildcardOnlyPatternMethodAsync(IResourceName, IResourceName, IEnumerable<IResourceName>, IResourceName, IEnumerable<IResourceName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodResourceNamesSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardOnlyPatternMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void WildcardOnlyPatternMethodResourceNames()
         {
             // Snippet: WildcardOnlyPatternMethod(IResourceName, IResourceName, IEnumerable<IResourceName>, IResourceName, IEnumerable<IResourceName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.ResourceNames.Snippets
     public sealed partial class GeneratedResourceNamesClientStandaloneSnippets
     {
         /// <summary>Snippet for WildcardOnlyPatternMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void WildcardOnlyPatternMethod()
         {
             // Snippet: WildcardOnlyPatternMethod(string, string, IEnumerable<string>, string, IEnumerable<string>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodBidiStreamingSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodBidiStreamingSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodBidiStreaming</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodBidiStreaming()
         {
             // Snippet: MethodBidiStreaming(CallSettings, BidirectionalStreamingSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesAsyncSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodDefaultValuesAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodDefaultValuesAsync()
         {
             // Snippet: MethodDefaultValuesAsync(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, IEnumerable<string>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesRequestObjectAsyncSnippet.g.cs
@@ -24,6 +24,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodDefaultValuesAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodDefaultValuesRequestObjectAsync()
         {
             // Snippet: MethodDefaultValuesAsync(DefaultValuesRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesRequestObjectSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodDefaultValues</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void MethodDefaultValuesRequestObject()
         {
             // Snippet: MethodDefaultValues(DefaultValuesRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesResourceNamesAsyncSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodDefaultValuesAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodDefaultValuesResourceNamesAsync()
         {
             // Snippet: MethodDefaultValuesAsync(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, IEnumerable<AResourceName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesResourceNamesSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodDefaultValues</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void MethodDefaultValuesResourceNames()
         {
             // Snippet: MethodDefaultValues(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, IEnumerable<AResourceName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodDefaultValues</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void MethodDefaultValues()
         {
             // Snippet: MethodDefaultValues(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, IEnumerable<string>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureAsyncSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodLroResourceSignatureAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodLroResourceSignatureAsync()
         {
             // Snippet: MethodLroResourceSignatureAsync(string, string, string, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureRequestObjectAsyncSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodLroResourceSignatureAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodLroResourceSignatureRequestObjectAsync()
         {
             // Snippet: MethodLroResourceSignatureAsync(ResourceSignatureRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureRequestObjectSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodLroResourceSignature</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void MethodLroResourceSignatureRequestObject()
         {
             // Snippet: MethodLroResourceSignature(ResourceSignatureRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureResourceNamesAsyncSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodLroResourceSignatureAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodLroResourceSignatureResourceNamesAsync()
         {
             // Snippet: MethodLroResourceSignatureAsync(SimpleResourceName, SimpleResourceName, SimpleResourceName, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureResourceNamesSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodLroResourceSignature</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void MethodLroResourceSignatureResourceNames()
         {
             // Snippet: MethodLroResourceSignature(SimpleResourceName, SimpleResourceName, SimpleResourceName, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodLroResourceSignature</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void MethodLroResourceSignature()
         {
             // Snippet: MethodLroResourceSignature(string, string, string, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroSignaturesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroSignaturesAsyncSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodLroSignaturesAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodLroSignaturesAsync()
         {
             // Snippet: MethodLroSignaturesAsync(string, int, bool, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroSignaturesRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroSignaturesRequestObjectAsyncSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodLroSignaturesAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodLroSignaturesRequestObjectAsync()
         {
             // Snippet: MethodLroSignaturesAsync(SignatureRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroSignaturesRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroSignaturesRequestObjectSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodLroSignatures</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void MethodLroSignaturesRequestObject()
         {
             // Snippet: MethodLroSignatures(SignatureRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroSignaturesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroSignaturesSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodLroSignatures</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void MethodLroSignatures()
         {
             // Snippet: MethodLroSignatures(string, int, bool, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodMapSignatureAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodMapSignatureAsyncSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodMapSignatureAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodMapSignatureAsync()
         {
             // Snippet: MethodMapSignatureAsync(IDictionary<int,string>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodMapSignatureRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodMapSignatureRequestObjectAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodMapSignatureAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodMapSignatureRequestObjectAsync()
         {
             // Snippet: MethodMapSignatureAsync(SignatureRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodMapSignatureRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodMapSignatureRequestObjectSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodMapSignature</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void MethodMapSignatureRequestObject()
         {
             // Snippet: MethodMapSignature(SignatureRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodMapSignatureSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodMapSignatureSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodMapSignature</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void MethodMapSignature()
         {
             // Snippet: MethodMapSignature(IDictionary<int,string>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodOneSignatureAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodOneSignatureAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodOneSignatureAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodOneSignatureAsync()
         {
             // Snippet: MethodOneSignatureAsync(string, int, bool, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodOneSignatureRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodOneSignatureRequestObjectAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodOneSignatureAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodOneSignatureRequestObjectAsync()
         {
             // Snippet: MethodOneSignatureAsync(SignatureRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodOneSignatureRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodOneSignatureRequestObjectSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodOneSignature</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void MethodOneSignatureRequestObject()
         {
             // Snippet: MethodOneSignature(SignatureRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodOneSignatureSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodOneSignatureSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodOneSignature</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void MethodOneSignature()
         {
             // Snippet: MethodOneSignature(string, int, bool, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureAsyncSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodRepeatedResourceSignatureAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodRepeatedResourceSignatureAsync()
         {
             // Snippet: MethodRepeatedResourceSignatureAsync(IEnumerable<string>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureRequestObjectAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodRepeatedResourceSignatureAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodRepeatedResourceSignatureRequestObjectAsync()
         {
             // Snippet: MethodRepeatedResourceSignatureAsync(RepeatedResourceSignatureRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureRequestObjectSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodRepeatedResourceSignature</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void MethodRepeatedResourceSignatureRequestObject()
         {
             // Snippet: MethodRepeatedResourceSignature(RepeatedResourceSignatureRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureResourceNamesAsyncSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodRepeatedResourceSignatureAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodRepeatedResourceSignatureResourceNamesAsync()
         {
             // Snippet: MethodRepeatedResourceSignatureAsync(IEnumerable<SimpleResourceName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureResourceNamesSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodRepeatedResourceSignature</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void MethodRepeatedResourceSignatureResourceNames()
         {
             // Snippet: MethodRepeatedResourceSignature(IEnumerable<SimpleResourceName>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodRepeatedResourceSignature</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void MethodRepeatedResourceSignature()
         {
             // Snippet: MethodRepeatedResourceSignature(IEnumerable<string>, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature1AsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodResourceSignatureAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodResourceSignature1Async()
         {
             // Snippet: MethodResourceSignatureAsync(string, string, string, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature1ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature1ResourceNamesAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodResourceSignatureAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodResourceSignature1ResourceNamesAsync()
         {
             // Snippet: MethodResourceSignatureAsync(SimpleResourceName, SimpleResourceName, SimpleResourceName, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature1ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature1ResourceNamesSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodResourceSignature</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void MethodResourceSignature1ResourceNames()
         {
             // Snippet: MethodResourceSignature(SimpleResourceName, SimpleResourceName, SimpleResourceName, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature1Snippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodResourceSignature</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void MethodResourceSignature1()
         {
             // Snippet: MethodResourceSignature(string, string, string, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature2AsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodResourceSignatureAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodResourceSignature2Async()
         {
             // Snippet: MethodResourceSignatureAsync(string, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature2ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature2ResourceNamesAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodResourceSignatureAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodResourceSignature2ResourceNamesAsync()
         {
             // Snippet: MethodResourceSignatureAsync(SimpleResourceName, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature2ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature2ResourceNamesSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodResourceSignature</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void MethodResourceSignature2ResourceNames()
         {
             // Snippet: MethodResourceSignature(SimpleResourceName, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature2Snippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodResourceSignature</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void MethodResourceSignature2()
         {
             // Snippet: MethodResourceSignature(string, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignatureRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignatureRequestObjectAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodResourceSignatureAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodResourceSignatureRequestObjectAsync()
         {
             // Snippet: MethodResourceSignatureAsync(ResourceSignatureRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignatureRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignatureRequestObjectSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodResourceSignature</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void MethodResourceSignatureRequestObject()
         {
             // Snippet: MethodResourceSignature(ResourceSignatureRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreaming1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreaming1Snippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodServerStreaming</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodServerStreaming1()
         {
             // Snippet: MethodServerStreaming(string, bool, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreaming2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreaming2Snippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodServerStreaming</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodServerStreaming2()
         {
             // Snippet: MethodServerStreaming(CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreamingRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreamingRequestObjectSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodServerStreaming</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodServerStreamingRequestObject()
         {
             // Snippet: MethodServerStreaming(SignatureRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreamingResourcesRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreamingResourcesRequestObjectSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodServerStreamingResources</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodServerStreamingResourcesRequestObject()
         {
             // Snippet: MethodServerStreamingResources(ResourceSignatureRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreamingResourcesResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreamingResourcesResourceNamesSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodServerStreamingResources</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodServerStreamingResourcesResourceNames()
         {
             // Snippet: MethodServerStreamingResources(SimpleResourceName, SimpleResourceName, SimpleResourceName, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreamingResourcesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreamingResourcesSnippet.g.cs
@@ -23,6 +23,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodServerStreamingResources</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodServerStreamingResources()
         {
             // Snippet: MethodServerStreamingResources(string, string, string, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures1AsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodThreeSignaturesAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodThreeSignatures1Async()
         {
             // Snippet: MethodThreeSignaturesAsync(string, int, bool, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures1Snippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodThreeSignatures</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void MethodThreeSignatures1()
         {
             // Snippet: MethodThreeSignatures(string, int, bool, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures2AsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodThreeSignaturesAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodThreeSignatures2Async()
         {
             // Snippet: MethodThreeSignaturesAsync(string, bool, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures2Snippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodThreeSignatures</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void MethodThreeSignatures2()
         {
             // Snippet: MethodThreeSignatures(string, bool, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures3AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures3AsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodThreeSignaturesAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodThreeSignatures3Async()
         {
             // Snippet: MethodThreeSignaturesAsync(CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures3Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures3Snippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodThreeSignatures</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void MethodThreeSignatures3()
         {
             // Snippet: MethodThreeSignatures(CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignaturesRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignaturesRequestObjectAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodThreeSignaturesAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task MethodThreeSignaturesRequestObjectAsync()
         {
             // Snippet: MethodThreeSignaturesAsync(SignatureRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignaturesRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignaturesRequestObjectSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for MethodThreeSignatures</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void MethodThreeSignaturesRequestObject()
         {
             // Snippet: MethodThreeSignatures(SignatureRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.OneOfMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.OneOfMethodRequestObjectAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for OneOfMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task OneOfMethodRequestObjectAsync()
         {
             // Snippet: OneOfMethodAsync(OneOfRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.OneOfMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.OneOfMethodRequestObjectSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for OneOfMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void OneOfMethodRequestObject()
         {
             // Snippet: OneOfMethod(OneOfRequest, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.TaskMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.TaskMethodRequestObjectAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for TaskMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task TaskMethodRequestObjectAsync()
         {
             // Snippet: TaskMethodAsync(Task, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.TaskMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.TaskMethodRequestObjectSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.Snippets.Snippets
     public sealed partial class GeneratedSnippetsClientStandaloneSnippets
     {
         /// <summary>Snippet for TaskMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void TaskMethodRequestObject()
         {
             // Snippet: TaskMethod(Task, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.VoidReturn.Snippets
     public sealed partial class GeneratedVoidReturnClientStandaloneSnippets
     {
         /// <summary>Snippet for VoidMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task VoidMethodAsync()
         {
             // Snippet: VoidMethodAsync(string, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodRequestObjectAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.VoidReturn.Snippets
     public sealed partial class GeneratedVoidReturnClientStandaloneSnippets
     {
         /// <summary>Snippet for VoidMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task VoidMethodRequestObjectAsync()
         {
             // Snippet: VoidMethodAsync(Request, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodRequestObjectSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.VoidReturn.Snippets
     public sealed partial class GeneratedVoidReturnClientStandaloneSnippets
     {
         /// <summary>Snippet for VoidMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void VoidMethodRequestObject()
         {
             // Snippet: VoidMethod(Request, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodResourceNamesAsyncSnippet.g.cs
@@ -22,6 +22,10 @@ namespace Testing.VoidReturn.Snippets
     public sealed partial class GeneratedVoidReturnClientStandaloneSnippets
     {
         /// <summary>Snippet for VoidMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public async Task VoidMethodResourceNamesAsync()
         {
             // Snippet: VoidMethodAsync(ResourceName, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodResourceNamesSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.VoidReturn.Snippets
     public sealed partial class GeneratedVoidReturnClientStandaloneSnippets
     {
         /// <summary>Snippet for VoidMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void VoidMethodResourceNames()
         {
             // Snippet: VoidMethod(ResourceName, CallSettings)

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodSnippet.g.cs
@@ -21,6 +21,10 @@ namespace Testing.VoidReturn.Snippets
     public sealed partial class GeneratedVoidReturnClientStandaloneSnippets
     {
         /// <summary>Snippet for VoidMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated for illustrative purposes only.
+        /// It may require modifications to work in your environment.
+        /// </remarks>
         public void VoidMethod()
         {
             // Snippet: VoidMethod(string, CallSettings)


### PR DESCRIPTION
Production code changes are in `SnippetCodeGenerator` only. The rest of the changes are just updates to the expected output to include the notice.

This PR shouldn't trigger regeneration for library repos, but I'm running the generator locally just to make sure. I'm setting the `do not merge` label until local generation is done, but this PR is ready for review.