### PR TITLE
feat: Stabilize snippet metadata file by sorting on service name.

### DIFF
--- a/Google.Api.Generator/Generation/SnippetCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/SnippetCodeGenerator.cs
@@ -54,7 +54,7 @@ namespace Google.Api.Generator.Generation
                         Version = serviceDetails.PackageVersion ?? ""
                     }}
                 },
-                Snippets = { snippets }
+                Snippets = { snippets.OrderBy(snippet => snippet.ClientMethod.Method.Service.ShortName, StringComparer.Ordinal) }
             }.ToFormattedJson();
 
         public static CompilationUnitSyntax Generate(SourceFileContext ctx, ServiceDetails svc)


### PR DESCRIPTION
I ran the generator locally and most (all?) libraries with multiple clients are affected.