### PR TITLE
chore: Fix occasional CI issue

### DIFF
--- a/Google.Api.Generator.Tests/Invoker.cs
+++ b/Google.Api.Generator.Tests/Invoker.cs
@@ -91,11 +91,16 @@ namespace Google.Api.Generator.Tests
             var output = new List<string>();
             using (var process = Process.Start(start))
             {
-                process.ErrorDataReceived += (_, e) => output.Add(e.Data);
-                process.OutputDataReceived += (_, e) => output.Add(e.Data);
+                DataReceivedEventHandler handler = (_, e) => output.Add(e.Data);
+                process.ErrorDataReceived += handler;
+                process.OutputDataReceived += handler;
                 process.BeginErrorReadLine();
                 process.BeginOutputReadLine();
                 var exited = process.WaitForExit((int)timeout.TotalMilliseconds);
+
+                // Avoid any extra data being added to our output while we're processing assertions.
+                process.ErrorDataReceived -= handler;
+                process.OutputDataReceived -= handler;
                 if (!exited)
                 {
                     process.Kill();


### PR DESCRIPTION
We've occasionally seen CI failures like this:

>  Error Message:
>   System.InvalidOperationException : Collection was modified; enumeration operation may not execute.

I believe this is *just* because of a race condition between the
output being modified and the assertion.

Fixes #292