### PR TITLE
fix: Don't use mixins in the same package that generates them

### DIFF
--- a/Google.Api.Generator/Generation/ServiceDetails.cs
+++ b/Google.Api.Generator/Generation/ServiceDetails.cs
@@ -78,7 +78,12 @@ namespace Google.Api.Generator.Generation
             SnippetsClientName = $"{desc.Name.ToLowerCamelCase()}Client";
             UnitTestsTyp = Typ.Manual(UnitTestsNamespace, $"Generated{desc.Name}ClientTest");
             NonStandardLro = NonStandardLroDetails.ForService(desc);
-            Mixins = serviceConfig?.Apis.Select(api => AvailableMixins.GetValueOrDefault(api.Name)).Where(mixin => mixin is object).ToList() ?? Enumerable.Empty<MixinDetails>();
+            Mixins = serviceConfig?.Apis
+                .Select(api => AvailableMixins.GetValueOrDefault(api.Name))
+                .Where(mixin => mixin is object)
+                // Don't use mixins within the package that contains that mixin.
+                .Where(mixin => mixin.GapicClientType.Namespace != ns)
+                .ToList() ?? Enumerable.Empty<MixinDetails>();
         }
 
         /// <summary>The lines of service documentation from the proto.</summary>


### PR DESCRIPTION
For example, LocationsClient shouldn't have a LocationsClient property

Fixes #438

(No extra tests for this, but local generation works now and didn't before.)