### PR TITLE
fix: Make metadata generation order stable

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTests/GrpcServiceConfig/gapic_metadata.json
+++ b/Google.Api.Generator.Tests/ProtoTests/GrpcServiceConfig/gapic_metadata.json
@@ -5,6 +5,45 @@
   "protoPackage": "testing.grpcserviceconfig",
   "libraryPackage": "Testing.GrpcServiceConfig",
   "services": {
+    "GrpcServiceConfig": {
+      "clients": {
+        "grpc": {
+          "libraryClient": "GrpcServiceConfigClient",
+          "rpcs": {
+            "MethodLevelRetryMethod": {
+              "methods": [
+                "MethodLevelRetryMethod",
+                "MethodLevelRetryMethodAsync"
+              ]
+            },
+            "MethodTimeoutOnly": {
+              "methods": [
+                "MethodTimeoutOnly",
+                "MethodTimeoutOnlyAsync"
+              ]
+            },
+            "MethodWithBidiRetry": {
+              "methods": [
+                "MethodWithBidiRetry",
+                "MethodWithBidiRetryAsync"
+              ]
+            },
+            "MethodWithServerRetry": {
+              "methods": [
+                "MethodWithServerRetry",
+                "MethodWithServerRetryAsync"
+              ]
+            },
+            "ServiceLevelRetryMethod": {
+              "methods": [
+                "ServiceLevelRetryMethod",
+                "ServiceLevelRetryMethodAsync"
+              ]
+            }
+          }
+        }
+      }
+    },
     "GrpcServiceConfigNoRetry": {
       "clients": {
         "grpc": {
@@ -14,45 +53,6 @@
               "methods": [
                 "NoRetryMethod",
                 "NoRetryMethodAsync"
-              ]
-            }
-          }
-        }
-      }
-    },
-    "GrpcServiceConfig": {
-      "clients": {
-        "grpc": {
-          "libraryClient": "GrpcServiceConfigClient",
-          "rpcs": {
-            "ServiceLevelRetryMethod": {
-              "methods": [
-                "ServiceLevelRetryMethod",
-                "ServiceLevelRetryMethodAsync"
-              ]
-            },
-            "MethodLevelRetryMethod": {
-              "methods": [
-                "MethodLevelRetryMethod",
-                "MethodLevelRetryMethodAsync"
-              ]
-            },
-            "MethodWithServerRetry": {
-              "methods": [
-                "MethodWithServerRetry",
-                "MethodWithServerRetryAsync"
-              ]
-            },
-            "MethodWithBidiRetry": {
-              "methods": [
-                "MethodWithBidiRetry",
-                "MethodWithBidiRetryAsync"
-              ]
-            },
-            "MethodTimeoutOnly": {
-              "methods": [
-                "MethodTimeoutOnly",
-                "MethodTimeoutOnlyAsync"
               ]
             }
           }

--- a/Google.Api.Generator/Generation/MetadataGenerator.cs
+++ b/Google.Api.Generator/Generation/MetadataGenerator.cs
@@ -41,10 +41,10 @@ namespace Google.Api.Generator.Generation
                 LibraryPackage = allServiceDetails.First().Namespace,
                 Services = 
                 {
-                    allServiceDetails.ToDictionary(
-                        serviceDetails => serviceDetails.ServiceName,
-                        ServiceForTransportMetadata)
-
+                    new SortedDictionary<string, ServiceForTransport>(
+                        allServiceDetails.ToDictionary(
+                            serviceDetails => serviceDetails.ServiceName,
+                            ServiceForTransportMetadata), StringComparer.Ordinal)
                 }
             };
 
@@ -66,13 +66,13 @@ namespace Google.Api.Generator.Generation
                             LibraryClient = serviceDetails.ClientAbstractTyp.Name,
                             Rpcs = 
                             {
-                                serviceDetails.Methods.ToDictionary(
-                                    methodDetails => methodDetails.ProtoRpcName,
-                                    methodDetails => new MethodList
-                                    {
-                                        Methods = { methodDetails.SyncMethodName, methodDetails.AsyncMethodName }
-
-                                    })
+                                new SortedDictionary<string, MethodList>(
+                                    serviceDetails.Methods.ToDictionary(
+                                        methodDetails => methodDetails.ProtoRpcName,
+                                        methodDetails => new MethodList
+                                        {
+                                            Methods = { methodDetails.SyncMethodName, methodDetails.AsyncMethodName }
+                                        }), StringComparer.Ordinal)
                             }
                         }
                 }


### PR DESCRIPTION
(It would be nice if `MapField` contains an `Add` overload accepting an
`IEnumerable<TKey, TValue>`, but it doesn't at the moment. Using
SortedDictionary is a fairly simple alternative though.)