### PR TITLE
fix: Conditionalize access to the MessageType property

### DIFF
--- a/Google.Api.Generator/Generation/MethodDetails.cs
+++ b/Google.Api.Generator/Generation/MethodDetails.cs
@@ -269,7 +269,9 @@ namespace Google.Api.Generator.Generation
                 return null;
             }
 
-            if (pageSizeCandidate.Name == "max_results" && pageSizeCandidate.MessageType?.FullName == "google.protobuf.UInt32Value")
+            if (pageSizeCandidate.Name == "max_results" &&
+                pageSizeCandidate.FieldType == FieldType.Message &&
+                pageSizeCandidate.MessageType?.FullName == "google.protobuf.UInt32Value")
             {
                 // This happens in BigQuery APIs that should still be generated, without pagination
                 return null;


### PR DESCRIPTION
This is a fix on the recent BigQuery pagination fix, which
unfortunately broke Compute.