### PR TITLE
tests: write generated output to temporary directory

### DIFF
--- a/Google.Api.Generator.Tests/Invoker.cs
+++ b/Google.Api.Generator.Tests/Invoker.cs
@@ -49,6 +49,8 @@ namespace Google.Api.Generator.Tests
                 isWindows ? "Google.Api.Generator.exe" : "Google.Api.Generator");
             CommonProtosDir = Path.Combine(RootDir, "api-common-protos");
             ProtobufDir = Path.Combine(RootDir, "tools", "protos");
+            var now = DateTime.UtcNow;
+            ActualGeneratedFilesDir = Path.Combine(Path.GetTempPath(), $"GeneratorTests-{now:yyyyMMddHHmmssZ}");
         }
 
         /// <summary>Root path; where the .sln file is.</summary>
@@ -59,6 +61,9 @@ namespace Google.Api.Generator.Tests
 
         /// <summary>Generator tests path; where the generator tests .csproj file is.</summary>
         public static string GeneratorTestsDir { get; }
+
+        /// <summary>The directory in which to write actual generated files. (This is in a temporary directory.)</summary>
+        public static string ActualGeneratedFilesDir { get; }
 
         /// <summary>Path to protoc executable.</summary>
         public static string ProtocFile { get; }

--- a/Google.Api.Generator.Tests/ProtoTest.cs
+++ b/Google.Api.Generator.Tests/ProtoTest.cs
@@ -75,6 +75,16 @@ namespace Google.Api.Generator.Tests
                 grpcServiceConfigPath, commonResourcesConfigPaths);
             // Check output is present.
             Assert.NotEmpty(files);
+
+            // Write all output files to the temporary directory before validating any.
+            // This makes it easier to see the complete set of outputs.
+            foreach (var file in files)
+            {
+                var pathToWriteTo = Path.Combine(Invoker.ActualGeneratedFilesDir, dirName, file.RelativePath);
+                Directory.CreateDirectory(Path.GetDirectoryName(pathToWriteTo));
+                File.WriteAllText(pathToWriteTo, file.Content);
+            }
+
             // Verify each output file.
             foreach (var file in files)
             {


### PR DESCRIPTION
This makes it easier to perform fuller diffs, and to bootstrap new
tests. Files should still be reviewed carefully, of course.

cc @viacheslav-rostovtsev 