### PR TITLE
fix(REST): Type and property declaration for keyword named enums didn't match.

### DIFF
--- a/Google.Api.Generator.Rest/Models/EnumModel.cs
+++ b/Google.Api.Generator.Rest/Models/EnumModel.cs
@@ -47,7 +47,7 @@ namespace Google.Api.Generator.Rest.Models
             IList<string> values = schema.Enum__;
             IList<string> description = schema.EnumDescriptions;
             Description = schema.Description;
-            TypeName = name.ToMemberName() + "Enum";
+            TypeName = name.ToMemberName(addUnderscoresToEscape: false) + "Enum";
             // The exact value of the key doesn't particularly matter, so long as it's unique.
             // This should be fine.
             string enumStorageKey = $"{parentTyp.FullName}.{TypeName}";

--- a/Google.Api.Generator.Rest/Models/Naming.cs
+++ b/Google.Api.Generator.Rest/Models/Naming.cs
@@ -47,15 +47,15 @@ namespace Google.Api.Generator.Rest.Models
         /// <summary>
         /// Equivalent to ToClassName in csharp_generator.py
         /// </summary>
-        internal static string ToClassName(this string name, PackageModel package, string containingClass)
+        internal static string ToClassName(this string name, PackageModel package, string containingClass, bool escapeIfKeyword = true)
         {
-            if (Keywords.IsKeyword(name.ToLowerInvariant()))
+            if (escapeIfKeyword && Keywords.IsKeyword(name.ToLowerInvariant()))
             {
                 return package.ClassName.ToUpperCamelCase() + name.ToUpperCamelCase();
             }
             // csharp_generator.py splits by dots and then joins the bits together with dots,
             // but we never need that (and it causes issues with names like "$.xgafv").
-            var candidate = ToMemberName(name);
+            var candidate = ToMemberName(name, addUnderscoresToEscape: escapeIfKeyword);
             var suffix = candidate == containingClass ? "Schema" : "";
             return candidate + suffix;
         }

--- a/Google.Api.Generator.Rest/Models/SchemaTypes.cs
+++ b/Google.Api.Generator.Rest/Models/SchemaTypes.cs
@@ -78,7 +78,7 @@ namespace Google.Api.Generator.Rest.Models
             }
             else if (inParameter && schema.Enum__ is object)
             {
-                Typ enumTyp = Typ.Nested(currentTyp, name.ToClassName(package, currentTyp.Name) + "Enum", isEnum: true);
+                Typ enumTyp = Typ.Nested(currentTyp, name.ToClassName(package, currentTyp.Name, escapeIfKeyword: false) + "Enum", isEnum: true);
                 return (schema.Required ?? false) ? enumTyp : Typ.Generic(Typ.Of(typeof(Nullable<>)), enumTyp);
             }
             else if (schema.Repeated ?? false)


### PR DESCRIPTION
Found when generating https://admin.googleapis.com/$discovery/rest?version=directory_v1, which contains an enum named `event`.