### PR TITLE
fix: Fix Asset generation which otherwise fails due to unknown resources

### DIFF
--- a/Google.Api.Generator/CodeGenerator.cs
+++ b/Google.Api.Generator/CodeGenerator.cs
@@ -109,7 +109,7 @@ namespace Google.Api.Generator
                         "All files in the same package must have the same C# namespace. " +
                         $"Found namespaces '{string.Join(", ", namespaces)}' in package '{singlePackageFileDescs.Key}'.");
                 }
-                var catalog = new ProtoCatalog(singlePackageFileDescs.Key, descriptors, commonResourcesConfigs);
+                var catalog = new ProtoCatalog(singlePackageFileDescs.Key, descriptors, singlePackageFileDescs, commonResourcesConfigs);
                 foreach (var resultFile in GeneratePackage(namespaces[0], singlePackageFileDescs, catalog, clock, grpcServiceConfig, generateMetadata))
                 {
                     yield return resultFile;

--- a/Google.Api.Generator/ProtoUtils/ResourceDetails.cs
+++ b/Google.Api.Generator/ProtoUtils/ResourceDetails.cs
@@ -206,7 +206,7 @@ namespace Google.Api.Generator.ProtoUtils
         }
 
         public static IEnumerable<Field> LoadResourceReference(MessageDescriptor msgDesc, FieldDescriptor fieldDesc,
-            IReadOnlyDictionary<string, Definition> resourcesByUrt, IReadOnlyDictionary<string, IReadOnlyList<Definition>> resourcesByParentComparison)
+            IReadOnlyDictionary<string, Definition> resourcesByUrt, IReadOnlyDictionary<string, IReadOnlyList<Definition>> resourcesByParentComparison, bool required)
         {
             // Is this field the name-field of a resource descriptor?
             var resourceDesc = msgDesc.GetExtension(ResourceExtensions.Resource);
@@ -247,7 +247,14 @@ namespace Google.Api.Generator.ProtoUtils
                     }
                     if (!resourcesByUrt.TryGetValue(resourceRef.Type, out var def))
                     {
-                        throw new InvalidOperationException($"No resource type with name: '{resourceRef.Type}' for field {msgDesc.Name}.{fieldDesc.Name}");
+                        if (required)
+                        {
+                            throw new InvalidOperationException($"No resource type with name: '{resourceRef.Type}' for field {msgDesc.Name}.{fieldDesc.Name}");
+                        }
+                        else
+                        {
+                            yield break;
+                        }
                     }
                     if (def.HasNotWildcard)
                     {
@@ -267,7 +274,14 @@ namespace Google.Api.Generator.ProtoUtils
                     }
                     if (!resourcesByUrt.TryGetValue(resourceRef.ChildType, out var childDef))
                     {
-                        throw new InvalidOperationException($"No resource type with child name: '{resourceRef.ChildType}' for field {msgDesc.Name}.{fieldDesc.Name}");
+                        if (required)
+                        {
+                            throw new InvalidOperationException($"No resource type with child name: '{resourceRef.ChildType}' for field {msgDesc.Name}.{fieldDesc.Name}");
+                        }
+                        else
+                        {
+                            yield break;
+                        }
                     }
                     // Find all resources in which the patterns are a subset of the child patterns; a wildcard matches a child wildcard.
                     // Verify that these resources together match all parent patterns of the child resource.


### PR DESCRIPTION
Before this commit, generation fails if any resource name field is
loaded without the resource definition being present. That's only
actually a problem if the field is used for generation - otherwise,
it's fine.

This commit fixes Google.Cloud.Asset.V1 to avoid an
otherwise-unnecessary import being required.

Once this has been submitted, we can create a release which will fix the Kokoro builds for googleapis/googleapis, and we can remove the workaround in google-cloud-dotnet.