### PR TITLE
Implement mixin generation 

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTest.cs
+++ b/Google.Api.Generator.Tests/ProtoTest.cs
@@ -27,7 +27,7 @@ namespace Google.Api.Generator.Tests
     public class ProtoTest
     {
         private IEnumerable<ResultFile> Run(IEnumerable<string> protoFilenames, string package,
-            string grpcServiceConfigPath, IEnumerable<string> commonResourcesConfigPaths)
+            string grpcServiceConfigPath, string serviceConfigPath, IEnumerable<string> commonResourcesConfigPaths)
         {
             var clock = new FakeClock(new DateTime(2019, 1, 1));
             var protoPaths = protoFilenames.Select(x => Path.Combine(Invoker.GeneratorTestsDir, x));
@@ -37,7 +37,7 @@ namespace Google.Api.Generator.Tests
                     $"-I{Invoker.CommonProtosDir} -I{Invoker.ProtobufDir} -I{Invoker.GeneratorTestsDir} {string.Join(" ", protoPaths)}");
                 var descriptorBytes = File.ReadAllBytes(desc.Path);
                 FileDescriptorSet descriptorSet = FileDescriptorSet.Parser.ParseFrom(descriptorBytes);
-                return CodeGenerator.Generate(descriptorSet, package, clock, grpcServiceConfigPath, commonResourcesConfigPaths);
+                return CodeGenerator.Generate(descriptorSet, package, clock, grpcServiceConfigPath, serviceConfigPath, commonResourcesConfigPaths);
             }
         }
 
@@ -46,25 +46,26 @@ namespace Google.Api.Generator.Tests
         {
             // Test that protoc executes successfully,
             // and the generator processes the descriptors without crashing!
-            Run(new[] { "ProtoTest.proto" }, "testing", null, null);
+            Run(new[] { "ProtoTest.proto" }, "testing", null, null, null);
         }
 
         private void ProtoTestSingle(string testProtoName,
             bool ignoreCsProj = false, bool ignoreSnippets = false, bool ignoreUnitTests = false,
-            string grpcServiceConfigPath = null, IEnumerable<string> commonResourcesConfigPaths = null, bool ignoreMetadataFile = true) =>
+            string grpcServiceConfigPath = null, string serviceConfigPath = null, IEnumerable<string> commonResourcesConfigPaths = null, bool ignoreMetadataFile = true) =>
             ProtoTestSingle(
                 new[] { testProtoName },
                 ignoreCsProj,
                 ignoreSnippets,
                 ignoreUnitTests,
                 grpcServiceConfigPath,
+                serviceConfigPath,
                 commonResourcesConfigPaths,
                 ignoreMetadataFile
             );
 
         private void ProtoTestSingle(IEnumerable<string> testProtoNames,
             bool ignoreCsProj = false, bool ignoreSnippets = false, bool ignoreUnitTests = false,
-            string grpcServiceConfigPath = null, IEnumerable<string> commonResourcesConfigPaths = null, bool ignoreMetadataFile = true)
+            string grpcServiceConfigPath = null, string serviceConfigPath = null, IEnumerable<string> commonResourcesConfigPaths = null, bool ignoreMetadataFile = true)
         {
             // Confirm each generated file is identical to the expected output.
             // Use `// TEST_START` and `// TEST_END` lines in the expected file to test subsets of output files.
@@ -72,7 +73,7 @@ namespace Google.Api.Generator.Tests
             var dirName = testProtoNames.First();
             var protoPaths = testProtoNames.Select(x => Path.Combine("ProtoTests", dirName, $"{x}.proto"));
             var files = Run(protoPaths, $"testing.{dirName.ToLowerInvariant()}",
-                grpcServiceConfigPath, commonResourcesConfigPaths);
+                grpcServiceConfigPath, serviceConfigPath, commonResourcesConfigPaths);
             // Check output is present.
             Assert.NotEmpty(files);
 

--- a/Google.Api.Generator.Tests/ProtoTest.cs
+++ b/Google.Api.Generator.Tests/ProtoTest.cs
@@ -236,5 +236,9 @@ namespace Google.Api.Generator.Tests
 
         [Fact]
         public void BuildLro() => BuildTest("Lro", ignoreUnitTests: true);
+
+        [Fact]
+        public void Mixins() => ProtoTestSingle("Mixins", ignoreMetadataFile: false, ignoreSnippets: true,
+            serviceConfigPath: Path.Combine(Invoker.GeneratorTestsDir, "ProtoTests", "Mixins", "Mixins.yaml"));
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Mixins/Mixins.proto
+++ b/Google.Api.Generator.Tests/ProtoTests/Mixins/Mixins.proto
@@ -1,0 +1,20 @@
+﻿syntax = "proto3";
+
+package testing.mixins;
+
+option csharp_namespace = "Testing.Mixins";
+
+import "google/api/client.proto";
+
+service MixinService {
+  option (google.api.default_host) = "mixins.example.com";
+  option (google.api.oauth_scopes) = "scope1,scope2";
+
+  rpc Method(Request) returns(Response);
+}
+
+message Request {
+}
+
+message Response {
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Mixins/Mixins.yaml
+++ b/Google.Api.Generator.Tests/ProtoTests/Mixins/Mixins.yaml
@@ -1,0 +1,12 @@
+﻿type: google.api.Service
+config_version: 3
+name: mixins.googleapis.com
+title: Mixins Test API
+
+apis:
+- name: testing.mixins.MixinService
+# These are treated as mixins
+- name: google.cloud.location.Locations
+- name: google.iam.v1.IAMPolicy
+# LROs are not treated as mixings as we have dedicated per-method handling for them.
+- name: google.longrunning.Operations

--- a/Google.Api.Generator.Tests/ProtoTests/Mixins/Testing.Mixins.Tests/MixinServiceClientTest.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Mixins/Testing.Mixins.Tests/MixinServiceClientTest.g.cs
@@ -1,0 +1,67 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+using gaxgrpc = Google.Api.Gax.Grpc;
+using gciv = Google.Cloud.Iam.V1;
+using gcl = Google.Cloud.Location;
+using grpccore = Grpc.Core;
+using moq = Moq;
+using st = System.Threading;
+using stt = System.Threading.Tasks;
+using xunit = Xunit;
+
+namespace Testing.Mixins.Tests
+{
+    /// <summary>Generated unit tests.</summary>
+    public sealed class GeneratedMixinServiceClientTest
+    {
+        [xunit::FactAttribute]
+        public void MethodRequestObject()
+        {
+            // TEST_START
+            moq::Mock<MixinService.MixinServiceClient> mockGrpcClient = new moq::Mock<MixinService.MixinServiceClient>(moq::MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLocationsClient()).Returns(new moq::Mock<gcl::Locations.LocationsClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateIAMPolicyClient()).Returns(new moq::Mock<gciv::IAMPolicy.IAMPolicyClient>().Object);
+            // TEST_END
+            Request request = new Request { };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.Method(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
+            MixinServiceClient client = new MixinServiceClientImpl(mockGrpcClient.Object, null);
+            Response response = client.Method(request);
+            xunit::Assert.Same(expectedResponse, response);
+            mockGrpcClient.VerifyAll();
+        }
+
+        [xunit::FactAttribute]
+        public async stt::Task MethodRequestObjectAsync()
+        {
+            // TEST_START
+            moq::Mock<MixinService.MixinServiceClient> mockGrpcClient = new moq::Mock<MixinService.MixinServiceClient>(moq::MockBehavior.Strict);
+            mockGrpcClient.Setup(x => x.CreateLocationsClient()).Returns(new moq::Mock<gcl::Locations.LocationsClient>().Object);
+            mockGrpcClient.Setup(x => x.CreateIAMPolicyClient()).Returns(new moq::Mock<gciv::IAMPolicy.IAMPolicyClient>().Object);
+            // TEST_END
+            Request request = new Request { };
+            Response expectedResponse = new Response { };
+            mockGrpcClient.Setup(x => x.MethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
+            MixinServiceClient client = new MixinServiceClientImpl(mockGrpcClient.Object, null);
+            Response responseCallSettings = await client.MethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
+            xunit::Assert.Same(expectedResponse, responseCallSettings);
+            Response responseCancellationToken = await client.MethodAsync(request, st::CancellationToken.None);
+            xunit::Assert.Same(expectedResponse, responseCancellationToken);
+            mockGrpcClient.VerifyAll();
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Mixins/Testing.Mixins.Tests/Testing.Mixins.Tests.csproj
+++ b/Google.Api.Generator.Tests/ProtoTests/Mixins/Testing.Mixins.Tests/Testing.Mixins.Tests.csproj
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
+    <ProjectReference Include="../Testing.Mixins/Testing.Mixins.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Google.Api.Generator.Tests/ProtoTests/Mixins/Testing.Mixins/MixinFakes.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Mixins/Testing.Mixins/MixinFakes.cs
@@ -1,0 +1,51 @@
+﻿// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+using System;
+
+// Disable warning: Missing XML comment on public members.
+// Required to successfully build this generated test project.
+#pragma warning disable 1591
+
+namespace Testing.Mixins
+{
+    // (Re-)define this here; required to successfully build this generated test project.
+    public abstract class ProtoMsgFake<T> : Google.Protobuf.IMessage<T> where T : ProtoMsgFake<T>
+    {
+        public Google.Protobuf.Reflection.MessageDescriptor Descriptor => throw new NotImplementedException();
+        public int CalculateSize() => throw new NotImplementedException();
+        public T Clone() => throw new NotImplementedException();
+        public bool Equals(T other) => throw new NotImplementedException();
+        public void MergeFrom(T message) => throw new NotImplementedException();
+        public void MergeFrom(Google.Protobuf.CodedInputStream input) => throw new NotImplementedException();
+        public void WriteTo(Google.Protobuf.CodedOutputStream output) => throw new NotImplementedException();
+    }
+
+    public partial class MixinService
+    {
+        public partial class MixinServiceClient
+        {
+            public MixinServiceClient() { }
+            public MixinServiceClient(CallInvoker callInvoker) { }
+            private CallInvoker CallInvoker => throw new NotImplementedException();
+            public virtual AsyncUnaryCall<Response> MethodAsync(Request request, CallOptions options) => throw new NotImplementedException();
+            public virtual Response Method(Request request, CallOptions options) => throw new NotImplementedException();            
+        }
+    }
+
+    public class Request : ProtoMsgFake<Request> { }
+    public class Response : ProtoMsgFake<Response> { }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Mixins/Testing.Mixins/MixinServiceClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Mixins/Testing.Mixins/MixinServiceClient.g.cs
@@ -1,0 +1,366 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+using gax = Google.Api.Gax;
+using gaxgrpc = Google.Api.Gax.Grpc;
+using gaxgrpccore = Google.Api.Gax.Grpc.GrpcCore;
+using gciv = Google.Cloud.Iam.V1;
+using gcl = Google.Cloud.Location;
+using proto = Google.Protobuf;
+using grpccore = Grpc.Core;
+using grpcinter = Grpc.Core.Interceptors;
+using sys = System;
+using scg = System.Collections.Generic;
+using sco = System.Collections.ObjectModel;
+using st = System.Threading;
+using stt = System.Threading.Tasks;
+
+namespace Testing.Mixins
+{
+    /// <summary>Settings for <see cref="MixinServiceClient"/> instances.</summary>
+    public sealed partial class MixinServiceSettings : gaxgrpc::ServiceSettingsBase
+    {
+        /// <summary>Get a new instance of the default <see cref="MixinServiceSettings"/>.</summary>
+        /// <returns>A new instance of the default <see cref="MixinServiceSettings"/>.</returns>
+        public static MixinServiceSettings GetDefault() => new MixinServiceSettings();
+
+        /// <summary>Constructs a new <see cref="MixinServiceSettings"/> object with default settings.</summary>
+        public MixinServiceSettings()
+        {
+        }
+
+        // TEST_START
+        private MixinServiceSettings(MixinServiceSettings existing) : base(existing)
+        {
+            gax::GaxPreconditions.CheckNotNull(existing, nameof(existing));
+            MethodSettings = existing.MethodSettings;
+            LocationsSettings = existing.LocationsSettings;
+            IAMPolicySettings = existing.IAMPolicySettings;
+            OnCopy(existing);
+        }
+        // TEST_END
+
+        partial void OnCopy(MixinServiceSettings existing);
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to <c>MixinServiceClient.Method</c>
+        ///  and <c>MixinServiceClient.MethodAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// <list type="bullet">
+        /// <item><description>This call will not be retried.</description></item>
+        /// <item><description>No timeout is applied.</description></item>
+        /// </list>
+        /// </remarks>
+        public gaxgrpc::CallSettings MethodSettings { get; set; } = gaxgrpc::CallSettings.FromExpiration(gax::Expiration.None);
+
+        // TEST_START
+        /// <summary>
+        /// The settings to use for the <see cref="gcl::LocationsClient"/> associated with the client.
+        /// </summary>
+        public gcl::LocationsSettings LocationsSettings { get; set; } = gcl::LocationsSettings.GetDefault();
+
+        /// <summary>
+        /// The settings to use for the <see cref="gciv::IAMPolicyClient"/> associated with the client.
+        /// </summary>
+        public gciv::IAMPolicySettings IAMPolicySettings { get; set; } = gciv::IAMPolicySettings.GetDefault();
+        // TEST_END
+
+        /// <summary>Creates a deep clone of this object, with all the same property values.</summary>
+        /// <returns>A deep clone of this <see cref="MixinServiceSettings"/> object.</returns>
+        public MixinServiceSettings Clone() => new MixinServiceSettings(this);
+    }
+
+    /// <summary>
+    /// Builder class for <see cref="MixinServiceClient"/> to provide simple configuration of credentials, endpoint etc.
+    /// </summary>
+    public sealed partial class MixinServiceClientBuilder : gaxgrpc::ClientBuilderBase<MixinServiceClient>
+    {
+        /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
+        public MixinServiceSettings Settings { get; set; }
+
+        /// <summary>Creates a new builder with default settings.</summary>
+        public MixinServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = MixinServiceClient.UseJwtAccessWithScopes;
+        }
+
+        partial void InterceptBuild(ref MixinServiceClient client);
+
+        partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<MixinServiceClient> task);
+
+        /// <summary>Builds the resulting client.</summary>
+        public override MixinServiceClient Build()
+        {
+            MixinServiceClient client = null;
+            InterceptBuild(ref client);
+            return client ?? BuildImpl();
+        }
+
+        /// <summary>Builds the resulting client asynchronously.</summary>
+        public override stt::Task<MixinServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
+        {
+            stt::Task<MixinServiceClient> task = null;
+            InterceptBuildAsync(cancellationToken, ref task);
+            return task ?? BuildAsyncImpl(cancellationToken);
+        }
+
+        private MixinServiceClient BuildImpl()
+        {
+            Validate();
+            grpccore::CallInvoker callInvoker = CreateCallInvoker();
+            return MixinServiceClient.Create(callInvoker, Settings);
+        }
+
+        private async stt::Task<MixinServiceClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
+        {
+            Validate();
+            grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
+            return MixinServiceClient.Create(callInvoker, Settings);
+        }
+
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
+        protected override string GetDefaultEndpoint() => MixinServiceClient.DefaultEndpoint;
+
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
+        protected override scg::IReadOnlyList<string> GetDefaultScopes() => MixinServiceClient.DefaultScopes;
+
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
+        protected override gaxgrpc::ChannelPool GetChannelPool() => MixinServiceClient.ChannelPool;
+
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
+        protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
+    }
+
+    /// <summary>MixinService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// </remarks>
+    public abstract partial class MixinServiceClient
+    {
+        /// <summary>
+        /// The default endpoint for the MixinService service, which is a host of "mixins.example.com" and a port of
+        /// 443.
+        /// </summary>
+        public static string DefaultEndpoint { get; } = "mixins.example.com:443";
+
+        /// <summary>The default MixinService scopes.</summary>
+        /// <remarks>
+        /// The default MixinService scopes are:
+        /// <list type="bullet">
+        /// <item><description>scope1</description></item>
+        /// <item><description>scope2</description></item>
+        /// </list>
+        /// </remarks>
+        public static scg::IReadOnlyList<string> DefaultScopes { get; } = new sco::ReadOnlyCollection<string>(new string[] { "scope1", "scope2", });
+
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
+
+        /// <summary>
+        /// Asynchronously creates a <see cref="MixinServiceClient"/> using the default credentials, endpoint and
+        /// settings. To specify custom credentials or other settings, use <see cref="MixinServiceClientBuilder"/>.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// The <see cref="st::CancellationToken"/> to use while creating the client.
+        /// </param>
+        /// <returns>The task representing the created <see cref="MixinServiceClient"/>.</returns>
+        public static stt::Task<MixinServiceClient> CreateAsync(st::CancellationToken cancellationToken = default) =>
+            new MixinServiceClientBuilder().BuildAsync(cancellationToken);
+
+        /// <summary>
+        /// Synchronously creates a <see cref="MixinServiceClient"/> using the default credentials, endpoint and
+        /// settings. To specify custom credentials or other settings, use <see cref="MixinServiceClientBuilder"/>.
+        /// </summary>
+        /// <returns>The created <see cref="MixinServiceClient"/>.</returns>
+        public static MixinServiceClient Create() => new MixinServiceClientBuilder().Build();
+
+        /// <summary>
+        /// Creates a <see cref="MixinServiceClient"/> which uses the specified call invoker for remote operations.
+        /// </summary>
+        /// <param name="callInvoker">
+        /// The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.
+        /// </param>
+        /// <param name="settings">Optional <see cref="MixinServiceSettings"/>.</param>
+        /// <returns>The created <see cref="MixinServiceClient"/>.</returns>
+        internal static MixinServiceClient Create(grpccore::CallInvoker callInvoker, MixinServiceSettings settings = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            grpcinter::Interceptor interceptor = settings?.Interceptor;
+            if (interceptor != null)
+            {
+                callInvoker = grpcinter::CallInvokerExtensions.Intercept(callInvoker, interceptor);
+            }
+            MixinService.MixinServiceClient grpcClient = new MixinService.MixinServiceClient(callInvoker);
+            return new MixinServiceClientImpl(grpcClient, settings);
+        }
+
+        /// <summary>
+        /// Shuts down any channels automatically created by <see cref="Create()"/> and
+        /// <see cref="CreateAsync(st::CancellationToken)"/>. Channels which weren't automatically created are not
+        /// affected.
+        /// </summary>
+        /// <remarks>
+        /// After calling this method, further calls to <see cref="Create()"/> and
+        /// <see cref="CreateAsync(st::CancellationToken)"/> will create new channels, which could in turn be shut down
+        /// by another call to this method.
+        /// </remarks>
+        /// <returns>A task representing the asynchronous shutdown operation.</returns>
+        public static stt::Task ShutdownDefaultChannelsAsync() => ChannelPool.ShutdownChannelsAsync();
+
+        /// <summary>The underlying gRPC MixinService client</summary>
+        public virtual MixinService.MixinServiceClient GrpcClient => throw new sys::NotImplementedException();
+
+        // TEST_START
+        /// <summary>The <see cref="gcl::LocationsClient"/> associated with this client.</summary>
+        public virtual gcl::LocationsClient LocationsClient => throw new sys::NotImplementedException();
+
+        /// <summary>The <see cref="gciv::IAMPolicyClient"/> associated with this client.</summary>
+        public virtual gciv::IAMPolicyClient IAMPolicyClient => throw new sys::NotImplementedException();
+        // TEST_END
+
+        /// <summary>
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The RPC response.</returns>
+        public virtual Response Method(Request request, gaxgrpc::CallSettings callSettings = null) =>
+            throw new sys::NotImplementedException();
+
+        /// <summary>
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual stt::Task<Response> MethodAsync(Request request, gaxgrpc::CallSettings callSettings = null) =>
+            throw new sys::NotImplementedException();
+
+        /// <summary>
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="cancellationToken">A <see cref="st::CancellationToken"/> to use for this RPC.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual stt::Task<Response> MethodAsync(Request request, st::CancellationToken cancellationToken) =>
+            MethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+    }
+
+    /// <summary>MixinService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// </remarks>
+    public sealed partial class MixinServiceClientImpl : MixinServiceClient
+    {
+        private readonly gaxgrpc::ApiCall<Request, Response> _callMethod;
+
+        // TEST_START
+        /// <summary>
+        /// Constructs a client wrapper for the MixinService service, with the specified gRPC client and settings.
+        /// </summary>
+        /// <param name="grpcClient">The underlying gRPC client.</param>
+        /// <param name="settings">The base <see cref="MixinServiceSettings"/> used within this client.</param>
+        public MixinServiceClientImpl(MixinService.MixinServiceClient grpcClient, MixinServiceSettings settings)
+        {
+            GrpcClient = grpcClient;
+            MixinServiceSettings effectiveSettings = settings ?? MixinServiceSettings.GetDefault();
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings);
+            LocationsClient = new gcl::LocationsClientImpl(grpcClient.CreateLocationsClient(), effectiveSettings.LocationsSettings);
+            IAMPolicyClient = new gciv::IAMPolicyClientImpl(grpcClient.CreateIAMPolicyClient(), effectiveSettings.IAMPolicySettings);
+            _callMethod = clientHelper.BuildApiCall<Request, Response>(grpcClient.MethodAsync, grpcClient.Method, effectiveSettings.MethodSettings);
+            Modify_ApiCall(ref _callMethod);
+            Modify_MethodApiCall(ref _callMethod);
+            OnConstruction(grpcClient, effectiveSettings, clientHelper);
+        }
+        // TEST_END
+
+        partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call) where TRequest : class, proto::IMessage<TRequest> where TResponse : class, proto::IMessage<TResponse>;
+
+        partial void Modify_MethodApiCall(ref gaxgrpc::ApiCall<Request, Response> call);
+
+        partial void OnConstruction(MixinService.MixinServiceClient grpcClient, MixinServiceSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);
+
+        /// <summary>The underlying gRPC MixinService client</summary>
+        public override MixinService.MixinServiceClient GrpcClient { get; }
+
+        /// <summary>The <see cref="gcl::LocationsClient"/> associated with this client.</summary>
+        public override gcl::LocationsClient LocationsClient { get; }
+
+        /// <summary>The <see cref="gciv::IAMPolicyClient"/> associated with this client.</summary>
+        public override gciv::IAMPolicyClient IAMPolicyClient { get; }
+
+        partial void Modify_Request(ref Request request, ref gaxgrpc::CallSettings settings);
+
+        /// <summary>
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The RPC response.</returns>
+        public override Response Method(Request request, gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_Request(ref request, ref callSettings);
+            return _callMethod.Sync(request, callSettings);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public override stt::Task<Response> MethodAsync(Request request, gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_Request(ref request, ref callSettings);
+            return _callMethod.Async(request, callSettings);
+        }
+    }
+
+    // TEST_START
+    public static partial class MixinService
+    {
+        public partial class MixinServiceClient
+        {
+            /// <summary>
+            /// Creates a new instance of <see cref="gcl::Locations.LocationsClient"/> using the same call invoker as
+            /// this client.
+            /// </summary>
+            /// <returns>
+            /// A new <see cref="gcl::Locations.LocationsClient"/> for the same target as this client.
+            /// </returns>
+            public virtual gcl::Locations.LocationsClient CreateLocationsClient() =>
+                new gcl::Locations.LocationsClient(CallInvoker);
+
+            /// <summary>
+            /// Creates a new instance of <see cref="gciv::IAMPolicy.IAMPolicyClient"/> using the same call invoker as
+            /// this client.
+            /// </summary>
+            /// <returns>
+            /// A new <see cref="gciv::IAMPolicy.IAMPolicyClient"/> for the same target as this client.
+            /// </returns>
+            public virtual gciv::IAMPolicy.IAMPolicyClient CreateIAMPolicyClient() =>
+                new gciv::IAMPolicy.IAMPolicyClient(CallInvoker);
+        }
+    }
+    // TEST_END
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Mixins/Testing.Mixins/Testing.Mixins.csproj
+++ b/Google.Api.Generator.Tests/ProtoTests/Mixins/Testing.Mixins/Testing.Mixins.csproj
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+
+    <!-- TODO: Version defaults to 1.0.0-alpha01, edit as required -->
+    <Version>1.0.0-alpha01</Version>
+
+    <!-- TODO: NuGet packaging options -->
+    <!--
+      <Description>
+        TODO: Description of this library.
+      </Description>
+      <PackageTags>TODO;Library;Tags</PackageTags>
+      <Copyright>TODO: Copyright Statement</Copyright>
+      <Authors>TODO:Authors</Authors>
+      *** TODO: These Icon, License, Project, and repo settings *MUST* be checked and edited ***
+      *** The values given are just examples ***
+      <PackageIconUrl>TODO: https://cloud.google.com/images/gcp-icon-64x64.png</PackageIconUrl>
+      <PackageLicenseUrl>TODO: https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+      <PackageProjectUrl>TODO: https://github.com/googleapis/google-cloud-dotnet</PackageProjectUrl>
+      <RepositoryType>TODO: git</RepositoryType>
+      <RepositoryUrl>TODO: https://github.com/googleapis/google-cloud-dotnet</RepositoryUrl>
+    -->
+
+    <!-- TODO: Configure package signing -->
+    <!--
+      <AssemblyOriginatorKeyFile>...</AssemblyOriginatorKeyFile>
+      <SignAssembly>true</SignAssembly>
+      <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
+    -->
+
+    <!-- These items should not require editing -->
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Deterministic>true</Deterministic>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.6.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.41.0, 3.0.0)" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
+    <PackageReference Include="Google.Cloud.Location" Version="[1.0.0, 2.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.3.0, 3.0.0)" />
+  </ItemGroup>
+
+</Project>

--- a/Google.Api.Generator.Tests/ProtoTests/Mixins/gapic_metadata.json
+++ b/Google.Api.Generator.Tests/ProtoTests/Mixins/gapic_metadata.json
@@ -1,0 +1,24 @@
+{
+  "schema": "1.0",
+  "comment": "This file maps proto services/RPCs to the corresponding library clients/methods",
+  "language": "csharp",
+  "protoPackage": "testing.mixins",
+  "libraryPackage": "Testing.Mixins",
+  "services": {
+    "MixinService": {
+      "clients": {
+        "grpc": {
+          "libraryClient": "MixinServiceClient",
+          "rpcs": {
+            "Method": {
+              "methods": [
+                "Method",
+                "MethodAsync"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/Google.Api.Generator/Generation/CsProjGenerator.cs
+++ b/Google.Api.Generator/Generation/CsProjGenerator.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.Iam.V1;
+using Google.Cloud.Location;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -23,14 +25,21 @@ namespace Google.Api.Generator.Generation
         private const string GaxGrpcCoreVersion = "[3.6.0, 4.0.0)";
         private const string GrpcCoreVersion = "[2.41.0, 3.0.0)";
         private const string LroVersion = "[2.3.0, 3.0.0)";
+        private const string IamVersion = "[2.3.0, 3.0.0)";
+        private const string LocationVersion = "[1.0.0, 2.0.0)";
         private const string ReferenceAssembliesVersion = "1.0.2";
         private const string SystemLinqAsyncVersion = "5.1.0";
         private const string TestSdkVersion = "17.0.0";
         private const string XUnitRunnerVersion = "2.4.3";
         private const string XUnitVersion = "2.4.1";
         private const string MoqVersion = "4.16.1";
+        private static readonly Dictionary<string, (string, string)> MixinToPackageAndVersion = new Dictionary<string, (string, string)>
+        {
+            { IAMPolicy.Descriptor.FullName, (typeof(IAMPolicyClient).Namespace, IamVersion) },
+            { Locations.Descriptor.FullName, (typeof(LocationsClient).Namespace, LocationVersion) }
+        };
 
-        public static string GenerateClient(bool hasLro)
+        public static string GenerateClient(bool hasLro, IEnumerable<string> mixins)
         {
             var packageRefs = string.Join("", ExtraRefs().Select(x => $"{Environment.NewLine}    {x}"));
             // TODO: Use information from package metadata; when it's finalised.
@@ -90,6 +99,11 @@ namespace Google.Api.Generator.Generation
                 if (hasLro)
                 {
                     yield return $@"<PackageReference Include=""Google.LongRunning"" Version=""{LroVersion}"" />";
+                }
+                foreach (var mixin in mixins.OrderBy(m => m, StringComparer.Ordinal))
+                {
+                    var packageVersion = MixinToPackageAndVersion[mixin];
+                    yield return $@"<PackageReference Include=""{packageVersion.Item1}"" Version=""{packageVersion.Item2}"" />";
                 }
             }
         }

--- a/Google.Api.Generator/Generation/LroAdaptationGenerator.cs
+++ b/Google.Api.Generator/Generation/LroAdaptationGenerator.cs
@@ -75,7 +75,7 @@ namespace Google.Api.Generator.Generation
         {
             foreach (var service in _fileDesc.Services)
             {
-                var serviceDetails = new ServiceDetails(_catalog, _ctx.Namespace, service, grpcServiceConfig: null);
+                var serviceDetails = new ServiceDetails(_catalog, _ctx.Namespace, service, grpcServiceConfig: null, serviceConfig: null);
                 // Assumption: each method has its own request type.
                 foreach (var method in serviceDetails.Methods.OfType<MethodDetails.NonStandardLro>())
                 {
@@ -119,7 +119,7 @@ namespace Google.Api.Generator.Generation
         {
             foreach (var service in _fileDesc.Services)
             {
-                var serviceDetails = new ServiceDetails(_catalog, _ctx.Namespace, service, grpcServiceConfig: null);
+                var serviceDetails = new ServiceDetails(_catalog, _ctx.Namespace, service, grpcServiceConfig: null, serviceConfig: null);
                 // TODO: Use "is not" and continue when we can guarantee a recent enough version of C#.
                 if (serviceDetails.NonStandardLro is ServiceDetails.NonStandardLroDetails lroDetails)
                 {

--- a/Google.Api.Generator/Generation/ServiceAbstractClientClassCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceAbstractClientClassCodeGenerator.cs
@@ -63,6 +63,7 @@ namespace Google.Api.Generator.Generation
                 cls = cls.AddMembers(
                     defaultEndpoint, defaultScopes, channelPool, useJwtAccessWithScopes, maybeUseJwtAccessWithScopes,
                     createAsync, create, createFromCallInvoker, shutdown, grpcClient);
+                cls = cls.AddMembers(Mixins().ToArray());
                 var methods = ServiceMethodGenerator.Generate(_ctx, _svc, inAbstract: true);
                 cls = cls.AddMembers(methods.ToArray());
             }
@@ -168,5 +169,11 @@ namespace Google.Api.Generator.Generation
             Property(Public | Virtual, _ctx.Type(_svc.GrpcClientTyp), "GrpcClient")
                 .WithGetBody(Throw(New(_ctx.Type<NotImplementedException>())()))
                 .WithXmlDoc(XmlDoc.Summary("The underlying gRPC ", _svc.DocumentationName, " client"));
+
+        private IEnumerable<PropertyDeclarationSyntax> Mixins() =>
+            _svc.Mixins.Select(mixin =>
+                Property(Public | Virtual, _ctx.Type(mixin.GapicClientType), mixin.GapicClientType.Name)
+                    .WithGetBody(Throw(New(_ctx.Type<NotImplementedException>())()))
+                    .WithXmlDoc(XmlDoc.Summary("The ", _ctx.Type(mixin.GapicClientType), " associated with this client.")));
     }
 }

--- a/Google.Api.Generator/Generation/ServiceSettingsCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceSettingsCodeGenerator.cs
@@ -103,7 +103,8 @@ namespace Google.Api.Generator.Generation
 
         private IEnumerable<PropertyDeclarationSyntax> SettingsProperties()
         {
-            return _svc.Methods.SelectMany(PerMethod);
+            return _svc.Methods.SelectMany(PerMethod)
+                .Concat(_svc.Mixins.Select(PerMixin));
             IEnumerable<PropertyDeclarationSyntax> PerMethod(MethodDetails method)
             {
                 var cSync = XmlDoc.C($"{_svc.ClientAbstractTyp.Name}.{method.SyncMethodName}");
@@ -198,6 +199,15 @@ namespace Google.Api.Generator.Generation
                         yield return BidiSettingsProperty(bidi);
                         break;
                 }
+            }
+
+            PropertyDeclarationSyntax PerMixin(ServiceDetails.MixinDetails mixin)
+            {
+                var settingsType = _ctx.Type(mixin.GapicSettingsType);
+                var propertyName = mixin.GapicSettingsType.Name;
+                return AutoProperty(Public, settingsType, propertyName, hasSetter: true)
+                    .WithInitializer(settingsType.Call("GetDefault")())
+                    .WithXmlDoc(XmlDoc.Summary("The settings to use for the ", _ctx.Type(mixin.GapicClientType), " associated with the client."));
             }
         }
 

--- a/Google.Api.Generator/Generation/UnitTestCodeGeneration.cs
+++ b/Google.Api.Generator/Generation/UnitTestCodeGeneration.cs
@@ -257,6 +257,10 @@ namespace Google.Api.Generator.Generation
                 }
             }
 
+            private IEnumerable<object> MixinsSetup() => Svc.Mixins.Select(mixin =>
+                MockGrpcClient.Call(nameof(Mock<string>.Setup))(Lambda(X)(X.Call("Create" + mixin.GrpcClientType.Name)()))
+                    .Call(nameof(IReturns<string, int>.Returns))(New(Ctx.Type(Typ.Generic(typeof(Mock<>), mixin.GrpcClientType)))().Access(nameof(Mock.Object))));
+
             private MethodDeclarationSyntax Sync(string methodName, IEnumerable<MethodDetails.Signature.Field> requestFields, object requestMethodArgs)
             {
                 var obsolete = Method.IsDeprecated || (requestFields?.Any(f => f.IsDeprecated) ?? false);
@@ -275,6 +279,7 @@ namespace Google.Api.Generator.Generation
                     .WithBody(
                         MockGrpcClient.WithInitializer(New(Ctx.Type(Typ.Generic(typeof(Mock<>), Svc.GrpcClientTyp)))(Ctx.Type<MockBehavior>().Access(MockBehavior.Strict))),
                         LroSetup(),
+                        MixinsSetup(),
                         Request.WithInitializer(New(Ctx.Type(Method.RequestTyp))().WithInitializer(InitMessage(Method.RequestMessageDesc, requestFields).ToArray())),
                         ExpectedResponse.WithInitializer(New(Ctx.Type(Method.ResponseTyp))().WithInitializer(InitMessage(Method.ResponseMessageDesc, null).ToArray())),
                         MockGrpcClient.Call(nameof(Mock<string>.Setup))(
@@ -311,6 +316,7 @@ namespace Google.Api.Generator.Generation
                     .WithBody(
                         MockGrpcClient.WithInitializer(New(Ctx.Type(Typ.Generic(typeof(Mock<>), Svc.GrpcClientTyp)))(Ctx.Type<MockBehavior>().Access(MockBehavior.Strict))),
                         LroSetup(),
+                        MixinsSetup(),
                         Request.WithInitializer(New(Ctx.Type(Method.RequestTyp))().WithInitializer(InitMessage(Method.RequestMessageDesc, requestFields).ToArray())),
                         ExpectedResponse.WithInitializer(New(Ctx.Type(Method.ResponseTyp))().WithInitializer(InitMessage(Method.ResponseMessageDesc, null).ToArray())),
                         MockGrpcClient.Call(nameof(Mock<string>.Setup))(

--- a/Google.Api.Generator/Google.Api.Generator.csproj
+++ b/Google.Api.Generator/Google.Api.Generator.csproj
@@ -11,6 +11,8 @@
     <PackageReference Include="Google.Api.CommonProtos" Version="2.5.0" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="3.6.0" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="3.6.0" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="2.3.0" />
+    <PackageReference Include="Google.Cloud.Location" Version="1.0.0" />
     <PackageReference Include="Google.Protobuf" Version="3.19.0" />
     <PackageReference Include="Google.LongRunning" Version="2.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
@@ -18,6 +20,7 @@
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Linq.Async" Version="5.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="YamlDotNet" Version="11.2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Google.Api.Generator/Program.cs
+++ b/Google.Api.Generator/Program.cs
@@ -30,11 +30,13 @@ namespace Google.Api.Generator
     public static class Program
     {
         private const string nameGrpcServiceConfig = "grpc-service-config";
+        private const string nameServiceConfigYaml = "service-config";
         private const string nameCommonResourcesConfig = "common-resources-config";
 
         private static IImmutableSet<string> s_validParameters = ImmutableHashSet.Create(
             nameGrpcServiceConfig,
-            nameCommonResourcesConfig);
+            nameCommonResourcesConfig,
+            nameServiceConfigYaml);
 
         public class Options
         {
@@ -49,6 +51,9 @@ namespace Google.Api.Generator
 
             [Option(nameGrpcServiceConfig, Required = false, HelpText = "Client-side gRPC service config path. JSON proto of type ServiceConfig.")]
             public string GrpcServiceConfig { get; private set; }
+
+            [Option(nameServiceConfigYaml, Required = false, HelpText = "Service config (google.api.Service) YAML path.")]
+            public string ServiceConfigYaml { get; private set; }
 
             [Option(nameCommonResourcesConfig, Required = false, HelpText = "Common resources config path. JSON proto of type CommonResources.")]
             public IEnumerable<string> CommonResourcesConfigs { get; private set; }
@@ -159,10 +164,11 @@ namespace Google.Api.Generator
                 // Generate code.
                 // On success, send all generated files back to protoc.
                 var grpcServiceConfigPath = extraParams.GetValueOrDefault(nameGrpcServiceConfig)?.SingleOrDefault();
+                var serviceConfigPath = extraParams.GetValueOrDefault(nameServiceConfigYaml)?.SingleOrDefault();
                 var commonResourcesConfigPaths = extraParams.GetValueOrDefault(nameCommonResourcesConfig);
 
                 var results = CodeGenerator.Generate(codeGenRequest.ProtoFile, codeGenRequest.FileToGenerate,
-                    SystemClock.Instance, grpcServiceConfigPath, commonResourcesConfigPaths);
+                    SystemClock.Instance, grpcServiceConfigPath, serviceConfigPath, commonResourcesConfigPaths);
 
                 codeGenResponse = new CodeGeneratorResponse
                 {
@@ -221,7 +227,7 @@ namespace Google.Api.Generator
             var descriptorBytes = File.ReadAllBytes(options.Descriptor);
             var fileDescriptorSet = FileDescriptorSet.Parser.ParseFrom(descriptorBytes);
             var files = CodeGenerator.Generate(fileDescriptorSet, options.Package, SystemClock.Instance,
-                options.GrpcServiceConfig, options.CommonResourcesConfigs);
+                options.GrpcServiceConfig, options.ServiceConfigYaml, options.CommonResourcesConfigs);
             foreach (var file in files)
             {
                 var path = Path.Combine(options.Output, file.RelativePath);


### PR DESCRIPTION
This won't build on CI as Google.Cloud.Location isn't released yet.

Various things still to do, mostly:

- Check whether routing header customization is an issue
- Generate proper XML docs instead of FIXME
- Work out whether the default mixin settings are appropriate

However, the result of generation does genuinely work:
https://github.com/googleapis/google-cloud-dotnet/pull/7426

(I've just tested listing locations, but that worked first time.)