### PR TITLE
feat: Support service config in Bazel scripts

### DIFF
--- a/bazel_example/BUILD.bazel
+++ b/bazel_example/BUILD.bazel
@@ -58,6 +58,7 @@ csharp_gapic_library(
     ],
     grpc_service_config = "grpc_service_config.json",
     # common_resources_config = "common_resources_config.json",
+    service_yaml = "example.yaml"
 )
 
 csharp_gapic_assembly_pkg(

--- a/bazel_example/example.proto
+++ b/bazel_example/example.proto
@@ -5,7 +5,7 @@ package example;
 import "google/api/client.proto";
 import "google/api/resource.proto";
 
-service Example {
+service ExampleService {
     option (google.api.default_host) = "example.com";
 
     rpc ExampleMethod(Request) returns(Response);

--- a/bazel_example/example.yaml
+++ b/bazel_example/example.yaml
@@ -1,0 +1,7 @@
+type: google.api.Service
+config_version: 3
+name: example.googleapis.com
+title: Example API
+
+apis:
+- name: example.ExampleService

--- a/rules_csharp_gapic/csharp_gapic.bzl
+++ b/rules_csharp_gapic/csharp_gapic.bzl
@@ -40,6 +40,7 @@ def csharp_gapic_library(
         deps,
         grpc_service_config = None,
         common_resources_config = None,
+        service_yaml = None,
         **kwargs):
     # Build zip file of gapic-generator output
     name_srcjar = "{name}_srcjar".format(name = name)
@@ -48,6 +49,8 @@ def csharp_gapic_library(
         plugin_file_args[grpc_service_config] = "grpc-service-config"
     if common_resources_config:
         plugin_file_args[common_resources_config] = "common-resources-config"
+    if service_yaml:
+        plugin_file_args[service_yaml] = "service-config"
     proto_custom_library(
         name = name_srcjar,
         deps = srcs,


### PR DESCRIPTION
The additional parameter to `csharp_gapic_library` is `service_yaml`
even though the protobuf plugin argument is `service-config` - this is
to be consistent with the Bazel rules for other languages.

The service in example.proto has been renamed to avoid naming
collisions (so that we generate C# code that would actually build.)