### PR TITLE
chore: Update expected data in tests to specify 2022

### DIFF
--- a/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.ManufacturerCenter.v1/Google.Apis.ManufacturerCenter.v1.cs
+++ b/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.ManufacturerCenter.v1/Google.Apis.ManufacturerCenter.v1.cs
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.ManufacturerCenter.v1/Google.Apis.ManufacturerCenter.v1.csproj
+++ b/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.ManufacturerCenter.v1/Google.Apis.ManufacturerCenter.v1.csproj
@@ -5,7 +5,7 @@
     <Title>Google.Apis.ManufacturerCenter.v1 Client Library</Title>
     <Version>1.54.0.2323</Version>
     <Authors>Google LLC</Authors>
-    <Copyright>Copyright 2021 Google LLC</Copyright>
+    <Copyright>Copyright 2022 Google LLC</Copyright>
     <PackageTags>Google</PackageTags>
     <PackageProjectUrl>https://github.com/google/google-api-dotnet-client</PackageProjectUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.Storage.v1/Google.Apis.Storage.v1.cs
+++ b/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.Storage.v1/Google.Apis.Storage.v1.cs
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.Storage.v1/Google.Apis.Storage.v1.csproj
+++ b/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.Storage.v1/Google.Apis.Storage.v1.csproj
@@ -5,7 +5,7 @@
     <Title>Google.Apis.Storage.v1 Client Library</Title>
     <Version>1.54.0.2234</Version>
     <Authors>Google LLC</Authors>
-    <Copyright>Copyright 2021 Google LLC</Copyright>
+    <Copyright>Copyright 2022 Google LLC</Copyright>
     <PackageTags>Google</PackageTags>
     <PackageProjectUrl>https://github.com/google/google-api-dotnet-client</PackageProjectUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.Translate.v2/Google.Apis.Translate.v2.cs
+++ b/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.Translate.v2/Google.Apis.Translate.v2.cs
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.Translate.v2/Google.Apis.Translate.v2.csproj
+++ b/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.Translate.v2/Google.Apis.Translate.v2.csproj
@@ -5,7 +5,7 @@
     <Title>Google.Apis.Translate.v2 Client Library</Title>
     <Version>1.54.0.875</Version>
     <Authors>Google LLC</Authors>
-    <Copyright>Copyright 2021 Google LLC</Copyright>
+    <Copyright>Copyright 2022 Google LLC</Copyright>
     <PackageTags>Google</PackageTags>
     <PackageProjectUrl>https://github.com/google/google-api-dotnet-client</PackageProjectUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.Webfonts.v1/Google.Apis.Webfonts.v1.cs
+++ b/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.Webfonts.v1/Google.Apis.Webfonts.v1.cs
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.Webfonts.v1/Google.Apis.Webfonts.v1.csproj
+++ b/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.Webfonts.v1/Google.Apis.Webfonts.v1.csproj
@@ -5,7 +5,7 @@
     <Title>Google.Apis.Webfonts.v1 Client Library</Title>
     <Version>1.54.0.2235</Version>
     <Authors>Google LLC</Authors>
-    <Copyright>Copyright 2021 Google LLC</Copyright>
+    <Copyright>Copyright 2022 Google LLC</Copyright>
     <PackageTags>Google</PackageTags>
     <PackageProjectUrl>https://github.com/google/google-api-dotnet-client</PackageProjectUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>


### PR DESCRIPTION
Ideally we shouldn't need to do this every year, but let's unblock
other PRs for now...