### PR TITLE
feat: Remove doc markers from standalone snippets.

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTests/Basic/Testing.Basic.StandaloneSnippets/BasicClient.AMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic/Testing.Basic.StandaloneSnippets/BasicClient.AMethodRequestObjectAsyncSnippet.g.cs
@@ -28,15 +28,12 @@ namespace Testing.Basic.Snippets
         /// </remarks>
         public async Task AMethodRequestObjectAsync()
         {
-            // Snippet: AMethodAsync(Request, CallSettings)
-            // Additional: AMethodAsync(Request, CancellationToken)
             // Create client
             BasicClient basicClient = await BasicClient.CreateAsync();
             // Initialize request argument(s)
             Request request = new Request { };
             // Make the request
             Response response = await basicClient.AMethodAsync(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Basic/Testing.Basic.StandaloneSnippets/BasicClient.AMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic/Testing.Basic.StandaloneSnippets/BasicClient.AMethodRequestObjectSnippet.g.cs
@@ -27,14 +27,12 @@ namespace Testing.Basic.Snippets
         /// </remarks>
         public void AMethodRequestObject()
         {
-            // Snippet: AMethod(Request, CallSettings)
             // Create client
             BasicClient basicClient = BasicClient.Create();
             // Initialize request argument(s)
             Request request = new Request { };
             // Make the request
             Response response = basicClient.AMethod(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/BasicLro/Testing.BasicLro.StandaloneSnippets/BasicLroClient.Method1RequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/BasicLro/Testing.BasicLro.StandaloneSnippets/BasicLroClient.Method1RequestObjectAsyncSnippet.g.cs
@@ -29,8 +29,6 @@ namespace Testing.BasicLro.Snippets
         /// </remarks>
         public async Task Method1RequestObjectAsync()
         {
-            // Snippet: Method1Async(Request, CallSettings)
-            // Additional: Method1Async(Request, CancellationToken)
             // Create client
             BasicLroClient basicLroClient = await BasicLroClient.CreateAsync();
             // Initialize request argument(s)
@@ -53,7 +51,6 @@ namespace Testing.BasicLro.Snippets
                 // If it has completed, then access the result
                 LroResponse retrievedResult = retrievedResponse.Result;
             }
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/BasicLro/Testing.BasicLro.StandaloneSnippets/BasicLroClient.Method1RequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/BasicLro/Testing.BasicLro.StandaloneSnippets/BasicLroClient.Method1RequestObjectSnippet.g.cs
@@ -28,7 +28,6 @@ namespace Testing.BasicLro.Snippets
         /// </remarks>
         public void Method1RequestObject()
         {
-            // Snippet: Method1(Request, CallSettings)
             // Create client
             BasicLroClient basicLroClient = BasicLroClient.Create();
             // Initialize request argument(s)
@@ -51,7 +50,6 @@ namespace Testing.BasicLro.Snippets
                 // If it has completed, then access the result
                 LroResponse retrievedResult = retrievedResponse.Result;
             }
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedFieldMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedFieldMethodAsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.Deprecated.Snippets
         /// </remarks>
         public async Task DeprecatedFieldMethodAsync()
         {
-            // Snippet: DeprecatedFieldMethodAsync(string, string, CallSettings)
-            // Additional: DeprecatedFieldMethodAsync(string, string, CancellationToken)
             // Create client
             DeprecatedClient deprecatedClient = await DeprecatedClient.CreateAsync();
             // Initialize request argument(s)
@@ -37,7 +35,6 @@ namespace Testing.Deprecated.Snippets
             string deprecatedField2 = "";
             // Make the request
             Response response = await deprecatedClient.DeprecatedFieldMethodAsync(deprecatedField1, deprecatedField2);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedFieldMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedFieldMethodRequestObjectAsyncSnippet.g.cs
@@ -28,15 +28,12 @@ namespace Testing.Deprecated.Snippets
         /// </remarks>
         public async Task DeprecatedFieldMethodRequestObjectAsync()
         {
-            // Snippet: DeprecatedFieldMethodAsync(DeprecatedFieldRequest, CallSettings)
-            // Additional: DeprecatedFieldMethodAsync(DeprecatedFieldRequest, CancellationToken)
             // Create client
             DeprecatedClient deprecatedClient = await DeprecatedClient.CreateAsync();
             // Initialize request argument(s)
             DeprecatedFieldRequest request = new DeprecatedFieldRequest { };
             // Make the request
             Response response = await deprecatedClient.DeprecatedFieldMethodAsync(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedFieldMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedFieldMethodRequestObjectSnippet.g.cs
@@ -27,14 +27,12 @@ namespace Testing.Deprecated.Snippets
         /// </remarks>
         public void DeprecatedFieldMethodRequestObject()
         {
-            // Snippet: DeprecatedFieldMethod(DeprecatedFieldRequest, CallSettings)
             // Create client
             DeprecatedClient deprecatedClient = DeprecatedClient.Create();
             // Initialize request argument(s)
             DeprecatedFieldRequest request = new DeprecatedFieldRequest { };
             // Make the request
             Response response = deprecatedClient.DeprecatedFieldMethod(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedFieldMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedFieldMethodSnippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.Deprecated.Snippets
         /// </remarks>
         public void DeprecatedFieldMethod()
         {
-            // Snippet: DeprecatedFieldMethod(string, string, CallSettings)
             // Create client
             DeprecatedClient deprecatedClient = DeprecatedClient.Create();
             // Initialize request argument(s)
@@ -35,7 +34,6 @@ namespace Testing.Deprecated.Snippets
             string deprecatedField2 = "";
             // Make the request
             Response response = deprecatedClient.DeprecatedFieldMethod(deprecatedField1, deprecatedField2);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedMessageMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedMessageMethodRequestObjectAsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.Deprecated.Snippets
         /// </remarks>
         public async Task DeprecatedMessageMethodRequestObjectAsync()
         {
-            // Snippet: DeprecatedMessageMethodAsync(DeprecatedMessageRequest, CallSettings)
-            // Additional: DeprecatedMessageMethodAsync(DeprecatedMessageRequest, CancellationToken)
             // Create client
             DeprecatedClient deprecatedClient = await DeprecatedClient.CreateAsync();
             // Initialize request argument(s)
@@ -38,7 +36,6 @@ namespace Testing.Deprecated.Snippets
 #pragma warning restore CS0612
             // Make the request
             Response response = await deprecatedClient.DeprecatedMessageMethodAsync(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedMessageMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedMessageMethodRequestObjectSnippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.Deprecated.Snippets
         /// </remarks>
         public void DeprecatedMessageMethodRequestObject()
         {
-            // Snippet: DeprecatedMessageMethod(DeprecatedMessageRequest, CallSettings)
             // Create client
             DeprecatedClient deprecatedClient = DeprecatedClient.Create();
             // Initialize request argument(s)
@@ -36,7 +35,6 @@ namespace Testing.Deprecated.Snippets
 #pragma warning restore CS0612
             // Make the request
             Response response = deprecatedClient.DeprecatedMessageMethod(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedMethodRequestObjectAsyncSnippet.g.cs
@@ -28,15 +28,12 @@ namespace Testing.Deprecated.Snippets
         /// </remarks>
         public async Task DeprecatedMethodRequestObjectAsync()
         {
-            // Snippet: DeprecatedMethodAsync(Request, CallSettings)
-            // Additional: DeprecatedMethodAsync(Request, CancellationToken)
             // Create client
             DeprecatedClient deprecatedClient = await DeprecatedClient.CreateAsync();
             // Initialize request argument(s)
             Request request = new Request { };
             // Make the request
             Response response = await deprecatedClient.DeprecatedMethodAsync(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedMethodRequestObjectSnippet.g.cs
@@ -27,14 +27,12 @@ namespace Testing.Deprecated.Snippets
         /// </remarks>
         public void DeprecatedMethodRequestObject()
         {
-            // Snippet: DeprecatedMethod(Request, CallSettings)
             // Create client
             DeprecatedClient deprecatedClient = DeprecatedClient.Create();
             // Initialize request argument(s)
             Request request = new Request { };
             // Make the request
             Response response = deprecatedClient.DeprecatedMethod(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedResponseMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedResponseMethodRequestObjectAsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.Deprecated.Snippets
         /// </remarks>
         public async Task DeprecatedResponseMethodRequestObjectAsync()
         {
-            // Snippet: DeprecatedResponseMethodAsync(Request, CallSettings)
-            // Additional: DeprecatedResponseMethodAsync(Request, CancellationToken)
             // Create client
             DeprecatedClient deprecatedClient = await DeprecatedClient.CreateAsync();
             // Initialize request argument(s)
@@ -38,7 +36,6 @@ namespace Testing.Deprecated.Snippets
 #pragma warning disable CS0612
             DeprecatedMessageResponse response = await deprecatedClient.DeprecatedResponseMethodAsync(request);
 #pragma warning restore CS0612
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedResponseMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.StandaloneSnippets/DeprecatedClient.DeprecatedResponseMethodRequestObjectSnippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.Deprecated.Snippets
         /// </remarks>
         public void DeprecatedResponseMethodRequestObject()
         {
-            // Snippet: DeprecatedResponseMethod(Request, CallSettings)
             // Create client
             DeprecatedClient deprecatedClient = DeprecatedClient.Create();
             // Initialize request argument(s)
@@ -36,7 +35,6 @@ namespace Testing.Deprecated.Snippets
 #pragma warning disable CS0612
             DeprecatedMessageResponse response = deprecatedClient.DeprecatedResponseMethod(request);
 #pragma warning restore CS0612
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1AsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.Keywords.Snippets
         /// </remarks>
         public async Task Method1Async()
         {
-            // Snippet: Method1Async(string, int, Enum, string, string, CallSettings)
-            // Additional: Method1Async(string, int, Enum, string, string, CancellationToken)
             // Create client
             KeywordsClient keywordsClient = await KeywordsClient.CreateAsync();
             // Initialize request argument(s)
@@ -40,7 +38,6 @@ namespace Testing.Keywords.Snippets
             string types = "";
             // Make the request
             Response response = await keywordsClient.Method1Async(@event, @switch, @void, request, types);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1RequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1RequestObjectAsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.Keywords.Snippets
         /// </remarks>
         public async Task Method1RequestObjectAsync()
         {
-            // Snippet: Method1Async(Request, CallSettings)
-            // Additional: Method1Async(Request, CancellationToken)
             // Create client
             KeywordsClient keywordsClient = await KeywordsClient.CreateAsync();
             // Initialize request argument(s)
@@ -43,7 +41,6 @@ namespace Testing.Keywords.Snippets
             };
             // Make the request
             Response response = await keywordsClient.Method1Async(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1RequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1RequestObjectSnippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.Keywords.Snippets
         /// </remarks>
         public void Method1RequestObject()
         {
-            // Snippet: Method1(Request, CallSettings)
             // Create client
             KeywordsClient keywordsClient = KeywordsClient.Create();
             // Initialize request argument(s)
@@ -41,7 +40,6 @@ namespace Testing.Keywords.Snippets
             };
             // Make the request
             Response response = keywordsClient.Method1(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1ResourceNamesAsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.Keywords.Snippets
         /// </remarks>
         public async Task Method1ResourceNamesAsync()
         {
-            // Snippet: Method1Async(ResourceName, int, Enum, string, string, CallSettings)
-            // Additional: Method1Async(ResourceName, int, Enum, string, string, CancellationToken)
             // Create client
             KeywordsClient keywordsClient = await KeywordsClient.CreateAsync();
             // Initialize request argument(s)
@@ -40,7 +38,6 @@ namespace Testing.Keywords.Snippets
             string types = "";
             // Make the request
             Response response = await keywordsClient.Method1Async(@event, @switch, @void, request, types);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1ResourceNamesSnippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.Keywords.Snippets
         /// </remarks>
         public void Method1ResourceNames()
         {
-            // Snippet: Method1(ResourceName, int, Enum, string, string, CallSettings)
             // Create client
             KeywordsClient keywordsClient = KeywordsClient.Create();
             // Initialize request argument(s)
@@ -38,7 +37,6 @@ namespace Testing.Keywords.Snippets
             string types = "";
             // Make the request
             Response response = keywordsClient.Method1(@event, @switch, @void, request, types);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method1Snippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.Keywords.Snippets
         /// </remarks>
         public void Method1()
         {
-            // Snippet: Method1(string, int, Enum, string, string, CallSettings)
             // Create client
             KeywordsClient keywordsClient = KeywordsClient.Create();
             // Initialize request argument(s)
@@ -38,7 +37,6 @@ namespace Testing.Keywords.Snippets
             string types = "";
             // Make the request
             Response response = keywordsClient.Method1(@event, @switch, @void, request, types);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2AsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.Keywords.Snippets
         /// </remarks>
         public async Task Method2Async()
         {
-            // Snippet: Method2Async(string, Enum, CallSettings)
-            // Additional: Method2Async(string, Enum, CancellationToken)
             // Create client
             KeywordsClient keywordsClient = await KeywordsClient.CreateAsync();
             // Initialize request argument(s)
@@ -37,7 +35,6 @@ namespace Testing.Keywords.Snippets
             Enum @enum = Enum.Void;
             // Make the request
             Response response = await keywordsClient.Method2Async(@while, @enum);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2RequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2RequestObjectAsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.Keywords.Snippets
         /// </remarks>
         public async Task Method2RequestObjectAsync()
         {
-            // Snippet: Method2Async(Resource, CallSettings)
-            // Additional: Method2Async(Resource, CancellationToken)
             // Create client
             KeywordsClient keywordsClient = await KeywordsClient.CreateAsync();
             // Initialize request argument(s)
@@ -40,7 +38,6 @@ namespace Testing.Keywords.Snippets
             };
             // Make the request
             Response response = await keywordsClient.Method2Async(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2RequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2RequestObjectSnippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.Keywords.Snippets
         /// </remarks>
         public void Method2RequestObject()
         {
-            // Snippet: Method2(Resource, CallSettings)
             // Create client
             KeywordsClient keywordsClient = KeywordsClient.Create();
             // Initialize request argument(s)
@@ -38,7 +37,6 @@ namespace Testing.Keywords.Snippets
             };
             // Make the request
             Response response = keywordsClient.Method2(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2ResourceNamesAsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.Keywords.Snippets
         /// </remarks>
         public async Task Method2ResourceNamesAsync()
         {
-            // Snippet: Method2Async(ResourceName, Enum, CallSettings)
-            // Additional: Method2Async(ResourceName, Enum, CancellationToken)
             // Create client
             KeywordsClient keywordsClient = await KeywordsClient.CreateAsync();
             // Initialize request argument(s)
@@ -37,7 +35,6 @@ namespace Testing.Keywords.Snippets
             Enum @enum = Enum.Void;
             // Make the request
             Response response = await keywordsClient.Method2Async(@while, @enum);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2ResourceNamesSnippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.Keywords.Snippets
         /// </remarks>
         public void Method2ResourceNames()
         {
-            // Snippet: Method2(ResourceName, Enum, CallSettings)
             // Create client
             KeywordsClient keywordsClient = KeywordsClient.Create();
             // Initialize request argument(s)
@@ -35,7 +34,6 @@ namespace Testing.Keywords.Snippets
             Enum @enum = Enum.Void;
             // Make the request
             Response response = keywordsClient.Method2(@while, @enum);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.StandaloneSnippets/KeywordsClient.Method2Snippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.Keywords.Snippets
         /// </remarks>
         public void Method2()
         {
-            // Snippet: Method2(string, Enum, CallSettings)
             // Create client
             KeywordsClient keywordsClient = KeywordsClient.Create();
             // Initialize request argument(s)
@@ -35,7 +34,6 @@ namespace Testing.Keywords.Snippets
             Enum @enum = Enum.Void;
             // Make the request
             Response response = keywordsClient.Method2(@while, @enum);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1AsyncSnippet.g.cs
@@ -31,7 +31,6 @@ namespace Testing.Paginated.Snippets
         /// </remarks>
         public async Task ResourcedMethod1Async()
         {
-            // Snippet: ResourcedMethodAsync(string, string, int?, CallSettings)
             // Create client
             PaginatedClient paginatedClient = await PaginatedClient.CreateAsync();
             // Initialize request argument(s)
@@ -70,7 +69,6 @@ namespace Testing.Paginated.Snippets
             }
             // Store the pageToken, for when the next page is required.
             string nextPageToken = singlePage.NextPageToken;
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1ResourceNamesAsyncSnippet.g.cs
@@ -31,7 +31,6 @@ namespace Testing.Paginated.Snippets
         /// </remarks>
         public async Task ResourcedMethod1ResourceNamesAsync()
         {
-            // Snippet: ResourcedMethodAsync(ResourceName, string, int?, CallSettings)
             // Create client
             PaginatedClient paginatedClient = await PaginatedClient.CreateAsync();
             // Initialize request argument(s)
@@ -70,7 +69,6 @@ namespace Testing.Paginated.Snippets
             }
             // Store the pageToken, for when the next page is required.
             string nextPageToken = singlePage.NextPageToken;
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1ResourceNamesSnippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.Paginated.Snippets
         /// </remarks>
         public void ResourcedMethod1ResourceNames()
         {
-            // Snippet: ResourcedMethod(ResourceName, string, int?, CallSettings)
             // Create client
             PaginatedClient paginatedClient = PaginatedClient.Create();
             // Initialize request argument(s)
@@ -68,7 +67,6 @@ namespace Testing.Paginated.Snippets
             }
             // Store the pageToken, for when the next page is required.
             string nextPageToken = singlePage.NextPageToken;
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod1Snippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.Paginated.Snippets
         /// </remarks>
         public void ResourcedMethod1()
         {
-            // Snippet: ResourcedMethod(string, string, int?, CallSettings)
             // Create client
             PaginatedClient paginatedClient = PaginatedClient.Create();
             // Initialize request argument(s)
@@ -68,7 +67,6 @@ namespace Testing.Paginated.Snippets
             }
             // Store the pageToken, for when the next page is required.
             string nextPageToken = singlePage.NextPageToken;
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2AsyncSnippet.g.cs
@@ -31,7 +31,6 @@ namespace Testing.Paginated.Snippets
         /// </remarks>
         public async Task ResourcedMethod2Async()
         {
-            // Snippet: ResourcedMethodAsync(string, string, string, int?, CallSettings)
             // Create client
             PaginatedClient paginatedClient = await PaginatedClient.CreateAsync();
             // Initialize request argument(s)
@@ -71,7 +70,6 @@ namespace Testing.Paginated.Snippets
             }
             // Store the pageToken, for when the next page is required.
             string nextPageToken = singlePage.NextPageToken;
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2ResourceNamesAsyncSnippet.g.cs
@@ -31,7 +31,6 @@ namespace Testing.Paginated.Snippets
         /// </remarks>
         public async Task ResourcedMethod2ResourceNamesAsync()
         {
-            // Snippet: ResourcedMethodAsync(ResourceName, string, string, int?, CallSettings)
             // Create client
             PaginatedClient paginatedClient = await PaginatedClient.CreateAsync();
             // Initialize request argument(s)
@@ -71,7 +70,6 @@ namespace Testing.Paginated.Snippets
             }
             // Store the pageToken, for when the next page is required.
             string nextPageToken = singlePage.NextPageToken;
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2ResourceNamesSnippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.Paginated.Snippets
         /// </remarks>
         public void ResourcedMethod2ResourceNames()
         {
-            // Snippet: ResourcedMethod(ResourceName, string, string, int?, CallSettings)
             // Create client
             PaginatedClient paginatedClient = PaginatedClient.Create();
             // Initialize request argument(s)
@@ -69,7 +68,6 @@ namespace Testing.Paginated.Snippets
             }
             // Store the pageToken, for when the next page is required.
             string nextPageToken = singlePage.NextPageToken;
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethod2Snippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.Paginated.Snippets
         /// </remarks>
         public void ResourcedMethod2()
         {
-            // Snippet: ResourcedMethod(string, string, string, int?, CallSettings)
             // Create client
             PaginatedClient paginatedClient = PaginatedClient.Create();
             // Initialize request argument(s)
@@ -69,7 +68,6 @@ namespace Testing.Paginated.Snippets
             }
             // Store the pageToken, for when the next page is required.
             string nextPageToken = singlePage.NextPageToken;
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethodRequestObjectAsyncSnippet.g.cs
@@ -31,7 +31,6 @@ namespace Testing.Paginated.Snippets
         /// </remarks>
         public async Task ResourcedMethodRequestObjectAsync()
         {
-            // Snippet: ResourcedMethodAsync(ResourceRequest, CallSettings)
             // Create client
             PaginatedClient paginatedClient = await PaginatedClient.CreateAsync();
             // Initialize request argument(s)
@@ -74,7 +73,6 @@ namespace Testing.Paginated.Snippets
             }
             // Store the pageToken, for when the next page is required.
             string nextPageToken = singlePage.NextPageToken;
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.ResourcedMethodRequestObjectSnippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.Paginated.Snippets
         /// </remarks>
         public void ResourcedMethodRequestObject()
         {
-            // Snippet: ResourcedMethod(ResourceRequest, CallSettings)
             // Create client
             PaginatedClient paginatedClient = PaginatedClient.Create();
             // Initialize request argument(s)
@@ -72,7 +71,6 @@ namespace Testing.Paginated.Snippets
             }
             // Store the pageToken, for when the next page is required.
             string nextPageToken = singlePage.NextPageToken;
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod1AsyncSnippet.g.cs
@@ -31,7 +31,6 @@ namespace Testing.Paginated.Snippets
         /// </remarks>
         public async Task SignatureMethod1Async()
         {
-            // Snippet: SignatureMethodAsync(string, int, string, int?, CallSettings)
             // Create client
             PaginatedClient paginatedClient = await PaginatedClient.CreateAsync();
             // Initialize request argument(s)
@@ -71,7 +70,6 @@ namespace Testing.Paginated.Snippets
             }
             // Store the pageToken, for when the next page is required.
             string nextPageToken = singlePage.NextPageToken;
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod1Snippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.Paginated.Snippets
         /// </remarks>
         public void SignatureMethod1()
         {
-            // Snippet: SignatureMethod(string, int, string, int?, CallSettings)
             // Create client
             PaginatedClient paginatedClient = PaginatedClient.Create();
             // Initialize request argument(s)
@@ -69,7 +68,6 @@ namespace Testing.Paginated.Snippets
             }
             // Store the pageToken, for when the next page is required.
             string nextPageToken = singlePage.NextPageToken;
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2AsyncSnippet.g.cs
@@ -31,7 +31,6 @@ namespace Testing.Paginated.Snippets
         /// </remarks>
         public async Task SignatureMethod2Async()
         {
-            // Snippet: SignatureMethodAsync(string, string, int?, CallSettings)
             // Create client
             PaginatedClient paginatedClient = await PaginatedClient.CreateAsync();
             // Initialize request argument(s)
@@ -70,7 +69,6 @@ namespace Testing.Paginated.Snippets
             }
             // Store the pageToken, for when the next page is required.
             string nextPageToken = singlePage.NextPageToken;
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2RequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2RequestObjectAsyncSnippet.g.cs
@@ -31,7 +31,6 @@ namespace Testing.Paginated.Snippets
         /// </remarks>
         public async Task SignatureMethod2RequestObjectAsync()
         {
-            // Snippet: SignatureMethod2Async(Request, CallSettings)
             // Create client
             PaginatedClient paginatedClient = await PaginatedClient.CreateAsync();
             // Initialize request argument(s)
@@ -74,7 +73,6 @@ namespace Testing.Paginated.Snippets
             }
             // Store the pageToken, for when the next page is required.
             string nextPageToken = singlePage.NextPageToken;
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2RequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2RequestObjectSnippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.Paginated.Snippets
         /// </remarks>
         public void SignatureMethod2RequestObject()
         {
-            // Snippet: SignatureMethod2(Request, CallSettings)
             // Create client
             PaginatedClient paginatedClient = PaginatedClient.Create();
             // Initialize request argument(s)
@@ -72,7 +71,6 @@ namespace Testing.Paginated.Snippets
             }
             // Store the pageToken, for when the next page is required.
             string nextPageToken = singlePage.NextPageToken;
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod2Snippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.Paginated.Snippets
         /// </remarks>
         public void SignatureMethod2()
         {
-            // Snippet: SignatureMethod(string, string, int?, CallSettings)
             // Create client
             PaginatedClient paginatedClient = PaginatedClient.Create();
             // Initialize request argument(s)
@@ -68,7 +67,6 @@ namespace Testing.Paginated.Snippets
             }
             // Store the pageToken, for when the next page is required.
             string nextPageToken = singlePage.NextPageToken;
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod3AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod3AsyncSnippet.g.cs
@@ -31,7 +31,6 @@ namespace Testing.Paginated.Snippets
         /// </remarks>
         public async Task SignatureMethod3Async()
         {
-            // Snippet: SignatureMethodAsync(string, int?, CallSettings)
             // Create client
             PaginatedClient paginatedClient = await PaginatedClient.CreateAsync();
             // Make the request
@@ -68,7 +67,6 @@ namespace Testing.Paginated.Snippets
             }
             // Store the pageToken, for when the next page is required.
             string nextPageToken = singlePage.NextPageToken;
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod3Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethod3Snippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.Paginated.Snippets
         /// </remarks>
         public void SignatureMethod3()
         {
-            // Snippet: SignatureMethod(string, int?, CallSettings)
             // Create client
             PaginatedClient paginatedClient = PaginatedClient.Create();
             // Make the request
@@ -66,7 +65,6 @@ namespace Testing.Paginated.Snippets
             }
             // Store the pageToken, for when the next page is required.
             string nextPageToken = singlePage.NextPageToken;
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethodRequestObjectAsyncSnippet.g.cs
@@ -31,7 +31,6 @@ namespace Testing.Paginated.Snippets
         /// </remarks>
         public async Task SignatureMethodRequestObjectAsync()
         {
-            // Snippet: SignatureMethodAsync(Request, CallSettings)
             // Create client
             PaginatedClient paginatedClient = await PaginatedClient.CreateAsync();
             // Initialize request argument(s)
@@ -74,7 +73,6 @@ namespace Testing.Paginated.Snippets
             }
             // Store the pageToken, for when the next page is required.
             string nextPageToken = singlePage.NextPageToken;
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.StandaloneSnippets/PaginatedClient.SignatureMethodRequestObjectSnippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.Paginated.Snippets
         /// </remarks>
         public void SignatureMethodRequestObject()
         {
-            // Snippet: SignatureMethod(Request, CallSettings)
             // Create client
             PaginatedClient paginatedClient = PaginatedClient.Create();
             // Initialize request argument(s)
@@ -72,7 +71,6 @@ namespace Testing.Paginated.Snippets
             }
             // Store the pageToken, for when the next page is required.
             string nextPageToken = singlePage.NextPageToken;
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1AsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.ResourceNameSeparator.Snippets
         /// </remarks>
         public async Task Method1Async()
         {
-            // Snippet: Method1Async(string, string, CallSettings)
-            // Additional: Method1Async(string, string, CancellationToken)
             // Create client
             ResourceNameSeparatorClient resourceNameSeparatorClient = await ResourceNameSeparatorClient.CreateAsync();
             // Initialize request argument(s)
@@ -37,7 +35,6 @@ namespace Testing.ResourceNameSeparator.Snippets
             string @ref = "items/[ITEM_A_ID].[ITEM_B_ID]/details/[DETAILS_A_ID]_[DETAILS_B_ID]-[DETAILS_C_ID]/extra/[EXTRA_ID]";
             // Make the request
             Response response = await resourceNameSeparatorClient.Method1Async(name, @ref);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1RequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1RequestObjectAsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.ResourceNameSeparator.Snippets
         /// </remarks>
         public async Task Method1RequestObjectAsync()
         {
-            // Snippet: Method1Async(Request, CallSettings)
-            // Additional: Method1Async(Request, CancellationToken)
             // Create client
             ResourceNameSeparatorClient resourceNameSeparatorClient = await ResourceNameSeparatorClient.CreateAsync();
             // Initialize request argument(s)
@@ -40,7 +38,6 @@ namespace Testing.ResourceNameSeparator.Snippets
             };
             // Make the request
             Response response = await resourceNameSeparatorClient.Method1Async(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1RequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1RequestObjectSnippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.ResourceNameSeparator.Snippets
         /// </remarks>
         public void Method1RequestObject()
         {
-            // Snippet: Method1(Request, CallSettings)
             // Create client
             ResourceNameSeparatorClient resourceNameSeparatorClient = ResourceNameSeparatorClient.Create();
             // Initialize request argument(s)
@@ -38,7 +37,6 @@ namespace Testing.ResourceNameSeparator.Snippets
             };
             // Make the request
             Response response = resourceNameSeparatorClient.Method1(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1ResourceNamesAsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.ResourceNameSeparator.Snippets
         /// </remarks>
         public async Task Method1ResourceNamesAsync()
         {
-            // Snippet: Method1Async(RequestName, RequestName, CallSettings)
-            // Additional: Method1Async(RequestName, RequestName, CancellationToken)
             // Create client
             ResourceNameSeparatorClient resourceNameSeparatorClient = await ResourceNameSeparatorClient.CreateAsync();
             // Initialize request argument(s)
@@ -37,7 +35,6 @@ namespace Testing.ResourceNameSeparator.Snippets
             RequestName @ref = RequestName.FromItemAItemBDetailsADetailsBDetailsCExtra("[ITEM_A_ID]", "[ITEM_B_ID]", "[DETAILS_A_ID]", "[DETAILS_B_ID]", "[DETAILS_C_ID]", "[EXTRA_ID]");
             // Make the request
             Response response = await resourceNameSeparatorClient.Method1Async(name, @ref);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1ResourceNamesSnippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.ResourceNameSeparator.Snippets
         /// </remarks>
         public void Method1ResourceNames()
         {
-            // Snippet: Method1(RequestName, RequestName, CallSettings)
             // Create client
             ResourceNameSeparatorClient resourceNameSeparatorClient = ResourceNameSeparatorClient.Create();
             // Initialize request argument(s)
@@ -35,7 +34,6 @@ namespace Testing.ResourceNameSeparator.Snippets
             RequestName @ref = RequestName.FromItemAItemBDetailsADetailsBDetailsCExtra("[ITEM_A_ID]", "[ITEM_B_ID]", "[DETAILS_A_ID]", "[DETAILS_B_ID]", "[DETAILS_C_ID]", "[EXTRA_ID]");
             // Make the request
             Response response = resourceNameSeparatorClient.Method1(name, @ref);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.StandaloneSnippets/ResourceNameSeparatorClient.Method1Snippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.ResourceNameSeparator.Snippets
         /// </remarks>
         public void Method1()
         {
-            // Snippet: Method1(string, string, CallSettings)
             // Create client
             ResourceNameSeparatorClient resourceNameSeparatorClient = ResourceNameSeparatorClient.Create();
             // Initialize request argument(s)
@@ -35,7 +34,6 @@ namespace Testing.ResourceNameSeparator.Snippets
             string @ref = "items/[ITEM_A_ID].[ITEM_B_ID]/details/[DETAILS_A_ID]_[DETAILS_B_ID]-[DETAILS_C_ID]/extra/[EXTRA_ID]";
             // Make the request
             Response response = resourceNameSeparatorClient.Method1(name, @ref);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodAsyncSnippet.g.cs
@@ -29,8 +29,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public async Task SinglePatternMethodAsync()
         {
-            // Snippet: SinglePatternMethodAsync(string, string, IEnumerable<string>, string, IEnumerable<string>, CallSettings)
-            // Additional: SinglePatternMethodAsync(string, string, IEnumerable<string>, string, IEnumerable<string>, CancellationToken)
             // Create client
             ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
             // Initialize request argument(s)
@@ -41,7 +39,6 @@ namespace Testing.ResourceNames.Snippets
             IEnumerable<string> repeatedValueRef = new string[] { "items/[ITEM_ID]", };
             // Make the request
             Response response = await resourceNamesClient.SinglePatternMethodAsync(realName, @ref, repeatedRef, valueRef, repeatedValueRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodRequestObjectAsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public async Task SinglePatternMethodRequestObjectAsync()
         {
-            // Snippet: SinglePatternMethodAsync(SinglePattern, CallSettings)
-            // Additional: SinglePatternMethodAsync(SinglePattern, CancellationToken)
             // Create client
             ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
             // Initialize request argument(s)
@@ -49,7 +47,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = await resourceNamesClient.SinglePatternMethodAsync(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodRequestObjectSnippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public void SinglePatternMethodRequestObject()
         {
-            // Snippet: SinglePatternMethod(SinglePattern, CallSettings)
             // Create client
             ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
             // Initialize request argument(s)
@@ -47,7 +46,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = resourceNamesClient.SinglePatternMethod(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodResourceNamesAsyncSnippet.g.cs
@@ -29,8 +29,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public async Task SinglePatternMethodResourceNamesAsync()
         {
-            // Snippet: SinglePatternMethodAsync(SinglePatternName, SinglePatternName, IEnumerable<SinglePatternName>, SinglePatternName, IEnumerable<SinglePatternName>, CallSettings)
-            // Additional: SinglePatternMethodAsync(SinglePatternName, SinglePatternName, IEnumerable<SinglePatternName>, SinglePatternName, IEnumerable<SinglePatternName>, CancellationToken)
             // Create client
             ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
             // Initialize request argument(s)
@@ -47,7 +45,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = await resourceNamesClient.SinglePatternMethodAsync(realName, @ref, repeatedRef, valueRef, repeatedValueRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodResourceNamesSnippet.g.cs
@@ -28,7 +28,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public void SinglePatternMethodResourceNames()
         {
-            // Snippet: SinglePatternMethod(SinglePatternName, SinglePatternName, IEnumerable<SinglePatternName>, SinglePatternName, IEnumerable<SinglePatternName>, CallSettings)
             // Create client
             ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
             // Initialize request argument(s)
@@ -45,7 +44,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = resourceNamesClient.SinglePatternMethod(realName, @ref, repeatedRef, valueRef, repeatedValueRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.SinglePatternMethodSnippet.g.cs
@@ -28,7 +28,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public void SinglePatternMethod()
         {
-            // Snippet: SinglePatternMethod(string, string, IEnumerable<string>, string, IEnumerable<string>, CallSettings)
             // Create client
             ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
             // Initialize request argument(s)
@@ -39,7 +38,6 @@ namespace Testing.ResourceNames.Snippets
             IEnumerable<string> repeatedValueRef = new string[] { "items/[ITEM_ID]", };
             // Make the request
             Response response = resourceNamesClient.SinglePatternMethod(realName, @ref, repeatedRef, valueRef, repeatedValueRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodAsyncSnippet.g.cs
@@ -29,8 +29,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public async Task WildcardMultiPatternMethodAsync()
         {
-            // Snippet: WildcardMultiPatternMethodAsync(string, string, IEnumerable<string>, CallSettings)
-            // Additional: WildcardMultiPatternMethodAsync(string, string, IEnumerable<string>, CancellationToken)
             // Create client
             ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
             // Initialize request argument(s)
@@ -39,7 +37,6 @@ namespace Testing.ResourceNames.Snippets
             IEnumerable<string> repeatedRef = new string[] { "singular_item", };
             // Make the request
             Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodRequestObjectAsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public async Task WildcardMultiPatternMethodRequestObjectAsync()
         {
-            // Snippet: WildcardMultiPatternMethodAsync(WildcardMultiPattern, CallSettings)
-            // Additional: WildcardMultiPatternMethodAsync(WildcardMultiPattern, CancellationToken)
             // Create client
             ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
             // Initialize request argument(s)
@@ -44,7 +42,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodRequestObjectSnippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public void WildcardMultiPatternMethodRequestObject()
         {
-            // Snippet: WildcardMultiPatternMethod(WildcardMultiPattern, CallSettings)
             // Create client
             ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
             // Initialize request argument(s)
@@ -42,7 +41,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = resourceNamesClient.WildcardMultiPatternMethod(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames1AsyncSnippet.g.cs
@@ -29,8 +29,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public async Task WildcardMultiPatternMethodResourceNames1Async()
         {
-            // Snippet: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, WildcardMultiPatternName, IEnumerable<WildcardMultiPatternName>, CallSettings)
-            // Additional: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, WildcardMultiPatternName, IEnumerable<WildcardMultiPatternName>, CancellationToken)
             // Create client
             ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
             // Initialize request argument(s)
@@ -42,7 +40,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames1Snippet.g.cs
@@ -28,7 +28,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public void WildcardMultiPatternMethodResourceNames1()
         {
-            // Snippet: WildcardMultiPatternMethod(WildcardMultiPatternName, WildcardMultiPatternName, IEnumerable<WildcardMultiPatternName>, CallSettings)
             // Create client
             ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
             // Initialize request argument(s)
@@ -40,7 +39,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames2AsyncSnippet.g.cs
@@ -30,8 +30,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public async Task WildcardMultiPatternMethodResourceNames2Async()
         {
-            // Snippet: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, WildcardMultiPatternName, IEnumerable<IResourceName>, CallSettings)
-            // Additional: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, WildcardMultiPatternName, IEnumerable<IResourceName>, CancellationToken)
             // Create client
             ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
             // Initialize request argument(s)
@@ -43,7 +41,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames2Snippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public void WildcardMultiPatternMethodResourceNames2()
         {
-            // Snippet: WildcardMultiPatternMethod(WildcardMultiPatternName, WildcardMultiPatternName, IEnumerable<IResourceName>, CallSettings)
             // Create client
             ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
             // Initialize request argument(s)
@@ -41,7 +40,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames3AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames3AsyncSnippet.g.cs
@@ -30,8 +30,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public async Task WildcardMultiPatternMethodResourceNames3Async()
         {
-            // Snippet: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, IResourceName, IEnumerable<WildcardMultiPatternName>, CallSettings)
-            // Additional: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, IResourceName, IEnumerable<WildcardMultiPatternName>, CancellationToken)
             // Create client
             ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
             // Initialize request argument(s)
@@ -43,7 +41,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames3Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames3Snippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public void WildcardMultiPatternMethodResourceNames3()
         {
-            // Snippet: WildcardMultiPatternMethod(WildcardMultiPatternName, IResourceName, IEnumerable<WildcardMultiPatternName>, CallSettings)
             // Create client
             ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
             // Initialize request argument(s)
@@ -41,7 +40,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames4AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames4AsyncSnippet.g.cs
@@ -30,8 +30,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public async Task WildcardMultiPatternMethodResourceNames4Async()
         {
-            // Snippet: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, IResourceName, IEnumerable<IResourceName>, CallSettings)
-            // Additional: WildcardMultiPatternMethodAsync(WildcardMultiPatternName, IResourceName, IEnumerable<IResourceName>, CancellationToken)
             // Create client
             ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
             // Initialize request argument(s)
@@ -43,7 +41,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames4Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames4Snippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public void WildcardMultiPatternMethodResourceNames4()
         {
-            // Snippet: WildcardMultiPatternMethod(WildcardMultiPatternName, IResourceName, IEnumerable<IResourceName>, CallSettings)
             // Create client
             ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
             // Initialize request argument(s)
@@ -41,7 +40,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames5AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames5AsyncSnippet.g.cs
@@ -30,8 +30,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public async Task WildcardMultiPatternMethodResourceNames5Async()
         {
-            // Snippet: WildcardMultiPatternMethodAsync(IResourceName, WildcardMultiPatternName, IEnumerable<WildcardMultiPatternName>, CallSettings)
-            // Additional: WildcardMultiPatternMethodAsync(IResourceName, WildcardMultiPatternName, IEnumerable<WildcardMultiPatternName>, CancellationToken)
             // Create client
             ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
             // Initialize request argument(s)
@@ -43,7 +41,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames5Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames5Snippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public void WildcardMultiPatternMethodResourceNames5()
         {
-            // Snippet: WildcardMultiPatternMethod(IResourceName, WildcardMultiPatternName, IEnumerable<WildcardMultiPatternName>, CallSettings)
             // Create client
             ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
             // Initialize request argument(s)
@@ -41,7 +40,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames6AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames6AsyncSnippet.g.cs
@@ -30,8 +30,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public async Task WildcardMultiPatternMethodResourceNames6Async()
         {
-            // Snippet: WildcardMultiPatternMethodAsync(IResourceName, WildcardMultiPatternName, IEnumerable<IResourceName>, CallSettings)
-            // Additional: WildcardMultiPatternMethodAsync(IResourceName, WildcardMultiPatternName, IEnumerable<IResourceName>, CancellationToken)
             // Create client
             ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
             // Initialize request argument(s)
@@ -43,7 +41,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames6Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames6Snippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public void WildcardMultiPatternMethodResourceNames6()
         {
-            // Snippet: WildcardMultiPatternMethod(IResourceName, WildcardMultiPatternName, IEnumerable<IResourceName>, CallSettings)
             // Create client
             ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
             // Initialize request argument(s)
@@ -41,7 +40,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames7AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames7AsyncSnippet.g.cs
@@ -30,8 +30,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public async Task WildcardMultiPatternMethodResourceNames7Async()
         {
-            // Snippet: WildcardMultiPatternMethodAsync(IResourceName, IResourceName, IEnumerable<WildcardMultiPatternName>, CallSettings)
-            // Additional: WildcardMultiPatternMethodAsync(IResourceName, IResourceName, IEnumerable<WildcardMultiPatternName>, CancellationToken)
             // Create client
             ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
             // Initialize request argument(s)
@@ -43,7 +41,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames7Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames7Snippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public void WildcardMultiPatternMethodResourceNames7()
         {
-            // Snippet: WildcardMultiPatternMethod(IResourceName, IResourceName, IEnumerable<WildcardMultiPatternName>, CallSettings)
             // Create client
             ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
             // Initialize request argument(s)
@@ -41,7 +40,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames8AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames8AsyncSnippet.g.cs
@@ -30,8 +30,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public async Task WildcardMultiPatternMethodResourceNames8Async()
         {
-            // Snippet: WildcardMultiPatternMethodAsync(IResourceName, IResourceName, IEnumerable<IResourceName>, CallSettings)
-            // Additional: WildcardMultiPatternMethodAsync(IResourceName, IResourceName, IEnumerable<IResourceName>, CancellationToken)
             // Create client
             ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
             // Initialize request argument(s)
@@ -43,7 +41,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = await resourceNamesClient.WildcardMultiPatternMethodAsync(name, @ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames8Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames8Snippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public void WildcardMultiPatternMethodResourceNames8()
         {
-            // Snippet: WildcardMultiPatternMethod(IResourceName, IResourceName, IEnumerable<IResourceName>, CallSettings)
             // Create client
             ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
             // Initialize request argument(s)
@@ -41,7 +40,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMethodSnippet.g.cs
@@ -28,7 +28,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public void WildcardMultiPatternMethod()
         {
-            // Snippet: WildcardMultiPatternMethod(string, string, IEnumerable<string>, CallSettings)
             // Create client
             ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
             // Initialize request argument(s)
@@ -37,7 +36,6 @@ namespace Testing.ResourceNames.Snippets
             IEnumerable<string> repeatedRef = new string[] { "singular_item", };
             // Make the request
             Response response = resourceNamesClient.WildcardMultiPatternMethod(name, @ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodAsyncSnippet.g.cs
@@ -29,8 +29,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public async Task WildcardMultiPatternMultipleMethodAsync()
         {
-            // Snippet: WildcardMultiPatternMultipleMethodAsync(string, IEnumerable<string>, CallSettings)
-            // Additional: WildcardMultiPatternMultipleMethodAsync(string, IEnumerable<string>, CancellationToken)
             // Create client
             ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
             // Initialize request argument(s)
@@ -38,7 +36,6 @@ namespace Testing.ResourceNames.Snippets
             IEnumerable<string> repeatedRef = new string[] { "constPattern", };
             // Make the request
             Response response = await resourceNamesClient.WildcardMultiPatternMultipleMethodAsync(@ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodRequestObjectAsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public async Task WildcardMultiPatternMultipleMethodRequestObjectAsync()
         {
-            // Snippet: WildcardMultiPatternMultipleMethodAsync(WildcardMultiPatternMultiple, CallSettings)
-            // Additional: WildcardMultiPatternMultipleMethodAsync(WildcardMultiPatternMultiple, CancellationToken)
             // Create client
             ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
             // Initialize request argument(s)
@@ -44,7 +42,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = await resourceNamesClient.WildcardMultiPatternMultipleMethodAsync(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodRequestObjectSnippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public void WildcardMultiPatternMultipleMethodRequestObject()
         {
-            // Snippet: WildcardMultiPatternMultipleMethod(WildcardMultiPatternMultiple, CallSettings)
             // Create client
             ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
             // Initialize request argument(s)
@@ -42,7 +41,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = resourceNamesClient.WildcardMultiPatternMultipleMethod(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames1AsyncSnippet.g.cs
@@ -29,8 +29,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public async Task WildcardMultiPatternMultipleMethodResourceNames1Async()
         {
-            // Snippet: WildcardMultiPatternMultipleMethodAsync(WildcardMultiPatternMultipleName, IEnumerable<WildcardMultiPatternMultipleName>, CallSettings)
-            // Additional: WildcardMultiPatternMultipleMethodAsync(WildcardMultiPatternMultipleName, IEnumerable<WildcardMultiPatternMultipleName>, CancellationToken)
             // Create client
             ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
             // Initialize request argument(s)
@@ -41,7 +39,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = await resourceNamesClient.WildcardMultiPatternMultipleMethodAsync(@ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames1Snippet.g.cs
@@ -28,7 +28,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public void WildcardMultiPatternMultipleMethodResourceNames1()
         {
-            // Snippet: WildcardMultiPatternMultipleMethod(WildcardMultiPatternMultipleName, IEnumerable<WildcardMultiPatternMultipleName>, CallSettings)
             // Create client
             ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
             // Initialize request argument(s)
@@ -39,7 +38,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = resourceNamesClient.WildcardMultiPatternMultipleMethod(@ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames2AsyncSnippet.g.cs
@@ -30,8 +30,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public async Task WildcardMultiPatternMultipleMethodResourceNames2Async()
         {
-            // Snippet: WildcardMultiPatternMultipleMethodAsync(WildcardMultiPatternMultipleName, IEnumerable<IResourceName>, CallSettings)
-            // Additional: WildcardMultiPatternMultipleMethodAsync(WildcardMultiPatternMultipleName, IEnumerable<IResourceName>, CancellationToken)
             // Create client
             ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
             // Initialize request argument(s)
@@ -42,7 +40,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = await resourceNamesClient.WildcardMultiPatternMultipleMethodAsync(@ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames2Snippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public void WildcardMultiPatternMultipleMethodResourceNames2()
         {
-            // Snippet: WildcardMultiPatternMultipleMethod(WildcardMultiPatternMultipleName, IEnumerable<IResourceName>, CallSettings)
             // Create client
             ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
             // Initialize request argument(s)
@@ -40,7 +39,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = resourceNamesClient.WildcardMultiPatternMultipleMethod(@ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames3AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames3AsyncSnippet.g.cs
@@ -30,8 +30,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public async Task WildcardMultiPatternMultipleMethodResourceNames3Async()
         {
-            // Snippet: WildcardMultiPatternMultipleMethodAsync(IResourceName, IEnumerable<WildcardMultiPatternMultipleName>, CallSettings)
-            // Additional: WildcardMultiPatternMultipleMethodAsync(IResourceName, IEnumerable<WildcardMultiPatternMultipleName>, CancellationToken)
             // Create client
             ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
             // Initialize request argument(s)
@@ -42,7 +40,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = await resourceNamesClient.WildcardMultiPatternMultipleMethodAsync(@ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames3Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames3Snippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public void WildcardMultiPatternMultipleMethodResourceNames3()
         {
-            // Snippet: WildcardMultiPatternMultipleMethod(IResourceName, IEnumerable<WildcardMultiPatternMultipleName>, CallSettings)
             // Create client
             ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
             // Initialize request argument(s)
@@ -40,7 +39,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = resourceNamesClient.WildcardMultiPatternMultipleMethod(@ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames4AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames4AsyncSnippet.g.cs
@@ -30,8 +30,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public async Task WildcardMultiPatternMultipleMethodResourceNames4Async()
         {
-            // Snippet: WildcardMultiPatternMultipleMethodAsync(IResourceName, IEnumerable<IResourceName>, CallSettings)
-            // Additional: WildcardMultiPatternMultipleMethodAsync(IResourceName, IEnumerable<IResourceName>, CancellationToken)
             // Create client
             ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
             // Initialize request argument(s)
@@ -42,7 +40,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = await resourceNamesClient.WildcardMultiPatternMultipleMethodAsync(@ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames4Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames4Snippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public void WildcardMultiPatternMultipleMethodResourceNames4()
         {
-            // Snippet: WildcardMultiPatternMultipleMethod(IResourceName, IEnumerable<IResourceName>, CallSettings)
             // Create client
             ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
             // Initialize request argument(s)
@@ -40,7 +39,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = resourceNamesClient.WildcardMultiPatternMultipleMethod(@ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodSnippet.g.cs
@@ -28,7 +28,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public void WildcardMultiPatternMultipleMethod()
         {
-            // Snippet: WildcardMultiPatternMultipleMethod(string, IEnumerable<string>, CallSettings)
             // Create client
             ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
             // Initialize request argument(s)
@@ -36,7 +35,6 @@ namespace Testing.ResourceNames.Snippets
             IEnumerable<string> repeatedRef = new string[] { "constPattern", };
             // Make the request
             Response response = resourceNamesClient.WildcardMultiPatternMultipleMethod(@ref, repeatedRef);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodAsyncSnippet.g.cs
@@ -29,8 +29,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public async Task WildcardOnlyPatternMethodAsync()
         {
-            // Snippet: WildcardOnlyPatternMethodAsync(string, string, IEnumerable<string>, string, IEnumerable<string>, CallSettings)
-            // Additional: WildcardOnlyPatternMethodAsync(string, string, IEnumerable<string>, string, IEnumerable<string>, CancellationToken)
             // Create client
             ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
             // Initialize request argument(s)
@@ -47,7 +45,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = await resourceNamesClient.WildcardOnlyPatternMethodAsync(name, @ref, repeatedRef, refSugar, repeatedRefSugar);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodRequestObjectAsyncSnippet.g.cs
@@ -29,8 +29,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public async Task WildcardOnlyPatternMethodRequestObjectAsync()
         {
-            // Snippet: WildcardOnlyPatternMethodAsync(WildcardOnlyPattern, CallSettings)
-            // Additional: WildcardOnlyPatternMethodAsync(WildcardOnlyPattern, CancellationToken)
             // Create client
             ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
             // Initialize request argument(s)
@@ -50,7 +48,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = await resourceNamesClient.WildcardOnlyPatternMethodAsync(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodRequestObjectSnippet.g.cs
@@ -28,7 +28,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public void WildcardOnlyPatternMethodRequestObject()
         {
-            // Snippet: WildcardOnlyPatternMethod(WildcardOnlyPattern, CallSettings)
             // Create client
             ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
             // Initialize request argument(s)
@@ -48,7 +47,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = resourceNamesClient.WildcardOnlyPatternMethod(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodResourceNamesAsyncSnippet.g.cs
@@ -30,8 +30,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public async Task WildcardOnlyPatternMethodResourceNamesAsync()
         {
-            // Snippet: WildcardOnlyPatternMethodAsync(IResourceName, IResourceName, IEnumerable<IResourceName>, IResourceName, IEnumerable<IResourceName>, CallSettings)
-            // Additional: WildcardOnlyPatternMethodAsync(IResourceName, IResourceName, IEnumerable<IResourceName>, IResourceName, IEnumerable<IResourceName>, CancellationToken)
             // Create client
             ResourceNamesClient resourceNamesClient = await ResourceNamesClient.CreateAsync();
             // Initialize request argument(s)
@@ -48,7 +46,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = await resourceNamesClient.WildcardOnlyPatternMethodAsync(name, @ref, repeatedRef, refSugar, repeatedRefSugar);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodResourceNamesSnippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public void WildcardOnlyPatternMethodResourceNames()
         {
-            // Snippet: WildcardOnlyPatternMethod(IResourceName, IResourceName, IEnumerable<IResourceName>, IResourceName, IEnumerable<IResourceName>, CallSettings)
             // Create client
             ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
             // Initialize request argument(s)
@@ -46,7 +45,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = resourceNamesClient.WildcardOnlyPatternMethod(name, @ref, repeatedRef, refSugar, repeatedRefSugar);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.StandaloneSnippets/ResourceNamesClient.WildcardOnlyPatternMethodSnippet.g.cs
@@ -28,7 +28,6 @@ namespace Testing.ResourceNames.Snippets
         /// </remarks>
         public void WildcardOnlyPatternMethod()
         {
-            // Snippet: WildcardOnlyPatternMethod(string, string, IEnumerable<string>, string, IEnumerable<string>, CallSettings)
             // Create client
             ResourceNamesClient resourceNamesClient = ResourceNamesClient.Create();
             // Initialize request argument(s)
@@ -45,7 +44,6 @@ namespace Testing.ResourceNames.Snippets
             };
             // Make the request
             Response response = resourceNamesClient.WildcardOnlyPatternMethod(name, @ref, repeatedRef, refSugar, repeatedRefSugar);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodBidiStreamingSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodBidiStreamingSnippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodBidiStreaming()
         {
-            // Snippet: MethodBidiStreaming(CallSettings, BidirectionalStreamingSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize streaming call, retrieving the stream object
@@ -73,7 +72,6 @@ namespace Testing.Snippets.Snippets
             // Await the response handler
             // This will complete once all server responses have been processed
             await responseHandlerTask;
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesAsyncSnippet.g.cs
@@ -29,8 +29,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodDefaultValuesAsync()
         {
-            // Snippet: MethodDefaultValuesAsync(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, IEnumerable<string>, CallSettings)
-            // Additional: MethodDefaultValuesAsync(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, IEnumerable<string>, CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
@@ -45,7 +43,6 @@ namespace Testing.Snippets.Snippets
             };
             // Make the request
             Response response = await snippetsClient.MethodDefaultValuesAsync(repeatedDouble, repeatedNestedMessage, repeatedResourceName);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesRequestObjectAsyncSnippet.g.cs
@@ -30,8 +30,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodDefaultValuesRequestObjectAsync()
         {
-            // Snippet: MethodDefaultValuesAsync(DefaultValuesRequest, CallSettings)
-            // Additional: MethodDefaultValuesAsync(DefaultValuesRequest, CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
@@ -121,7 +119,6 @@ namespace Testing.Snippets.Snippets
             };
             // Make the request
             Response response = await snippetsClient.MethodDefaultValuesAsync(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesRequestObjectSnippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public void MethodDefaultValuesRequestObject()
         {
-            // Snippet: MethodDefaultValues(DefaultValuesRequest, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
@@ -119,7 +118,6 @@ namespace Testing.Snippets.Snippets
             };
             // Make the request
             Response response = snippetsClient.MethodDefaultValues(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesResourceNamesAsyncSnippet.g.cs
@@ -29,8 +29,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodDefaultValuesResourceNamesAsync()
         {
-            // Snippet: MethodDefaultValuesAsync(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, IEnumerable<AResourceName>, CallSettings)
-            // Additional: MethodDefaultValuesAsync(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, IEnumerable<AResourceName>, CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
@@ -45,7 +43,6 @@ namespace Testing.Snippets.Snippets
             };
             // Make the request
             Response response = await snippetsClient.MethodDefaultValuesAsync(repeatedDouble, repeatedNestedMessage, repeatedResourceName);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesResourceNamesSnippet.g.cs
@@ -28,7 +28,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public void MethodDefaultValuesResourceNames()
         {
-            // Snippet: MethodDefaultValues(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, IEnumerable<AResourceName>, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
@@ -43,7 +42,6 @@ namespace Testing.Snippets.Snippets
             };
             // Make the request
             Response response = snippetsClient.MethodDefaultValues(repeatedDouble, repeatedNestedMessage, repeatedResourceName);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodDefaultValuesSnippet.g.cs
@@ -28,7 +28,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public void MethodDefaultValues()
         {
-            // Snippet: MethodDefaultValues(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, IEnumerable<string>, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
@@ -43,7 +42,6 @@ namespace Testing.Snippets.Snippets
             };
             // Make the request
             Response response = snippetsClient.MethodDefaultValues(repeatedDouble, repeatedNestedMessage, repeatedResourceName);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureAsyncSnippet.g.cs
@@ -29,8 +29,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodLroResourceSignatureAsync()
         {
-            // Snippet: MethodLroResourceSignatureAsync(string, string, string, CallSettings)
-            // Additional: MethodLroResourceSignatureAsync(string, string, string, CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
@@ -55,7 +53,6 @@ namespace Testing.Snippets.Snippets
                 // If it has completed, then access the result
                 LroResponse retrievedResult = retrievedResponse.Result;
             }
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureRequestObjectAsyncSnippet.g.cs
@@ -29,8 +29,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodLroResourceSignatureRequestObjectAsync()
         {
-            // Snippet: MethodLroResourceSignatureAsync(ResourceSignatureRequest, CallSettings)
-            // Additional: MethodLroResourceSignatureAsync(ResourceSignatureRequest, CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
@@ -58,7 +56,6 @@ namespace Testing.Snippets.Snippets
                 // If it has completed, then access the result
                 LroResponse retrievedResult = retrievedResponse.Result;
             }
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureRequestObjectSnippet.g.cs
@@ -28,7 +28,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public void MethodLroResourceSignatureRequestObject()
         {
-            // Snippet: MethodLroResourceSignature(ResourceSignatureRequest, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
@@ -56,7 +55,6 @@ namespace Testing.Snippets.Snippets
                 // If it has completed, then access the result
                 LroResponse retrievedResult = retrievedResponse.Result;
             }
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureResourceNamesAsyncSnippet.g.cs
@@ -29,8 +29,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodLroResourceSignatureResourceNamesAsync()
         {
-            // Snippet: MethodLroResourceSignatureAsync(SimpleResourceName, SimpleResourceName, SimpleResourceName, CallSettings)
-            // Additional: MethodLroResourceSignatureAsync(SimpleResourceName, SimpleResourceName, SimpleResourceName, CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
@@ -55,7 +53,6 @@ namespace Testing.Snippets.Snippets
                 // If it has completed, then access the result
                 LroResponse retrievedResult = retrievedResponse.Result;
             }
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureResourceNamesSnippet.g.cs
@@ -28,7 +28,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public void MethodLroResourceSignatureResourceNames()
         {
-            // Snippet: MethodLroResourceSignature(SimpleResourceName, SimpleResourceName, SimpleResourceName, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
@@ -53,7 +52,6 @@ namespace Testing.Snippets.Snippets
                 // If it has completed, then access the result
                 LroResponse retrievedResult = retrievedResponse.Result;
             }
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroResourceSignatureSnippet.g.cs
@@ -28,7 +28,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public void MethodLroResourceSignature()
         {
-            // Snippet: MethodLroResourceSignature(string, string, string, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
@@ -53,7 +52,6 @@ namespace Testing.Snippets.Snippets
                 // If it has completed, then access the result
                 LroResponse retrievedResult = retrievedResponse.Result;
             }
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroSignaturesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroSignaturesAsyncSnippet.g.cs
@@ -29,8 +29,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodLroSignaturesAsync()
         {
-            // Snippet: MethodLroSignaturesAsync(string, int, bool, CallSettings)
-            // Additional: MethodLroSignaturesAsync(string, int, bool, CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
@@ -55,7 +53,6 @@ namespace Testing.Snippets.Snippets
                 // If it has completed, then access the result
                 LroResponse retrievedResult = retrievedResponse.Result;
             }
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroSignaturesRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroSignaturesRequestObjectAsyncSnippet.g.cs
@@ -29,8 +29,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodLroSignaturesRequestObjectAsync()
         {
-            // Snippet: MethodLroSignaturesAsync(SignatureRequest, CallSettings)
-            // Additional: MethodLroSignaturesAsync(SignatureRequest, CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
@@ -59,7 +57,6 @@ namespace Testing.Snippets.Snippets
                 // If it has completed, then access the result
                 LroResponse retrievedResult = retrievedResponse.Result;
             }
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroSignaturesRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroSignaturesRequestObjectSnippet.g.cs
@@ -28,7 +28,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public void MethodLroSignaturesRequestObject()
         {
-            // Snippet: MethodLroSignatures(SignatureRequest, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
@@ -57,7 +56,6 @@ namespace Testing.Snippets.Snippets
                 // If it has completed, then access the result
                 LroResponse retrievedResult = retrievedResponse.Result;
             }
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroSignaturesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodLroSignaturesSnippet.g.cs
@@ -28,7 +28,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public void MethodLroSignatures()
         {
-            // Snippet: MethodLroSignatures(string, int, bool, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
@@ -53,7 +52,6 @@ namespace Testing.Snippets.Snippets
                 // If it has completed, then access the result
                 LroResponse retrievedResult = retrievedResponse.Result;
             }
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodMapSignatureAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodMapSignatureAsyncSnippet.g.cs
@@ -29,15 +29,12 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodMapSignatureAsync()
         {
-            // Snippet: MethodMapSignatureAsync(IDictionary<int,string>, CallSettings)
-            // Additional: MethodMapSignatureAsync(IDictionary<int,string>, CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             IDictionary<int, string> mapIntString = new Dictionary<int, string> { { 0, "" }, };
             // Make the request
             Response response = await snippetsClient.MethodMapSignatureAsync(mapIntString);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodMapSignatureRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodMapSignatureRequestObjectAsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodMapSignatureRequestObjectAsync()
         {
-            // Snippet: MethodMapSignatureAsync(SignatureRequest, CallSettings)
-            // Additional: MethodMapSignatureAsync(SignatureRequest, CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
@@ -42,7 +40,6 @@ namespace Testing.Snippets.Snippets
             };
             // Make the request
             Response response = await snippetsClient.MethodMapSignatureAsync(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodMapSignatureRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodMapSignatureRequestObjectSnippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public void MethodMapSignatureRequestObject()
         {
-            // Snippet: MethodMapSignature(SignatureRequest, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
@@ -40,7 +39,6 @@ namespace Testing.Snippets.Snippets
             };
             // Make the request
             Response response = snippetsClient.MethodMapSignature(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodMapSignatureSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodMapSignatureSnippet.g.cs
@@ -28,14 +28,12 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public void MethodMapSignature()
         {
-            // Snippet: MethodMapSignature(IDictionary<int,string>, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
             IDictionary<int, string> mapIntString = new Dictionary<int, string> { { 0, "" }, };
             // Make the request
             Response response = snippetsClient.MethodMapSignature(mapIntString);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodOneSignatureAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodOneSignatureAsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodOneSignatureAsync()
         {
-            // Snippet: MethodOneSignatureAsync(string, int, bool, CallSettings)
-            // Additional: MethodOneSignatureAsync(string, int, bool, CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
@@ -38,7 +36,6 @@ namespace Testing.Snippets.Snippets
             bool aBool = false;
             // Make the request
             Response response = await snippetsClient.MethodOneSignatureAsync(aString, anInt, aBool);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodOneSignatureRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodOneSignatureRequestObjectAsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodOneSignatureRequestObjectAsync()
         {
-            // Snippet: MethodOneSignatureAsync(SignatureRequest, CallSettings)
-            // Additional: MethodOneSignatureAsync(SignatureRequest, CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
@@ -42,7 +40,6 @@ namespace Testing.Snippets.Snippets
             };
             // Make the request
             Response response = await snippetsClient.MethodOneSignatureAsync(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodOneSignatureRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodOneSignatureRequestObjectSnippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public void MethodOneSignatureRequestObject()
         {
-            // Snippet: MethodOneSignature(SignatureRequest, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
@@ -40,7 +39,6 @@ namespace Testing.Snippets.Snippets
             };
             // Make the request
             Response response = snippetsClient.MethodOneSignature(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodOneSignatureSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodOneSignatureSnippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public void MethodOneSignature()
         {
-            // Snippet: MethodOneSignature(string, int, bool, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
@@ -36,7 +35,6 @@ namespace Testing.Snippets.Snippets
             bool aBool = false;
             // Make the request
             Response response = snippetsClient.MethodOneSignature(aString, anInt, aBool);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureAsyncSnippet.g.cs
@@ -29,15 +29,12 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodRepeatedResourceSignatureAsync()
         {
-            // Snippet: MethodRepeatedResourceSignatureAsync(IEnumerable<string>, CallSettings)
-            // Additional: MethodRepeatedResourceSignatureAsync(IEnumerable<string>, CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             IEnumerable<string> names = new string[] { "items/[ITEM_ID]", };
             // Make the request
             Response response = await snippetsClient.MethodRepeatedResourceSignatureAsync(names);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureRequestObjectAsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodRepeatedResourceSignatureRequestObjectAsync()
         {
-            // Snippet: MethodRepeatedResourceSignatureAsync(RepeatedResourceSignatureRequest, CallSettings)
-            // Additional: MethodRepeatedResourceSignatureAsync(RepeatedResourceSignatureRequest, CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
@@ -42,7 +40,6 @@ namespace Testing.Snippets.Snippets
             };
             // Make the request
             Response response = await snippetsClient.MethodRepeatedResourceSignatureAsync(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureRequestObjectSnippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public void MethodRepeatedResourceSignatureRequestObject()
         {
-            // Snippet: MethodRepeatedResourceSignature(RepeatedResourceSignatureRequest, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
@@ -40,7 +39,6 @@ namespace Testing.Snippets.Snippets
             };
             // Make the request
             Response response = snippetsClient.MethodRepeatedResourceSignature(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureResourceNamesAsyncSnippet.g.cs
@@ -29,8 +29,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodRepeatedResourceSignatureResourceNamesAsync()
         {
-            // Snippet: MethodRepeatedResourceSignatureAsync(IEnumerable<SimpleResourceName>, CallSettings)
-            // Additional: MethodRepeatedResourceSignatureAsync(IEnumerable<SimpleResourceName>, CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
@@ -40,7 +38,6 @@ namespace Testing.Snippets.Snippets
             };
             // Make the request
             Response response = await snippetsClient.MethodRepeatedResourceSignatureAsync(names);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureResourceNamesSnippet.g.cs
@@ -28,7 +28,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public void MethodRepeatedResourceSignatureResourceNames()
         {
-            // Snippet: MethodRepeatedResourceSignature(IEnumerable<SimpleResourceName>, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
@@ -38,7 +37,6 @@ namespace Testing.Snippets.Snippets
             };
             // Make the request
             Response response = snippetsClient.MethodRepeatedResourceSignature(names);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodRepeatedResourceSignatureSnippet.g.cs
@@ -28,14 +28,12 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public void MethodRepeatedResourceSignature()
         {
-            // Snippet: MethodRepeatedResourceSignature(IEnumerable<string>, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
             IEnumerable<string> names = new string[] { "items/[ITEM_ID]", };
             // Make the request
             Response response = snippetsClient.MethodRepeatedResourceSignature(names);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature1AsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodResourceSignature1Async()
         {
-            // Snippet: MethodResourceSignatureAsync(string, string, string, CallSettings)
-            // Additional: MethodResourceSignatureAsync(string, string, string, CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
@@ -38,7 +36,6 @@ namespace Testing.Snippets.Snippets
             string thirdName = "items/[ITEM_ID]";
             // Make the request
             Response response = await snippetsClient.MethodResourceSignatureAsync(firstName, secondName, thirdName);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature1ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature1ResourceNamesAsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodResourceSignature1ResourceNamesAsync()
         {
-            // Snippet: MethodResourceSignatureAsync(SimpleResourceName, SimpleResourceName, SimpleResourceName, CallSettings)
-            // Additional: MethodResourceSignatureAsync(SimpleResourceName, SimpleResourceName, SimpleResourceName, CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
@@ -38,7 +36,6 @@ namespace Testing.Snippets.Snippets
             SimpleResourceName thirdName = SimpleResourceName.FromItem("[ITEM_ID]");
             // Make the request
             Response response = await snippetsClient.MethodResourceSignatureAsync(firstName, secondName, thirdName);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature1ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature1ResourceNamesSnippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public void MethodResourceSignature1ResourceNames()
         {
-            // Snippet: MethodResourceSignature(SimpleResourceName, SimpleResourceName, SimpleResourceName, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
@@ -36,7 +35,6 @@ namespace Testing.Snippets.Snippets
             SimpleResourceName thirdName = SimpleResourceName.FromItem("[ITEM_ID]");
             // Make the request
             Response response = snippetsClient.MethodResourceSignature(firstName, secondName, thirdName);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature1Snippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public void MethodResourceSignature1()
         {
-            // Snippet: MethodResourceSignature(string, string, string, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
@@ -36,7 +35,6 @@ namespace Testing.Snippets.Snippets
             string thirdName = "items/[ITEM_ID]";
             // Make the request
             Response response = snippetsClient.MethodResourceSignature(firstName, secondName, thirdName);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature2AsyncSnippet.g.cs
@@ -28,15 +28,12 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodResourceSignature2Async()
         {
-            // Snippet: MethodResourceSignatureAsync(string, CallSettings)
-            // Additional: MethodResourceSignatureAsync(string, CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             string firstName = "items/[ITEM_ID]";
             // Make the request
             Response response = await snippetsClient.MethodResourceSignatureAsync(firstName);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature2ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature2ResourceNamesAsyncSnippet.g.cs
@@ -28,15 +28,12 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodResourceSignature2ResourceNamesAsync()
         {
-            // Snippet: MethodResourceSignatureAsync(SimpleResourceName, CallSettings)
-            // Additional: MethodResourceSignatureAsync(SimpleResourceName, CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
             // Make the request
             Response response = await snippetsClient.MethodResourceSignatureAsync(firstName);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature2ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature2ResourceNamesSnippet.g.cs
@@ -27,14 +27,12 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public void MethodResourceSignature2ResourceNames()
         {
-            // Snippet: MethodResourceSignature(SimpleResourceName, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
             SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
             // Make the request
             Response response = snippetsClient.MethodResourceSignature(firstName);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignature2Snippet.g.cs
@@ -27,14 +27,12 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public void MethodResourceSignature2()
         {
-            // Snippet: MethodResourceSignature(string, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
             string firstName = "items/[ITEM_ID]";
             // Make the request
             Response response = snippetsClient.MethodResourceSignature(firstName);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignatureRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignatureRequestObjectAsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodResourceSignatureRequestObjectAsync()
         {
-            // Snippet: MethodResourceSignatureAsync(ResourceSignatureRequest, CallSettings)
-            // Additional: MethodResourceSignatureAsync(ResourceSignatureRequest, CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
@@ -41,7 +39,6 @@ namespace Testing.Snippets.Snippets
             };
             // Make the request
             Response response = await snippetsClient.MethodResourceSignatureAsync(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignatureRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodResourceSignatureRequestObjectSnippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public void MethodResourceSignatureRequestObject()
         {
-            // Snippet: MethodResourceSignature(ResourceSignatureRequest, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
@@ -39,7 +38,6 @@ namespace Testing.Snippets.Snippets
             };
             // Make the request
             Response response = snippetsClient.MethodResourceSignature(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreaming1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreaming1Snippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodServerStreaming1()
         {
-            // Snippet: MethodServerStreaming(string, bool, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
@@ -47,7 +46,6 @@ namespace Testing.Snippets.Snippets
                 // Do something with streamed response
             }
             // The response stream has completed
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreaming2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreaming2Snippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodServerStreaming2()
         {
-            // Snippet: MethodServerStreaming(CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Make the request, returning a streaming response
@@ -44,7 +43,6 @@ namespace Testing.Snippets.Snippets
                 // Do something with streamed response
             }
             // The response stream has completed
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreamingRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreamingRequestObjectSnippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodServerStreamingRequestObject()
         {
-            // Snippet: MethodServerStreaming(SignatureRequest, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
@@ -52,7 +51,6 @@ namespace Testing.Snippets.Snippets
                 // Do something with streamed response
             }
             // The response stream has completed
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreamingResourcesRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreamingResourcesRequestObjectSnippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodServerStreamingResourcesRequestObject()
         {
-            // Snippet: MethodServerStreamingResources(ResourceSignatureRequest, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
@@ -51,7 +50,6 @@ namespace Testing.Snippets.Snippets
                 // Do something with streamed response
             }
             // The response stream has completed
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreamingResourcesResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreamingResourcesResourceNamesSnippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodServerStreamingResourcesResourceNames()
         {
-            // Snippet: MethodServerStreamingResources(SimpleResourceName, SimpleResourceName, SimpleResourceName, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
@@ -48,7 +47,6 @@ namespace Testing.Snippets.Snippets
                 // Do something with streamed response
             }
             // The response stream has completed
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreamingResourcesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodServerStreamingResourcesSnippet.g.cs
@@ -29,7 +29,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodServerStreamingResources()
         {
-            // Snippet: MethodServerStreamingResources(string, string, string, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
@@ -48,7 +47,6 @@ namespace Testing.Snippets.Snippets
                 // Do something with streamed response
             }
             // The response stream has completed
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures1AsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodThreeSignatures1Async()
         {
-            // Snippet: MethodThreeSignaturesAsync(string, int, bool, CallSettings)
-            // Additional: MethodThreeSignaturesAsync(string, int, bool, CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
@@ -38,7 +36,6 @@ namespace Testing.Snippets.Snippets
             bool aBool = false;
             // Make the request
             Response response = await snippetsClient.MethodThreeSignaturesAsync(aString, anInt, aBool);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures1Snippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public void MethodThreeSignatures1()
         {
-            // Snippet: MethodThreeSignatures(string, int, bool, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
@@ -36,7 +35,6 @@ namespace Testing.Snippets.Snippets
             bool aBool = false;
             // Make the request
             Response response = snippetsClient.MethodThreeSignatures(aString, anInt, aBool);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures2AsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodThreeSignatures2Async()
         {
-            // Snippet: MethodThreeSignaturesAsync(string, bool, CallSettings)
-            // Additional: MethodThreeSignaturesAsync(string, bool, CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
@@ -37,7 +35,6 @@ namespace Testing.Snippets.Snippets
             bool aBool = false;
             // Make the request
             Response response = await snippetsClient.MethodThreeSignaturesAsync(aString, aBool);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures2Snippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public void MethodThreeSignatures2()
         {
-            // Snippet: MethodThreeSignatures(string, bool, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
@@ -35,7 +34,6 @@ namespace Testing.Snippets.Snippets
             bool aBool = false;
             // Make the request
             Response response = snippetsClient.MethodThreeSignatures(aString, aBool);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures3AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures3AsyncSnippet.g.cs
@@ -28,13 +28,10 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodThreeSignatures3Async()
         {
-            // Snippet: MethodThreeSignaturesAsync(CallSettings)
-            // Additional: MethodThreeSignaturesAsync(CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Make the request
             Response response = await snippetsClient.MethodThreeSignaturesAsync();
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures3Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignatures3Snippet.g.cs
@@ -27,12 +27,10 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public void MethodThreeSignatures3()
         {
-            // Snippet: MethodThreeSignatures(CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Make the request
             Response response = snippetsClient.MethodThreeSignatures();
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignaturesRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignaturesRequestObjectAsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task MethodThreeSignaturesRequestObjectAsync()
         {
-            // Snippet: MethodThreeSignaturesAsync(SignatureRequest, CallSettings)
-            // Additional: MethodThreeSignaturesAsync(SignatureRequest, CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
@@ -42,7 +40,6 @@ namespace Testing.Snippets.Snippets
             };
             // Make the request
             Response response = await snippetsClient.MethodThreeSignaturesAsync(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignaturesRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.MethodThreeSignaturesRequestObjectSnippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public void MethodThreeSignaturesRequestObject()
         {
-            // Snippet: MethodThreeSignatures(SignatureRequest, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
@@ -40,7 +39,6 @@ namespace Testing.Snippets.Snippets
             };
             // Make the request
             Response response = snippetsClient.MethodThreeSignatures(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.OneOfMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.OneOfMethodRequestObjectAsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task OneOfMethodRequestObjectAsync()
         {
-            // Snippet: OneOfMethodAsync(OneOfRequest, CallSettings)
-            // Additional: OneOfMethodAsync(OneOfRequest, CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
@@ -40,7 +38,6 @@ namespace Testing.Snippets.Snippets
             };
             // Make the request
             Response response = await snippetsClient.OneOfMethodAsync(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.OneOfMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.OneOfMethodRequestObjectSnippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public void OneOfMethodRequestObject()
         {
-            // Snippet: OneOfMethod(OneOfRequest, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
@@ -38,7 +37,6 @@ namespace Testing.Snippets.Snippets
             };
             // Make the request
             Response response = snippetsClient.OneOfMethod(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.TaskMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.TaskMethodRequestObjectAsyncSnippet.g.cs
@@ -28,15 +28,12 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public async Task TaskMethodRequestObjectAsync()
         {
-            // Snippet: TaskMethodAsync(Task, CallSettings)
-            // Additional: TaskMethodAsync(Task, CancellationToken)
             // Create client
             SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             ts::Task request = new ts::Task { };
             // Make the request
             ts::Task response = await snippetsClient.TaskMethodAsync(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.TaskMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.StandaloneSnippets/SnippetsClient.TaskMethodRequestObjectSnippet.g.cs
@@ -27,14 +27,12 @@ namespace Testing.Snippets.Snippets
         /// </remarks>
         public void TaskMethodRequestObject()
         {
-            // Snippet: TaskMethod(Task, CallSettings)
             // Create client
             SnippetsClient snippetsClient = SnippetsClient.Create();
             // Initialize request argument(s)
             Task request = new Task { };
             // Make the request
             Task response = snippetsClient.TaskMethod(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodAsyncSnippet.g.cs
@@ -28,15 +28,12 @@ namespace Testing.VoidReturn.Snippets
         /// </remarks>
         public async Task VoidMethodAsync()
         {
-            // Snippet: VoidMethodAsync(string, CallSettings)
-            // Additional: VoidMethodAsync(string, CancellationToken)
             // Create client
             VoidReturnClient voidReturnClient = await VoidReturnClient.CreateAsync();
             // Initialize request argument(s)
             string name = "items/[ITEM_ID]";
             // Make the request
             await voidReturnClient.VoidMethodAsync(name);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodRequestObjectAsyncSnippet.g.cs
@@ -28,8 +28,6 @@ namespace Testing.VoidReturn.Snippets
         /// </remarks>
         public async Task VoidMethodRequestObjectAsync()
         {
-            // Snippet: VoidMethodAsync(Request, CallSettings)
-            // Additional: VoidMethodAsync(Request, CancellationToken)
             // Create client
             VoidReturnClient voidReturnClient = await VoidReturnClient.CreateAsync();
             // Initialize request argument(s)
@@ -39,7 +37,6 @@ namespace Testing.VoidReturn.Snippets
             };
             // Make the request
             await voidReturnClient.VoidMethodAsync(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodRequestObjectSnippet.g.cs
@@ -27,7 +27,6 @@ namespace Testing.VoidReturn.Snippets
         /// </remarks>
         public void VoidMethodRequestObject()
         {
-            // Snippet: VoidMethod(Request, CallSettings)
             // Create client
             VoidReturnClient voidReturnClient = VoidReturnClient.Create();
             // Initialize request argument(s)
@@ -37,7 +36,6 @@ namespace Testing.VoidReturn.Snippets
             };
             // Make the request
             voidReturnClient.VoidMethod(request);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodResourceNamesAsyncSnippet.g.cs
@@ -28,15 +28,12 @@ namespace Testing.VoidReturn.Snippets
         /// </remarks>
         public async Task VoidMethodResourceNamesAsync()
         {
-            // Snippet: VoidMethodAsync(ResourceName, CallSettings)
-            // Additional: VoidMethodAsync(ResourceName, CancellationToken)
             // Create client
             VoidReturnClient voidReturnClient = await VoidReturnClient.CreateAsync();
             // Initialize request argument(s)
             ResourceName name = ResourceName.FromItem("[ITEM_ID]");
             // Make the request
             await voidReturnClient.VoidMethodAsync(name);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodResourceNamesSnippet.g.cs
@@ -27,14 +27,12 @@ namespace Testing.VoidReturn.Snippets
         /// </remarks>
         public void VoidMethodResourceNames()
         {
-            // Snippet: VoidMethod(ResourceName, CallSettings)
             // Create client
             VoidReturnClient voidReturnClient = VoidReturnClient.Create();
             // Initialize request argument(s)
             ResourceName name = ResourceName.FromItem("[ITEM_ID]");
             // Make the request
             voidReturnClient.VoidMethod(name);
-            // End snippet
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.StandaloneSnippets/VoidReturnClient.VoidMethodSnippet.g.cs
@@ -27,14 +27,12 @@ namespace Testing.VoidReturn.Snippets
         /// </remarks>
         public void VoidMethod()
         {
-            // Snippet: VoidMethod(string, CallSettings)
             // Create client
             VoidReturnClient voidReturnClient = VoidReturnClient.Create();
             // Initialize request argument(s)
             string name = "items/[ITEM_ID]";
             // Make the request
             voidReturnClient.VoidMethod(name);
-            // End snippet
         }
     }
 }


### PR DESCRIPTION
Standalone snippets will use region tags and metadata.

- Production code changes in SnippetCodeGenerator.cs only. The rest is just changes to the expected output.
- This shouldn't trigger regeneration but as usual I'm running it on local on won't merge until that's done.
- @jskeet as for your recommendation from #323 review to use a named parameter, that's a Func, so I can't. I've added a comment though.