### PR TITLE
feat: Include status codes that will be retried within documentation

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTests/GrpcServiceConfig/Testing.GrpcServiceConfig/GrpcServiceConfigClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/GrpcServiceConfig/Testing.GrpcServiceConfig/GrpcServiceConfigClient.g.cs
@@ -35,6 +35,12 @@ namespace Testing.GrpcServiceConfig
         /// <item><description>Retry delay multiplier: 1.3</description></item>
         /// <item><description>Retry maximum delay: 5000 milliseconds.</description></item>
         /// <item><description>Maximum attempts: Unlimited</description></item>
+        /// <item>
+        /// <description>
+        /// Retriable status codes: <see cref="grpccore::StatusCode.DeadlineExceeded"/>,
+        /// <see cref="grpccore::StatusCode.ResourceExhausted"/>.
+        /// </description>
+        /// </item>
         /// <item><description>Timeout: 20 seconds.</description></item>
         /// </list>
         /// </remarks>
@@ -51,6 +57,9 @@ namespace Testing.GrpcServiceConfig
         /// <item><description>Retry delay multiplier: 3</description></item>
         /// <item><description>Retry maximum delay: 10000 milliseconds.</description></item>
         /// <item><description>Maximum attempts: 10</description></item>
+        /// <item>
+        /// <description>Retriable status codes: <see cref="grpccore::StatusCode.Unavailable"/>.</description>
+        /// </item>
         /// <item><description>Timeout: 60 seconds.</description></item>
         /// </list>
         /// </remarks>

--- a/Google.Api.Generator.Utils/Roslyn/XmlDoc.cs
+++ b/Google.Api.Generator.Utils/Roslyn/XmlDoc.cs
@@ -95,7 +95,7 @@ namespace Google.Api.Generator.Utils.Roslyn
         public static XmlNodeSyntax Item(params object[] parts) => XmlElement("item", SingletonList<XmlNodeSyntax>(XmlElement("description", List(parts.Select(ToNode)))));
 
         public static XmlNodeSyntax UL(params object[] items) => UL((IEnumerable<object>)items);
-        public static XmlNodeSyntax UL<T>(IEnumerable<T> items) => BulletListOfItemNodes(items.Select(item => Item(item)).ToArray());
+        public static XmlNodeSyntax UL<T>(IEnumerable<T> items) => BulletListOfItemNodes(items.Select(item => item is object[] array ? Item(array) : Item(item)).ToArray());
         public static XmlNodeSyntax BulletListOfItemNodes(params XmlNodeSyntax[] itemNodes) =>
             XmlElement(
                 XmlElementStartTag(XmlName("list"), SingletonList<XmlAttributeSyntax>(XmlTextAttribute("type", "bullet"))),

--- a/Google.Api.Generator/Generation/ServiceSettingsCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceSettingsCodeGenerator.cs
@@ -151,7 +151,31 @@ namespace Google.Api.Generator.Generation
                                 $"Retry delay multiplier: {retry.BackoffMultiplier}",
                                 $"Retry maximum delay: {(int)retry.MaxBackoff.TotalMilliseconds} milliseconds.",
                                 $"Maximum attempts: {(retry.MaxAttempts == int.MaxValue ? "Unlimited" : retry.MaxAttempts.ToString())}",
+                                GetRetriableErrorCodeDocs().ToArray(),
                                 timeoutRemark));
+
+                        IEnumerable<object> GetRetriableErrorCodeDocs()
+                        {
+                            var codes = method.MethodRetryStatusCodes.ToList();
+                            if (!codes.Any())
+                            {
+                                // This is a little unusual, in terms of "Here are the retry timing parameters, that will never be used..." but
+                                // I guess the settings could then be augmented with status codes. (And this does happen.)
+                                yield return "No status codes are retried.";
+                                yield break;
+                            }
+
+                            yield return "Retriable status codes: ";
+                            for (int i = 0; i < codes.Count; i++)
+                            {
+                                if (i != 0)
+                                {
+                                    yield return ", ";
+                                }
+                                yield return _ctx.Type<StatusCode>().Access(codes[i]);
+                            }
+                            yield return ".";
+                        }
                     }
                 }
                 else


### PR DESCRIPTION
It's not *completely* clear to me that we want to do this, but I suspect we do. (I'm finding out what other languages do.)

See below for an example of the result of this applied to `Google.Cloud.Vision.V1.ProductServiceSettings`:

![Vision sample](https://user-images.githubusercontent.com/17011/134302034-741aea07-4392-485c-b698-7bfd025ec674.png)

