### PR TITLE
Update all dependencies prior to adding Renovate

### DIFF
--- a/Google.Api.Generator.Rest.Tests/Google.Api.Generator.Rest.Tests.csproj
+++ b/Google.Api.Generator.Rest.Tests/Google.Api.Generator.Rest.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/Google.Api.Generator.Rest/Google.Api.Generator.Rest.csproj
+++ b/Google.Api.Generator.Rest/Google.Api.Generator.Rest.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Apis.Discovery.v1" Version="1.49.0" />
+    <PackageReference Include="Google.Apis.Discovery.v1" Version="1.52.0" />
     <ProjectReference Include="..\Google.Api.Generator.Utils\Google.Api.Generator.Utils.csproj" />
     <EmbeddedResource Include="StaticResources/**" />
   </ItemGroup>

--- a/Google.Api.Generator.Tests/Google.Api.Generator.Tests.csproj
+++ b/Google.Api.Generator.Tests/Google.Api.Generator.Tests.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="2.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="3.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/Google.Api.Generator.Utils/Google.Api.Generator.Utils.csproj
+++ b/Google.Api.Generator.Utils/Google.Api.Generator.Utils.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
-    <PackageReference Include="Google.Api.Gax" Version="3.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
+    <PackageReference Include="Google.Api.Gax" Version="3.4.0" />
   </ItemGroup>
 </Project>

--- a/Google.Api.Generator/Google.Api.Generator.csproj
+++ b/Google.Api.Generator/Google.Api.Generator.csproj
@@ -8,14 +8,14 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.5.0" />
-    <PackageReference Include="Google.Api.CommonProtos" Version="2.0.0-beta02" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="3.0.0-beta01" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="3.0.0-beta01" />
-    <PackageReference Include="Google.Protobuf" Version="3.15.0" />
-    <PackageReference Include="Google.LongRunning" Version="2.0.0-beta01" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
-    <PackageReference Include="Moq" Version="4.12.0" />
-    <PackageReference Include="System.Linq.Async" Version="4.0.0" />
+    <PackageReference Include="Google.Api.CommonProtos" Version="2.3.0" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="3.4.0" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="3.4.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.17.3" />
+    <PackageReference Include="Google.LongRunning" Version="2.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="System.Linq.Async" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 


### PR DESCRIPTION
This will avoid a huge slew of PRs when we first add Renovate support