### PR TITLE
feat [bazel]: update and redirect proto and grpc rules

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -17,11 +17,13 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//rules_csharp_gapic:csharp_compiler_repo.bzl", "csharp_compiler", "dotnet_restore")
 
 def gapic_generator_csharp_repositories():
-    _rules_gapic_version = "0.5.4"
+    _rules_gapic_version = "0.7.0"
+    _rules_gapic_sha256 = "3536ddd6d03b80733fd4dbde98d9f5be784dc0a38aba14ad2f7ac2e0209a15f8"
+
     maybe(
         http_archive,
         name = "rules_gapic",
-        sha256 = "802623c01fa54d758ffb98d8613e978c44807c8dc532c0ef088a1f33b3c92bf3",
+        sha256 = _rules_gapic_sha256,
         strip_prefix = "rules_gapic-%s" % _rules_gapic_version,
         urls = ["https://github.com/googleapis/rules_gapic/archive/v%s.tar.gz" % _rules_gapic_version],
     )

--- a/rules_csharp_gapic/csharp_gapic.bzl
+++ b/rules_csharp_gapic/csharp_gapic.bzl
@@ -13,28 +13,13 @@
 # limitations under the License.
 
 load("@rules_gapic//:gapic.bzl", "GapicInfo", "proto_custom_library")
+load("@rules_gapic//csharp:csharp_gapic.bzl", _csharp_proto_library="csharp_proto_library", _csharp_grpc_library="csharp_grpc_library")
 
 def csharp_proto_library(name, deps, **kwargs):
-    # Build zip file of protoc output
-    proto_custom_library(
-        name = name,
-        deps = deps,
-        opt_args = ["file_extension=.g.cs"],
-        output_type = "csharp",
-        output_suffix = ".srcjar",
-        **kwargs
-    )
+    _csharp_proto_library(name, deps, **kwargs)
 
 def csharp_grpc_library(name, srcs, deps, **kwargs):
-    # Build zip file of grpc output
-    proto_custom_library(
-        name = name,
-        deps = srcs,
-        plugin = Label("@com_github_grpc_grpc//src/compiler:grpc_csharp_plugin"),
-        output_type = "grpc",
-        output_suffix = ".srcjar",
-        **kwargs
-    )
+    _csharp_grpc_library(name, srcs, deps, **kwargs)
 
 def _csharp_gapic_library_add_gapicinfo_impl(ctx):
     return [


### PR DESCRIPTION
bringing our local grpc and proto rules (used by bazel_example) to a better state:
(1) `csharp_proto` and `csharp_grpc` rules are now just aliases to the rules from rules_gapic
(2) updated rules_gapic to the latest version

With this bazel_example now generates `Grpc.g.cs` files