### PR TITLE
fix: Don't generate metadata when there are no services

### DIFF
--- a/Google.Api.Generator/CodeGenerator.cs
+++ b/Google.Api.Generator/CodeGenerator.cs
@@ -219,9 +219,9 @@ namespace Google.Api.Generator
                 var unitTestsCsprojContent = CsProjGenerator.GenerateUnitTests(ns);
                 var unitTestsCsprojFilename = $"{unitTestsPathPrefix}{ns}.Tests.csproj";
                 yield return new ResultFile(unitTestsCsprojFilename, unitTestsCsprojContent);
-                if (generateMetadata)
+                if (generateMetadata && allServiceDetails.Any())
                 {
-                    // Generate gapic_metadata.json
+                    // Generate gapic_metadata.json, if there are any services.
                     var gapicMetadataJsonContent = MetadataGenerator.GenerateGapicMetadataJson(allServiceDetails);
                     yield return new ResultFile("gapic_metadata.json", gapicMetadataJsonContent);
                 }


### PR DESCRIPTION
(Example: Google.Cloud.OsLogin.Common, where we just generate resources names.)

Ideally we'd actually delete any existing metadata file, but we don't have a way of expressing that - and it's very unlikely to happen.