### PR TITLE
fix: carve a pagination detection exception for bigquery

### DIFF
--- a/Google.Api.Generator/Generation/MethodDetails.cs
+++ b/Google.Api.Generator/Generation/MethodDetails.cs
@@ -24,7 +24,6 @@ using Grpc.ServiceConfig;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Text;

--- a/Google.Api.Generator/Generation/MethodDetails.cs
+++ b/Google.Api.Generator/Generation/MethodDetails.cs
@@ -269,7 +269,7 @@ namespace Google.Api.Generator.Generation
                 return null;
             }
 
-            if (pageSizeCandidate.Name == "max_results" && !(pageSizeCandidate.MessageType is null) && pageSizeCandidate.MessageType.FullName == "google.protobuf.UInt32Value")
+            if (pageSizeCandidate.Name == "max_results" && pageSizeCandidate.MessageType?.FullName == "google.protobuf.UInt32Value")
             {
                 // This happens in BigQuery APIs that should still be generated, without pagination
                 return null;

--- a/Google.Api.Generator/Generation/MethodDetails.cs
+++ b/Google.Api.Generator/Generation/MethodDetails.cs
@@ -269,7 +269,7 @@ namespace Google.Api.Generator.Generation
                 return null;
             }
 
-            if (pageSizeCandidate.Name == "max_results" && pageSizeCandidate.MessageType.FullName == "google.protobuf.UInt32Value")
+            if (pageSizeCandidate.Name == "max_results" && !(pageSizeCandidate.MessageType is null) && pageSizeCandidate.MessageType.FullName == "google.protobuf.UInt32Value")
             {
                 // This happens in BigQuery APIs that should still be generated, without pagination
                 return null;

--- a/Google.Api.Generator/Generation/MethodDetails.cs
+++ b/Google.Api.Generator/Generation/MethodDetails.cs
@@ -24,6 +24,7 @@ using Grpc.ServiceConfig;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Text;
@@ -266,6 +267,12 @@ namespace Google.Api.Generator.Generation
 
             if (pageSizeCandidate is null || pageTokenCandidate is null || nextPageTokenCandidate is null || !hasMapOrRepeatedCandidates)
             {
+                return null;
+            }
+
+            if (pageSizeCandidate.Name == "max_results" && pageSizeCandidate.MessageType.FullName == "google.protobuf.UInt32Value")
+            {
+                // This happens in BigQuery APIs that should still be generated, without pagination
                 return null;
             }
 


### PR DESCRIPTION
BigQuery libraries do have generation Bazel rules, even though the published library is a handwritten veneer.
Turns out those libraries also have paginated methods with `max_results` and a type google.protobuf.UInt32Value and our new pagination detection falsely identifies those as errors.