### PR TITLE
fix(bazel): Eradicate monolith Bazel deps from C# µgen repo

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -17,14 +17,6 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//rules_csharp_gapic:csharp_compiler_repo.bzl", "csharp_compiler", "dotnet_restore")
 
 def gapic_generator_csharp_repositories():
-    maybe(
-      http_archive,
-      name = "com_google_api_codegen",
-      strip_prefix = "gapic-generator-2.2.0",
-      urls = ["https://github.com/googleapis/gapic-generator/archive/v2.2.0.zip"],
-      sha256 = "0633651c7e7cdbea16231025de8a8e55773c224ad840507a8f3b38f96461ad30"
-    )
-
     _rules_gapic_version = "0.5.4"
     maybe(
         http_archive,


### PR DESCRIPTION
Context: Cleaning up the removal of monolith Bazel deps from microgenerators, for the monolith's deprecation. Similar PRs in other microgenerators:
- [Java](https://github.com/googleapis/gapic-generator-java/pull/778)
- [Ruby](https://github.com/googleapis/gapic-generator-ruby/pull/614)
- [PHP](https://github.com/googleapis/gapic-generator-php/pull/311)