### PR TITLE
fix(bazel): Remove monolith Bazel rule deps [csharp]

### DIFF
--- a/bazel_example/BUILD.bazel
+++ b/bazel_example/BUILD.bazel
@@ -14,6 +14,7 @@
 
 load("@gapic_generator_csharp//rules_csharp_gapic:csharp_gapic.bzl", "csharp_proto_library", "csharp_grpc_library", "csharp_gapic_library")
 load("@gapic_generator_csharp//rules_csharp_gapic:csharp_gapic_pkg.bzl", "csharp_gapic_assembly_pkg")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "example_proto",

--- a/bazel_example/WORKSPACE.bazel
+++ b/bazel_example/WORKSPACE.bazel
@@ -14,15 +14,14 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+_protobuf_version = "3.17.3"
 http_archive(
     name = "com_google_protobuf",
 #    sha256 = "e5265d552e12c1f39c72842fa91d84941726026fa056d914ea6a25cd58d7bbf8",
 #    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.12.3.zip"],
 #    strip_prefix = "protobuf-3.12.3",
-# The 3.12.3 tag is incorrect, so reference the commit-hash of what it should have been.
-    sha256 = "bba884e1dce7b9ba5bce566bfa2d23ea2c824aa928a9133139c5485cefa69139",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/9ce8c330e736b99c2bb00bdc6a60f00ab600c283.zip"],
-    strip_prefix = "protobuf-9ce8c330e736b99c2bb00bdc6a60f00ab600c283",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/v%s.zip" % _protobuf_version],
+    strip_prefix = "protobuf-%s" % _protobuf_version,
 )
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 protobuf_deps()

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -17,13 +17,13 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//rules_csharp_gapic:csharp_compiler_repo.bzl", "csharp_compiler", "dotnet_restore")
 
 def gapic_generator_csharp_repositories():
-    maybe(
-        http_archive,
-        name = "com_google_api_codegen",
-        strip_prefix = "gapic-generator-2.2.0",
-        urls = ["https://github.com/googleapis/gapic-generator/archive/v2.2.0.zip"],
-        sha256 = "0633651c7e7cdbea16231025de8a8e55773c224ad840507a8f3b38f96461ad30"
+    _rules_gapic_version = "0.5.4"
+    http_archive(
+        name = "rules_gapic",
+        strip_prefix = "rules_gapic-%s" % _rules_gapic_version,
+        urls = ["https://github.com/googleapis/rules_gapic/archive/v%s.tar.gz" % _rules_gapic_version],
     )
+
     maybe(
         csharp_compiler,
         name = "csharp_compiler",

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -17,6 +17,14 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//rules_csharp_gapic:csharp_compiler_repo.bzl", "csharp_compiler", "dotnet_restore")
 
 def gapic_generator_csharp_repositories():
+    maybe(
+      http_archive,
+      name = "com_google_api_codegen",
+      strip_prefix = "gapic-generator-2.2.0",
+      urls = ["https://github.com/googleapis/gapic-generator/archive/v2.2.0.zip"],
+      sha256 = "0633651c7e7cdbea16231025de8a8e55773c224ad840507a8f3b38f96461ad30"
+    )
+
     _rules_gapic_version = "0.5.4"
     maybe(
         http_archive,

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -18,7 +18,8 @@ load("//rules_csharp_gapic:csharp_compiler_repo.bzl", "csharp_compiler", "dotnet
 
 def gapic_generator_csharp_repositories():
     _rules_gapic_version = "0.5.4"
-    http_archive(
+    maybe(
+        http_archive,
         name = "rules_gapic",
         strip_prefix = "rules_gapic-%s" % _rules_gapic_version,
         urls = ["https://github.com/googleapis/rules_gapic/archive/v%s.tar.gz" % _rules_gapic_version],

--- a/rules_csharp_gapic/csharp_gapic.bzl
+++ b/rules_csharp_gapic/csharp_gapic.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@com_google_api_codegen//rules_gapic:gapic.bzl", "proto_custom_library", "GapicInfo")
+load("@rules_gapic//:gapic.bzl", "GapicInfo", "proto_custom_library")
 
 def csharp_proto_library(name, deps, **kwargs):
     # Build zip file of protoc output
@@ -45,8 +45,8 @@ def _csharp_gapic_library_add_gapicinfo_impl(ctx):
 _csharp_gapic_library_add_gapicinfo = rule(
     implementation = _csharp_gapic_library_add_gapicinfo_impl,
     attrs = {
-        "output": attr.label(allow_single_file = True)
-    }
+        "output": attr.label(allow_single_file = True),
+    },
 )
 
 def csharp_gapic_library(
@@ -76,4 +76,3 @@ def csharp_gapic_library(
         name = name,
         output = ":{name_srcjar}".format(name_srcjar = name_srcjar),
     )
-

--- a/rules_csharp_gapic/csharp_gapic_pkg.bzl
+++ b/rules_csharp_gapic/csharp_gapic_pkg.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@com_google_api_codegen//rules_gapic:gapic.bzl", "GapicInfo")
+load("@rules_gapic//:gapic.bzl", "GapicInfo")
 
 def _csharp_gapic_assembly_pkg_impl(ctx):
     out_dir = ctx.actions.declare_directory(ctx.attr.package_dir)
@@ -43,10 +43,10 @@ tar -czhpf {out_tar} -C {out_dir}/.. {pkg_name}
             out_dir = out_dir.path,
             out_tar = out_tar.path,
             pkg_name = ctx.attr.name,
-        )
+        ),
     )
     return [DefaultInfo(
-        files = depset(direct = [out_tar])
+        files = depset(direct = [out_tar]),
     )]
 
 _csharp_gapic_assembly_pkg = rule(
@@ -55,7 +55,7 @@ _csharp_gapic_assembly_pkg = rule(
         "deps": attr.label_list(mandatory = True, allow_files = True),
         "package_dir": attr.string(mandatory = True),
         "_zipper": attr.label(default = Label("@bazel_tools//tools/zip:zipper"), cfg = "host", executable = True),
-    }
+    },
 )
 
 def csharp_gapic_assembly_pkg(name, deps, **kwargs):


### PR DESCRIPTION
This is needed for the preliminary removal of the monolith rules from `googleapis`' `switched_rules_by_language`.
Confirming that `bazel_example` builds with this PR.