### PR TITLE
chore: Add System.Collections.Immutable dependency

### DIFF
--- a/Google.Api.Generator/Google.Api.Generator.csproj
+++ b/Google.Api.Generator/Google.Api.Generator.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Google.LongRunning" Version="2.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="System.Linq.Async" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>


### PR DESCRIPTION
It's unclear exactly why this is required, but it may well be due to
a separate recent dependency update. With this in place, it's fine.