### PR TITLE
fix: Better deprecation handling

### DIFF
--- a/Google.Api.Generator/Generation/UnitTestCodeGeneration.cs
+++ b/Google.Api.Generator/Generation/UnitTestCodeGeneration.cs
@@ -234,7 +234,8 @@ namespace Google.Api.Generator.Generation
                             yield return new ObjectInitExpr(
                                 propertyName,
                                 New(Ctx.Type(ProtoTyp.Of(fieldDesc.MessageType)))()
-                                    .WithInitializer(InitMessage(fieldDesc.MessageType, fieldGroup, fieldDepth + 1).ToArray()));
+                                    .WithInitializer(InitMessage(fieldDesc.MessageType, fieldGroup, fieldDepth + 1).ToArray()),
+                                isDeprecated: fieldDesc.IsDeprecated());
                         }
                     }
                 }

--- a/Google.Api.Generator/ProtoUtils/ProtoExtensions.cs
+++ b/Google.Api.Generator/ProtoUtils/ProtoExtensions.cs
@@ -41,7 +41,8 @@ namespace Google.Api.Generator.ProtoUtils
 
         public static bool IsDeprecated(this MethodDescriptor desc) => desc?.GetOptions()?.Deprecated ?? false;
 
-        public static bool IsDeprecated(this FieldDescriptor desc) => desc?.GetOptions()?.Deprecated ?? false;
+        public static bool IsDeprecated(this FieldDescriptor desc) =>
+            (desc?.GetOptions()?.Deprecated ?? false) || IsDeprecated(desc?.ContainingType);
 
         public static IEnumerable<string> DocLines(this DescriptorDeclaration decl) =>
             decl?.LeadingComments.Split('\n').Select(x => x.Trim())


### PR DESCRIPTION
- Fix one missing piece of decorating a property initializer with
  deprecation suppression
- Change deprecation detection for fields to match protoc: if the
  field isn't deprecated, but the parent message is, it's still
  marked as being obsolete