### PR TITLE
fix: Generate appropriate XML docs for generic paginated resources

### DIFF
--- a/Google.Api.Generator/Generation/MethodDetails.cs
+++ b/Google.Api.Generator/Generation/MethodDetails.cs
@@ -59,6 +59,10 @@ namespace Google.Api.Generator.Generation
                 FieldDescriptor responseResourceField, int pageSizeFieldNumber, int pageTokenFieldNumber) : base(svc, desc)
             {
                 ResourceTyp = ProtoTyp.Of(responseResourceField, forceRepeated: false);
+                // For map fields, ResourceTyp is a constructed KeyValuePair<,> type: we need the open type in a cref.
+                ResourceTypForCref = responseResourceField.IsMap
+                    ? Typ.Generic(typeof(KeyValuePair<,>), Typ.GenericParam("TKey"), Typ.GenericParam("TValue"))
+                    : ResourceTyp;
                 ApiCallTyp = Typ.Generic(typeof(ApiCall<,>), RequestTyp, ResponseTyp);
                 SyncReturnTyp = Typ.Generic(typeof(PagedEnumerable<,>), ResponseTyp, ResourceTyp);
                 AsyncReturnTyp = Typ.Generic(typeof(PagedAsyncEnumerable<,>), ResponseTyp, ResourceTyp);
@@ -72,6 +76,11 @@ namespace Google.Api.Generator.Generation
             public override Typ SyncReturnTyp { get; }
             public override Typ AsyncReturnTyp { get; }
             public Typ ResourceTyp { get; }
+            /// <summary>
+            /// The resource type, but using open generic types instead of constructed ones where necessary,
+            /// so they're suitable for cref attributes.
+            /// </summary>
+            public Typ ResourceTypForCref { get; }
             public Typ SyncGrpcType { get; }
             public Typ AsyncGrpcType { get; }
             public string ResourcesFieldName { get; }

--- a/Google.Api.Generator/Generation/ServiceMethodGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceMethodGenerator.cs
@@ -186,8 +186,8 @@ namespace Google.Api.Generator.Generation
             private DocumentationCommentTriviaSyntax CancellationTokenXmlDoc => XmlDoc.Param(CancellationTokenParam, "A ", Ctx.Type<CancellationToken>(), " to use for this RPC.");
             private DocumentationCommentTriviaSyntax ReturnsSyncXmlDoc => XmlDoc.Returns("The RPC response.");
             private DocumentationCommentTriviaSyntax ReturnsAsyncXmlDoc => XmlDoc.Returns("A Task containing the RPC response.");
-            private DocumentationCommentTriviaSyntax ReturnsSyncPaginatedXmlDoc => XmlDoc.Returns("A pageable sequence of ", Ctx.Type(MethodDetailsPaginated.ResourceTyp) , " resources.");
-            private DocumentationCommentTriviaSyntax ReturnsAsyncPaginatedXmlDoc => XmlDoc.Returns("A pageable asynchronous sequence of ", Ctx.Type(MethodDetailsPaginated.ResourceTyp), " resources.");
+            private DocumentationCommentTriviaSyntax ReturnsSyncPaginatedXmlDoc => XmlDoc.Returns("A pageable sequence of ", Ctx.Type(MethodDetailsPaginated.ResourceTypForCref) , " resources.");
+            private DocumentationCommentTriviaSyntax ReturnsAsyncPaginatedXmlDoc => XmlDoc.Returns("A pageable asynchronous sequence of ", Ctx.Type(MethodDetailsPaginated.ResourceTypForCref), " resources.");
             private DocumentationCommentTriviaSyntax OperationsSummaryXmlDoc => XmlDoc.Summary("The long-running operations client for ", XmlDoc.C(MethodDetails.SyncMethodName), ".");
             private DocumentationCommentTriviaSyntax OperationNameXmlDoc => XmlDoc.Param(OperationNameParam, "The name of a previously invoked operation. Must not be ", XmlDoc.C("null"), " or empty.");
             private DocumentationCommentTriviaSyntax BidiStreamingSettingsXmlDoc => XmlDoc.Param(BidiStreamingSettingsParam, "If not null, applies streaming overrides to this RPC call.");


### PR DESCRIPTION
In XML docs, cref attributes can specify open generic types, but not
constructed ones... which means we can't just use the paginated
resource type directly in all cases.

This is a potentially more general problem, but the fact that it
hasn't bitten us elsewhere is encouraging - if it strikes anywhere
else, we'll know because the generated code won't compile cleanly.