### PR TITLE
Generator changes for GAX v4.0.0-alpha02

### DIFF
--- a/Google.Api.Generator.Tests/Google.Api.Generator.Tests.csproj
+++ b/Google.Api.Generator.Tests/Google.Api.Generator.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="4.0.0-alpha01" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="4.0.0-alpha02" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/Google.Api.Generator.Tests/ProtoTest.cs
+++ b/Google.Api.Generator.Tests/ProtoTest.cs
@@ -61,7 +61,8 @@ namespace Google.Api.Generator.Tests
 
         private void ProtoTestSingle(string testProtoName,
             bool ignoreCsProj = false, bool ignoreSnippets = false, bool ignoreUnitTests = false,
-            string grpcServiceConfigPath = null, string serviceConfigPath = null, IEnumerable<string> commonResourcesConfigPaths = null, bool ignoreMetadataFile = true, bool ignoreApiDescriptorFile = true) =>
+            string grpcServiceConfigPath = null, string serviceConfigPath = null, IEnumerable<string> commonResourcesConfigPaths = null,
+            bool ignoreGapicMetadataFile = true, bool ignoreApiMetadataFile = true, bool ignoreServiceExtensionsFile = true) =>
             ProtoTestSingle(
                 new[] { testProtoName },
                 // The following three don't need to be customized for simple cases
@@ -74,12 +75,15 @@ namespace Google.Api.Generator.Tests
                 grpcServiceConfigPath,
                 serviceConfigPath,
                 commonResourcesConfigPaths,
-                ignoreMetadataFile
+                ignoreGapicMetadataFile,
+                ignoreApiMetadataFile,
+                ignoreServiceExtensionsFile
             );
 
         private void ProtoTestSingle(IEnumerable<string> testProtoNames, string sourceDir = null, string outputDir = null, string package = null,
             bool ignoreCsProj = false, bool ignoreSnippets = false, bool ignoreUnitTests = false,
-            string grpcServiceConfigPath = null, string serviceConfigPath = null, IEnumerable<string> commonResourcesConfigPaths = null, bool ignoreMetadataFile = true, bool ignoreApiDescriptorFile = true)
+            string grpcServiceConfigPath = null, string serviceConfigPath = null, IEnumerable<string> commonResourcesConfigPaths = null,
+            bool ignoreGapicMetadataFile = true, bool ignoreApiMetadataFile = true, bool ignoreServiceExtensionsFile = true)
         {
             // Confirm each generated file is identical to the expected output.
             // Use `// TEST_START` and `// TEST_END` lines in the expected file to test subsets of output files.
@@ -110,8 +114,9 @@ namespace Google.Api.Generator.Tests
                     (ignoreSnippets && file.RelativePath.Contains($".Snippets{Path.DirectorySeparatorChar}")) ||
                     (ignoreSnippets && file.RelativePath.Contains($".GeneratedSnippets{Path.DirectorySeparatorChar}")) ||
                     (ignoreUnitTests && file.RelativePath.Contains($".Tests{Path.DirectorySeparatorChar}")) ||
-                    (ignoreMetadataFile && file.RelativePath.EndsWith("gapic_metadata.json")) ||
-                    (ignoreApiDescriptorFile && file.RelativePath.EndsWith(PackageApiMetadataGenerator.FileName)))
+                    (ignoreGapicMetadataFile && file.RelativePath.EndsWith("gapic_metadata.json")) ||
+                    (ignoreApiMetadataFile && file.RelativePath.EndsWith(PackageApiMetadataGenerator.FileName)) ||
+                    (ignoreServiceExtensionsFile && file.RelativePath.EndsWith(ServiceCollectionExtensionsGenerator.FileName)))
                 {
                     continue;
                 }
@@ -172,7 +177,7 @@ namespace Google.Api.Generator.Tests
 
         // `0` suffix so it's easier to run this test by itself!
         [Fact]
-        public void Basic0() => ProtoTestSingle("Basic.v1", ignoreMetadataFile: false, ignoreApiDescriptorFile: false);
+        public void Basic0() => ProtoTestSingle("Basic.v1", ignoreGapicMetadataFile: false, ignoreApiMetadataFile: false);
 
         [Fact]
         public void BasicLro() => ProtoTestSingle("BasicLro", ignoreCsProj: true, ignoreUnitTests: true);
@@ -251,7 +256,7 @@ namespace Google.Api.Generator.Tests
         public void OptionalFields() => ProtoTestSingle("OptionalFields", ignoreCsProj: true, ignoreUnitTests: true, ignoreSnippets: true);
 
         [Fact]
-        public void Mixins() => ProtoTestSingle("Mixins", ignoreMetadataFile: false, ignoreSnippets: true,
+        public void Mixins() => ProtoTestSingle("Mixins", ignoreGapicMetadataFile: false, ignoreSnippets: true,
             serviceConfigPath: Path.Combine(Invoker.GeneratorTestsDir, "ProtoTests", "Mixins", "Mixins.yaml"));
 
         [Fact]
@@ -261,7 +266,7 @@ namespace Google.Api.Generator.Tests
             package: "google.showcase.v1beta1",
             ignoreUnitTests: true,
             ignoreSnippets: true,
-            ignoreApiDescriptorFile: false);
+            ignoreApiMetadataFile: false);
 
         // Build tests are testing `csproj` file generation only.
         // All other generated code is effectively "build tested" when this test project is built.

--- a/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1.Tests/BasicClientTest.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1.Tests/BasicClientTest.g.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Google LLC
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ namespace Testing.Basic.V1.Tests
             Request request = new Request { };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.AMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            BasicClient client = new BasicClientImpl(mockGrpcClient.Object, null);
+            BasicClient client = new BasicClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.AMethod(request);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -46,7 +46,7 @@ namespace Testing.Basic.V1.Tests
             Request request = new Request { };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.AMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            BasicClient client = new BasicClientImpl(mockGrpcClient.Object, null);
+            BasicClient client = new BasicClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.AMethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.AMethodAsync(request, st::CancellationToken.None);

--- a/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1/BasicClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1/BasicClient.g.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Google LLC
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ using gaxgrpc = Google.Api.Gax.Grpc;
 using proto = Google.Protobuf;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
+using mel = Microsoft.Extensions.Logging;
 using sys = System;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -102,14 +103,14 @@ namespace Testing.Basic.V1
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return BasicClient.Create(callInvoker, Settings);
+            return BasicClient.Create(callInvoker, Settings, Logger);
         }
 
         private async stt::Task<BasicClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return BasicClient.Create(callInvoker, Settings);
+            return BasicClient.Create(callInvoker, Settings, Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>
@@ -167,8 +168,9 @@ namespace Testing.Basic.V1
         /// The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.
         /// </param>
         /// <param name="settings">Optional <see cref="BasicSettings"/>.</param>
+        /// <param name="logger">Optional <see cref="mel::ILogger"/>.</param>
         /// <returns>The created <see cref="BasicClient"/>.</returns>
-        internal static BasicClient Create(grpccore::CallInvoker callInvoker, BasicSettings settings = null)
+        internal static BasicClient Create(grpccore::CallInvoker callInvoker, BasicSettings settings = null, mel::ILogger logger = null)
         {
             gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
             grpcinter::Interceptor interceptor = settings?.Interceptor;
@@ -177,7 +179,7 @@ namespace Testing.Basic.V1
                 callInvoker = grpcinter::CallInvokerExtensions.Intercept(callInvoker, interceptor);
             }
             Basic.BasicClient grpcClient = new Basic.BasicClient(callInvoker);
-            return new BasicClientImpl(grpcClient, settings);
+            return new BasicClientImpl(grpcClient, settings, logger);
         }
 
         /// <summary>
@@ -237,12 +239,13 @@ namespace Testing.Basic.V1
         /// </summary>
         /// <param name="grpcClient">The underlying gRPC client.</param>
         /// <param name="settings">The base <see cref="BasicSettings"/> used within this client.</param>
-        public BasicClientImpl(Basic.BasicClient grpcClient, BasicSettings settings)
+        /// <param name="logger">Optional <see cref="mel::ILogger"/> to use within this client.</param>
+        public BasicClientImpl(Basic.BasicClient grpcClient, BasicSettings settings, mel::ILogger logger)
         {
             GrpcClient = grpcClient;
             BasicSettings effectiveSettings = settings ?? BasicSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings);
-            _callAMethod = clientHelper.BuildApiCall<Request, Response>(grpcClient.AMethodAsync, grpcClient.AMethod, effectiveSettings.AMethodSettings);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            _callAMethod = clientHelper.BuildApiCall<Request, Response>("AMethod", grpcClient.AMethodAsync, grpcClient.AMethod, effectiveSettings.AMethodSettings);
             Modify_ApiCall(ref _callAMethod);
             Modify_AMethodApiCall(ref _callAMethod);
             OnConstruction(grpcClient, effectiveSettings, clientHelper);

--- a/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1/PackageApiMetadata.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1/PackageApiMetadata.g.cs
@@ -27,7 +27,7 @@ namespace Testing.Basic.V1
         internal static gaxgrpc::ApiMetadata ApiMetadata { get; } = new gaxgrpc::ApiMetadata("Testing.Basic.V1", GetFileDescriptors);
 
         private static scg::IEnumerable<gpr::FileDescriptor> GetFileDescriptors()
-        {//
+        {
             yield return BasicV1Reflection.Descriptor;
         }
     }

--- a/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1/ServiceCollectionExtensions.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1/ServiceCollectionExtensions.g.cs
@@ -1,0 +1,44 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+using gaxgrpc = Google.Api.Gax.Grpc;
+using gpr = Google.Protobuf.Reflection;
+using sys = System;
+using scg = System.Collections.Generic;
+using tbv = Testing.Basic.V1;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>Static class to provide extension methods to configure API clients.</summary>
+    public static partial class ServiceCollectionExtensions
+    {
+        /// <summary>Adds a singleton <see cref="tbv::BasicClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddBasicClient(this IServiceCollection services, sys::Action<tbv::BasicClientBuilder> action = null) =>
+            services.AddSingleton(provider =>
+            {
+                tbv::BasicClientBuilder builder = new tbv::BasicClientBuilder();
+                action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1/Testing.Basic.V1.csproj
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1/Testing.Basic.V1.csproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.0.0-alpha01, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.0.0-alpha02, 5.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.41.0, 3.0.0)" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>

--- a/Google.Api.Generator.Tests/ProtoTests/BasicLro/Testing.BasicLro/BasicLroClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/BasicLro/Testing.BasicLro/BasicLroClient.g.cs
@@ -17,6 +17,7 @@
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
 using lro = Google.LongRunning;
+using mel = Microsoft.Extensions.Logging;
 using sys = System;
 using st = System.Threading;
 using stt = System.Threading.Tasks;
@@ -125,11 +126,11 @@ namespace Testing.BasicLro
     {
         private readonly gaxgrpc::ApiCall<Request, lro::Operation> _callMethod1 = null;
 
-        public BasicLroClientImpl(BasicLro.BasicLroClient grpcClient)
+        public BasicLroClientImpl(BasicLro.BasicLroClient grpcClient, mel::ILogger logger)
         {
             var effectiveSettings = new BasicLroSettings();
             // TEST_START
-            Method1OperationsClient = new lro::OperationsClientImpl(grpcClient.CreateOperationsClient(), effectiveSettings.Method1OperationsSettings);
+            Method1OperationsClient = new lro::OperationsClientImpl(grpcClient.CreateOperationsClient(), effectiveSettings.Method1OperationsSettings, logger);
             // TEST_END
         }
 

--- a/Google.Api.Generator.Tests/ProtoTests/BasicServerStreaming/Testing.BasicServerStreaming/BasicServerStreamingClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/BasicServerStreaming/Testing.BasicServerStreaming/BasicServerStreamingClient.g.cs
@@ -16,6 +16,7 @@
 
 using gaxgrpc = Google.Api.Gax.Grpc;
 using grpccore = Grpc.Core;
+using mel = Microsoft.Extensions.Logging;
 using proto = Google.Protobuf;
 using scg = System.Collections.Generic;
 using sys = System;
@@ -51,12 +52,12 @@ namespace Testing.BasicServerStreaming
         private readonly gaxgrpc::ApiServerStreamingCall<Request, Response> _callMethodServer;
         // TEST_END
 
-        public BasicServerStreamingClientImpl(BasicServerStreaming.BasicServerStreamingClient grpcClient)
+        public BasicServerStreamingClientImpl(BasicServerStreaming.BasicServerStreamingClient grpcClient, mel::ILogger logger)
         {
             BasicServerStreamingSettings effectiveSettings = null;
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
             // TEST_START
-            _callMethodServer = clientHelper.BuildApiCall<Request, Response>(grpcClient.MethodServer, effectiveSettings.MethodServerSettings);
+            _callMethodServer = clientHelper.BuildApiCall<Request, Response>("MethodServer", grpcClient.MethodServer, effectiveSettings.MethodServerSettings);
             // TEST_END
         }
 

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.Tests/DeprecatedClientTest.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.Tests/DeprecatedClientTest.g.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Google LLC
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ namespace Testing.Deprecated.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.DeprecatedFieldMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            DeprecatedClient client = new DeprecatedClientImpl(mockGrpcClient.Object, null);
+            DeprecatedClient client = new DeprecatedClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.DeprecatedFieldMethod(request);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -58,7 +58,7 @@ namespace Testing.Deprecated.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.DeprecatedFieldMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            DeprecatedClient client = new DeprecatedClientImpl(mockGrpcClient.Object, null);
+            DeprecatedClient client = new DeprecatedClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.DeprecatedFieldMethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.DeprecatedFieldMethodAsync(request, st::CancellationToken.None);
@@ -79,7 +79,7 @@ namespace Testing.Deprecated.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.DeprecatedFieldMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            DeprecatedClient client = new DeprecatedClientImpl(mockGrpcClient.Object, null);
+            DeprecatedClient client = new DeprecatedClientImpl(mockGrpcClient.Object, null, null);
 #pragma warning disable CS0612
             Response response = client.DeprecatedFieldMethod(request.DeprecatedField1, request.DeprecatedField2);
 #pragma warning restore CS0612
@@ -100,7 +100,7 @@ namespace Testing.Deprecated.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.DeprecatedFieldMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            DeprecatedClient client = new DeprecatedClientImpl(mockGrpcClient.Object, null);
+            DeprecatedClient client = new DeprecatedClientImpl(mockGrpcClient.Object, null, null);
 #pragma warning disable CS0612
             Response responseCallSettings = await client.DeprecatedFieldMethodAsync(request.DeprecatedField1, request.DeprecatedField2, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
 #pragma warning restore CS0612
@@ -121,7 +121,7 @@ namespace Testing.Deprecated.Tests
 #pragma warning restore CS0612
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.DeprecatedMessageMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            DeprecatedClient client = new DeprecatedClientImpl(mockGrpcClient.Object, null);
+            DeprecatedClient client = new DeprecatedClientImpl(mockGrpcClient.Object, null, null);
 #pragma warning disable CS0612
             Response response = client.DeprecatedMessageMethod(request);
 #pragma warning restore CS0612
@@ -138,7 +138,7 @@ namespace Testing.Deprecated.Tests
 #pragma warning restore CS0612
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.DeprecatedMessageMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            DeprecatedClient client = new DeprecatedClientImpl(mockGrpcClient.Object, null);
+            DeprecatedClient client = new DeprecatedClientImpl(mockGrpcClient.Object, null, null);
 #pragma warning disable CS0612
             Response responseCallSettings = await client.DeprecatedMessageMethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
 #pragma warning restore CS0612
@@ -157,7 +157,7 @@ namespace Testing.Deprecated.Tests
             Request request = new Request { };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.DeprecatedMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            DeprecatedClient client = new DeprecatedClientImpl(mockGrpcClient.Object, null);
+            DeprecatedClient client = new DeprecatedClientImpl(mockGrpcClient.Object, null, null);
 #pragma warning disable CS0612
             Response response = client.DeprecatedMethod(request);
 #pragma warning restore CS0612
@@ -172,7 +172,7 @@ namespace Testing.Deprecated.Tests
             Request request = new Request { };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.DeprecatedMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            DeprecatedClient client = new DeprecatedClientImpl(mockGrpcClient.Object, null);
+            DeprecatedClient client = new DeprecatedClientImpl(mockGrpcClient.Object, null, null);
 #pragma warning disable CS0612
             Response responseCallSettings = await client.DeprecatedMethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
 #pragma warning restore CS0612
@@ -193,7 +193,7 @@ namespace Testing.Deprecated.Tests
             DeprecatedMessageResponse expectedResponse = new DeprecatedMessageResponse { };
 #pragma warning restore CS0612
             mockGrpcClient.Setup(x => x.DeprecatedResponseMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            DeprecatedClient client = new DeprecatedClientImpl(mockGrpcClient.Object, null);
+            DeprecatedClient client = new DeprecatedClientImpl(mockGrpcClient.Object, null, null);
 #pragma warning disable CS0612
             DeprecatedMessageResponse response = client.DeprecatedResponseMethod(request);
 #pragma warning restore CS0612
@@ -210,7 +210,7 @@ namespace Testing.Deprecated.Tests
             DeprecatedMessageResponse expectedResponse = new DeprecatedMessageResponse { };
             mockGrpcClient.Setup(x => x.DeprecatedResponseMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<DeprecatedMessageResponse>(stt::Task.FromResult(expectedResponse), null, null, null, null));
 #pragma warning restore CS0612
-            DeprecatedClient client = new DeprecatedClientImpl(mockGrpcClient.Object, null);
+            DeprecatedClient client = new DeprecatedClientImpl(mockGrpcClient.Object, null, null);
 #pragma warning disable CS0612
             DeprecatedMessageResponse responseCallSettings = await client.DeprecatedResponseMethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
 #pragma warning restore CS0612

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated/DeprecatedClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated/DeprecatedClient.g.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Google LLC
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ using gaxgrpc = Google.Api.Gax.Grpc;
 using proto = Google.Protobuf;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
+using mel = Microsoft.Extensions.Logging;
 using sys = System;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -141,14 +142,14 @@ namespace Testing.Deprecated
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return DeprecatedClient.Create(callInvoker, Settings);
+            return DeprecatedClient.Create(callInvoker, Settings, Logger);
         }
 
         private async stt::Task<DeprecatedClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return DeprecatedClient.Create(callInvoker, Settings);
+            return DeprecatedClient.Create(callInvoker, Settings, Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>
@@ -200,8 +201,9 @@ namespace Testing.Deprecated
         /// The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.
         /// </param>
         /// <param name="settings">Optional <see cref="DeprecatedSettings"/>.</param>
+        /// <param name="logger">Optional <see cref="mel::ILogger"/>.</param>
         /// <returns>The created <see cref="DeprecatedClient"/>.</returns>
-        internal static DeprecatedClient Create(grpccore::CallInvoker callInvoker, DeprecatedSettings settings = null)
+        internal static DeprecatedClient Create(grpccore::CallInvoker callInvoker, DeprecatedSettings settings = null, mel::ILogger logger = null)
         {
             gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
             grpcinter::Interceptor interceptor = settings?.Interceptor;
@@ -210,7 +212,7 @@ namespace Testing.Deprecated
                 callInvoker = grpcinter::CallInvokerExtensions.Intercept(callInvoker, interceptor);
             }
             Deprecated.DeprecatedClient grpcClient = new Deprecated.DeprecatedClient(callInvoker);
-            return new DeprecatedClientImpl(grpcClient, settings);
+            return new DeprecatedClientImpl(grpcClient, settings, logger);
         }
 
         /// <summary>
@@ -413,26 +415,27 @@ namespace Testing.Deprecated
         /// </summary>
         /// <param name="grpcClient">The underlying gRPC client.</param>
         /// <param name="settings">The base <see cref="DeprecatedSettings"/> used within this client.</param>
-        public DeprecatedClientImpl(Deprecated.DeprecatedClient grpcClient, DeprecatedSettings settings)
+        /// <param name="logger">Optional <see cref="mel::ILogger"/> to use within this client.</param>
+        public DeprecatedClientImpl(Deprecated.DeprecatedClient grpcClient, DeprecatedSettings settings, mel::ILogger logger)
         {
             GrpcClient = grpcClient;
             DeprecatedSettings effectiveSettings = settings ?? DeprecatedSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings);
-            _callDeprecatedFieldMethod = clientHelper.BuildApiCall<DeprecatedFieldRequest, Response>(grpcClient.DeprecatedFieldMethodAsync, grpcClient.DeprecatedFieldMethod, effectiveSettings.DeprecatedFieldMethodSettings);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            _callDeprecatedFieldMethod = clientHelper.BuildApiCall<DeprecatedFieldRequest, Response>("DeprecatedFieldMethod", grpcClient.DeprecatedFieldMethodAsync, grpcClient.DeprecatedFieldMethod, effectiveSettings.DeprecatedFieldMethodSettings);
             Modify_ApiCall(ref _callDeprecatedFieldMethod);
             Modify_DeprecatedFieldMethodApiCall(ref _callDeprecatedFieldMethod);
 #pragma warning disable CS0612
-            _callDeprecatedMessageMethod = clientHelper.BuildApiCall<DeprecatedMessageRequest, Response>(grpcClient.DeprecatedMessageMethodAsync, grpcClient.DeprecatedMessageMethod, effectiveSettings.DeprecatedMessageMethodSettings);
+            _callDeprecatedMessageMethod = clientHelper.BuildApiCall<DeprecatedMessageRequest, Response>("DeprecatedMessageMethod", grpcClient.DeprecatedMessageMethodAsync, grpcClient.DeprecatedMessageMethod, effectiveSettings.DeprecatedMessageMethodSettings);
 #pragma warning restore CS0612
             Modify_ApiCall(ref _callDeprecatedMessageMethod);
             Modify_DeprecatedMessageMethodApiCall(ref _callDeprecatedMessageMethod);
 #pragma warning disable CS0612
-            _callDeprecatedMethod = clientHelper.BuildApiCall<Request, Response>(grpcClient.DeprecatedMethodAsync, grpcClient.DeprecatedMethod, effectiveSettings.DeprecatedMethodSettings);
+            _callDeprecatedMethod = clientHelper.BuildApiCall<Request, Response>("DeprecatedMethod", grpcClient.DeprecatedMethodAsync, grpcClient.DeprecatedMethod, effectiveSettings.DeprecatedMethodSettings);
 #pragma warning restore CS0612
             Modify_ApiCall(ref _callDeprecatedMethod);
             Modify_DeprecatedMethodApiCall(ref _callDeprecatedMethod);
 #pragma warning disable CS0612
-            _callDeprecatedResponseMethod = clientHelper.BuildApiCall<Request, DeprecatedMessageResponse>(grpcClient.DeprecatedResponseMethodAsync, grpcClient.DeprecatedResponseMethod, effectiveSettings.DeprecatedResponseMethodSettings);
+            _callDeprecatedResponseMethod = clientHelper.BuildApiCall<Request, DeprecatedMessageResponse>("DeprecatedResponseMethod", grpcClient.DeprecatedResponseMethodAsync, grpcClient.DeprecatedResponseMethod, effectiveSettings.DeprecatedResponseMethodSettings);
 #pragma warning restore CS0612
             Modify_ApiCall(ref _callDeprecatedResponseMethod);
             Modify_DeprecatedResponseMethodApiCall(ref _callDeprecatedResponseMethod);

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.Tests/KeywordsClientTest.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.Tests/KeywordsClientTest.g.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Google LLC
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ namespace Testing.Keywords.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.Method1(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null);
+            KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.Method1(request);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -60,7 +60,7 @@ namespace Testing.Keywords.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.Method1Async(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null);
+            KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.Method1Async(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.Method1Async(request, st::CancellationToken.None);
@@ -82,7 +82,7 @@ namespace Testing.Keywords.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.Method1(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null);
+            KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.Method1(request.Event, request.Switch, request.Void, request.Request_, request.Types_);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -102,7 +102,7 @@ namespace Testing.Keywords.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.Method1Async(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null);
+            KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.Method1Async(request.Event, request.Switch, request.Void, request.Request_, request.Types_, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.Method1Async(request.Event, request.Switch, request.Void, request.Request_, request.Types_, st::CancellationToken.None);
@@ -124,7 +124,7 @@ namespace Testing.Keywords.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.Method1(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null);
+            KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.Method1(request.EventAsResourceName, request.Switch, request.Void, request.Request_, request.Types_);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -144,7 +144,7 @@ namespace Testing.Keywords.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.Method1Async(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null);
+            KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.Method1Async(request.EventAsResourceName, request.Switch, request.Void, request.Request_, request.Types_, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.Method1Async(request.EventAsResourceName, request.Switch, request.Void, request.Request_, request.Types_, st::CancellationToken.None);
@@ -163,7 +163,7 @@ namespace Testing.Keywords.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.Method2(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null);
+            KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.Method2(request);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -180,7 +180,7 @@ namespace Testing.Keywords.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.Method2Async(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null);
+            KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.Method2Async(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.Method2Async(request, st::CancellationToken.None);
@@ -199,7 +199,7 @@ namespace Testing.Keywords.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.Method2(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null);
+            KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.Method2(request.While, request.Enum);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -216,7 +216,7 @@ namespace Testing.Keywords.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.Method2Async(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null);
+            KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.Method2Async(request.While, request.Enum, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.Method2Async(request.While, request.Enum, st::CancellationToken.None);
@@ -235,7 +235,7 @@ namespace Testing.Keywords.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.Method2(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null);
+            KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.Method2(request.WhileAsResourceName, request.Enum);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -252,7 +252,7 @@ namespace Testing.Keywords.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.Method2Async(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null);
+            KeywordsClient client = new KeywordsClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.Method2Async(request.WhileAsResourceName, request.Enum, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.Method2Async(request.WhileAsResourceName, request.Enum, st::CancellationToken.None);

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords/KeywordsClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords/KeywordsClient.g.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Google LLC
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ using gaxgrpc = Google.Api.Gax.Grpc;
 using proto = Google.Protobuf;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
+using mel = Microsoft.Extensions.Logging;
 using sys = System;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -115,14 +116,14 @@ namespace Testing.Keywords
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return KeywordsClient.Create(callInvoker, Settings);
+            return KeywordsClient.Create(callInvoker, Settings, Logger);
         }
 
         private async stt::Task<KeywordsClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return KeywordsClient.Create(callInvoker, Settings);
+            return KeywordsClient.Create(callInvoker, Settings, Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>
@@ -171,8 +172,9 @@ namespace Testing.Keywords
         /// The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.
         /// </param>
         /// <param name="settings">Optional <see cref="KeywordsSettings"/>.</param>
+        /// <param name="logger">Optional <see cref="mel::ILogger"/>.</param>
         /// <returns>The created <see cref="KeywordsClient"/>.</returns>
-        internal static KeywordsClient Create(grpccore::CallInvoker callInvoker, KeywordsSettings settings = null)
+        internal static KeywordsClient Create(grpccore::CallInvoker callInvoker, KeywordsSettings settings = null, mel::ILogger logger = null)
         {
             gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
             grpcinter::Interceptor interceptor = settings?.Interceptor;
@@ -181,7 +183,7 @@ namespace Testing.Keywords
                 callInvoker = grpcinter::CallInvokerExtensions.Intercept(callInvoker, interceptor);
             }
             Keywords.KeywordsClient grpcClient = new Keywords.KeywordsClient(callInvoker);
-            return new KeywordsClientImpl(grpcClient, settings);
+            return new KeywordsClientImpl(grpcClient, settings, logger);
         }
 
         /// <summary>
@@ -475,15 +477,16 @@ namespace Testing.Keywords
         /// </summary>
         /// <param name="grpcClient">The underlying gRPC client.</param>
         /// <param name="settings">The base <see cref="KeywordsSettings"/> used within this client.</param>
-        public KeywordsClientImpl(Keywords.KeywordsClient grpcClient, KeywordsSettings settings)
+        /// <param name="logger">Optional <see cref="mel::ILogger"/> to use within this client.</param>
+        public KeywordsClientImpl(Keywords.KeywordsClient grpcClient, KeywordsSettings settings, mel::ILogger logger)
         {
             GrpcClient = grpcClient;
             KeywordsSettings effectiveSettings = settings ?? KeywordsSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings);
-            _callMethod1 = clientHelper.BuildApiCall<Request, Response>(grpcClient.Method1Async, grpcClient.Method1, effectiveSettings.Method1Settings);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            _callMethod1 = clientHelper.BuildApiCall<Request, Response>("Method1", grpcClient.Method1Async, grpcClient.Method1, effectiveSettings.Method1Settings);
             Modify_ApiCall(ref _callMethod1);
             Modify_Method1ApiCall(ref _callMethod1);
-            _callMethod2 = clientHelper.BuildApiCall<Resource, Response>(grpcClient.Method2Async, grpcClient.Method2, effectiveSettings.Method2Settings);
+            _callMethod2 = clientHelper.BuildApiCall<Resource, Response>("Method2", grpcClient.Method2Async, grpcClient.Method2, effectiveSettings.Method2Settings);
             Modify_ApiCall(ref _callMethod2);
             Modify_Method2ApiCall(ref _callMethod2);
             OnConstruction(grpcClient, effectiveSettings, clientHelper);

--- a/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro/Testing.Lro.csproj
+++ b/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro/Testing.Lro.csproj
@@ -39,10 +39,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.0.0-alpha01, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.0.0-alpha02, 5.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.41.0, 3.0.0)" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
-    <PackageReference Include="Google.LongRunning" Version="[3.0.0-alpha01, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.0.0-alpha02, 4.0.0)" />
   </ItemGroup>
 
 </Project>

--- a/Google.Api.Generator.Tests/ProtoTests/MethodSignatures/Testing.MethodSignatures.Tests/MethodSignaturesClientTest.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/MethodSignatures/Testing.MethodSignatures.Tests/MethodSignaturesClientTest.g.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Google LLC
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.SimpleMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.SimpleMethod(request);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -69,7 +69,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.SimpleMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.SimpleMethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.SimpleMethodAsync(request, st::CancellationToken.None);
@@ -84,7 +84,7 @@ namespace Testing.MethodSignatures.Tests
             SimpleRequest request = new SimpleRequest { };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.SimpleMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.SimpleMethod();
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -97,7 +97,7 @@ namespace Testing.MethodSignatures.Tests
             SimpleRequest request = new SimpleRequest { };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.SimpleMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.SimpleMethodAsync(gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.SimpleMethodAsync(st::CancellationToken.None);
@@ -115,7 +115,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.SimpleMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.SimpleMethod(request.ANumber);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -131,7 +131,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.SimpleMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.SimpleMethodAsync(request.ANumber, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.SimpleMethodAsync(request.ANumber, st::CancellationToken.None);
@@ -149,7 +149,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.SimpleMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.SimpleMethod(request.AString);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -165,7 +165,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.SimpleMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.SimpleMethodAsync(request.AString, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.SimpleMethodAsync(request.AString, st::CancellationToken.None);
@@ -184,7 +184,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.SimpleMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.SimpleMethod(request.ANumber, request.AString);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -201,7 +201,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.SimpleMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.SimpleMethodAsync(request.ANumber, request.AString, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.SimpleMethodAsync(request.ANumber, request.AString, st::CancellationToken.None);
@@ -220,7 +220,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.SimpleMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.SimpleMethod(request.AString, request.ANumber);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -237,7 +237,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.SimpleMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.SimpleMethodAsync(request.AString, request.ANumber, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.SimpleMethodAsync(request.AString, request.ANumber, st::CancellationToken.None);
@@ -258,7 +258,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.PrimitiveArgs(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.PrimitiveArgs(request);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -277,7 +277,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.PrimitiveArgsAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.PrimitiveArgsAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.PrimitiveArgsAsync(request, st::CancellationToken.None);
@@ -298,7 +298,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.PrimitiveArgs(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.PrimitiveArgs(request.Optional, request.Required, request.RepeatedOptional, request.RepeatedRequired);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -317,7 +317,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.PrimitiveArgsAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.PrimitiveArgsAsync(request.Optional, request.Required, request.RepeatedOptional, request.RepeatedRequired, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.PrimitiveArgsAsync(request.Optional, request.Required, request.RepeatedOptional, request.RepeatedRequired, st::CancellationToken.None);
@@ -344,7 +344,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.StringArgs(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.StringArgs(request);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -369,7 +369,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.StringArgsAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.StringArgsAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.StringArgsAsync(request, st::CancellationToken.None);
@@ -396,7 +396,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.StringArgs(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.StringArgs(request.Optional, request.Required, request.RepeatedOptional, request.RepeatedRequired);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -421,7 +421,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.StringArgsAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.StringArgsAsync(request.Optional, request.Required, request.RepeatedOptional, request.RepeatedRequired, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.StringArgsAsync(request.Optional, request.Required, request.RepeatedOptional, request.RepeatedRequired, st::CancellationToken.None);
@@ -448,7 +448,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.BytesArgs(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.BytesArgs(request);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -473,7 +473,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.BytesArgsAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.BytesArgsAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.BytesArgsAsync(request, st::CancellationToken.None);
@@ -500,7 +500,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.BytesArgs(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.BytesArgs(request.Optional, request.Required, request.RepeatedOptional, request.RepeatedRequired);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -525,7 +525,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.BytesArgsAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.BytesArgsAsync(request.Optional, request.Required, request.RepeatedOptional, request.RepeatedRequired, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.BytesArgsAsync(request.Optional, request.Required, request.RepeatedOptional, request.RepeatedRequired, st::CancellationToken.None);
@@ -552,7 +552,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.MessageArgs(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.MessageArgs(request);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -577,7 +577,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.MessageArgsAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.MessageArgsAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.MessageArgsAsync(request, st::CancellationToken.None);
@@ -604,7 +604,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.MessageArgs(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.MessageArgs(request.Optional, request.Required, request.RepeatedOptional, request.RepeatedRequired);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -629,7 +629,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.MessageArgsAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.MessageArgsAsync(request.Optional, request.Required, request.RepeatedOptional, request.RepeatedRequired, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.MessageArgsAsync(request.Optional, request.Required, request.RepeatedOptional, request.RepeatedRequired, st::CancellationToken.None);
@@ -660,7 +660,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.MapArgs(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.MapArgs(request);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -689,7 +689,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.MapArgsAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.MapArgsAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.MapArgsAsync(request, st::CancellationToken.None);
@@ -720,7 +720,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.MapArgs(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.MapArgs(request.Optional, request.Required);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -749,7 +749,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.MapArgsAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.MapArgsAsync(request.Optional, request.Required, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.MapArgsAsync(request.Optional, request.Required, st::CancellationToken.None);
@@ -786,7 +786,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.EnumArgs(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.EnumArgs(request);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -821,7 +821,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.EnumArgsAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.EnumArgsAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.EnumArgsAsync(request, st::CancellationToken.None);
@@ -858,7 +858,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.EnumArgs(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.EnumArgs(request.Optional, request.Required, request.RepeatedOptional, request.RepeatedRequired, request.TopLevelOptional, request.TopLevelRequired, request.RepeatedTopLevelOptional, request.RepeatedTopLevelRequired);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -893,7 +893,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.EnumArgsAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.EnumArgsAsync(request.Optional, request.Required, request.RepeatedOptional, request.RepeatedRequired, request.TopLevelOptional, request.TopLevelRequired, request.RepeatedTopLevelOptional, request.RepeatedTopLevelRequired, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.EnumArgsAsync(request.Optional, request.Required, request.RepeatedOptional, request.RepeatedRequired, request.TopLevelOptional, request.TopLevelRequired, request.RepeatedTopLevelOptional, request.RepeatedTopLevelRequired, st::CancellationToken.None);
@@ -912,7 +912,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.NestedArgs(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.NestedArgs(request);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -929,7 +929,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.NestedArgsAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.NestedArgsAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.NestedArgsAsync(request, st::CancellationToken.None);
@@ -957,7 +957,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.NestedArgs(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.NestedArgs(request.Nest1.AString, request.Nest1.Nest2.ANumber, request.Nest1.Nest2.AnotherNumber, request.Nest1.NestOuter.ABool, request.TopLevelString);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -983,7 +983,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.NestedArgsAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.NestedArgsAsync(request.Nest1.AString, request.Nest1.Nest2.ANumber, request.Nest1.Nest2.AnotherNumber, request.Nest1.NestOuter.ABool, request.TopLevelString, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.NestedArgsAsync(request.Nest1.AString, request.Nest1.Nest2.ANumber, request.Nest1.Nest2.AnotherNumber, request.Nest1.NestOuter.ABool, request.TopLevelString, st::CancellationToken.None);
@@ -1014,7 +1014,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WktArgs(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.WktArgs(request);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -1043,7 +1043,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WktArgsAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.WktArgsAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.WktArgsAsync(request, st::CancellationToken.None);
@@ -1074,7 +1074,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WktArgs(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.WktArgs(request.OptionalInt32, request.RequiredInt32, request.RepeatedOptionalInt32, request.RepeatedRequiredInt32, request.OptionalString, request.RequiredString, request.RepeatedOptionalString, request.RepeatedRequiredString);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -1103,7 +1103,7 @@ namespace Testing.MethodSignatures.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WktArgsAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null);
+            MethodSignaturesClient client = new MethodSignaturesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.WktArgsAsync(request.OptionalInt32, request.RequiredInt32, request.RepeatedOptionalInt32, request.RepeatedRequiredInt32, request.OptionalString, request.RequiredString, request.RepeatedOptionalString, request.RepeatedRequiredString, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.WktArgsAsync(request.OptionalInt32, request.RequiredInt32, request.RepeatedOptionalInt32, request.RepeatedRequiredInt32, request.OptionalString, request.RequiredString, request.RepeatedOptionalString, request.RepeatedRequiredString, st::CancellationToken.None);

--- a/Google.Api.Generator.Tests/ProtoTests/MethodSignatures/Testing.MethodSignatures/MethodSignaturesClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/MethodSignatures/Testing.MethodSignatures/MethodSignaturesClient.g.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Google LLC
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ using gaxgrpc = Google.Api.Gax.Grpc;
 using proto = Google.Protobuf;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
+using mel = Microsoft.Extensions.Logging;
 using sys = System;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -208,14 +209,14 @@ namespace Testing.MethodSignatures
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return MethodSignaturesClient.Create(callInvoker, Settings);
+            return MethodSignaturesClient.Create(callInvoker, Settings, Logger);
         }
 
         private async stt::Task<MethodSignaturesClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return MethodSignaturesClient.Create(callInvoker, Settings);
+            return MethodSignaturesClient.Create(callInvoker, Settings, Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>
@@ -267,8 +268,9 @@ namespace Testing.MethodSignatures
         /// The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.
         /// </param>
         /// <param name="settings">Optional <see cref="MethodSignaturesSettings"/>.</param>
+        /// <param name="logger">Optional <see cref="mel::ILogger"/>.</param>
         /// <returns>The created <see cref="MethodSignaturesClient"/>.</returns>
-        internal static MethodSignaturesClient Create(grpccore::CallInvoker callInvoker, MethodSignaturesSettings settings = null)
+        internal static MethodSignaturesClient Create(grpccore::CallInvoker callInvoker, MethodSignaturesSettings settings = null, mel::ILogger logger = null)
         {
             gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
             grpcinter::Interceptor interceptor = settings?.Interceptor;
@@ -277,7 +279,7 @@ namespace Testing.MethodSignatures
                 callInvoker = grpcinter::CallInvokerExtensions.Intercept(callInvoker, interceptor);
             }
             MethodSignatures.MethodSignaturesClient grpcClient = new MethodSignatures.MethodSignaturesClient(callInvoker);
-            return new MethodSignaturesClientImpl(grpcClient, settings);
+            return new MethodSignaturesClientImpl(grpcClient, settings, logger);
         }
 
         /// <summary>
@@ -1363,36 +1365,37 @@ namespace Testing.MethodSignatures
         /// </summary>
         /// <param name="grpcClient">The underlying gRPC client.</param>
         /// <param name="settings">The base <see cref="MethodSignaturesSettings"/> used within this client.</param>
-        public MethodSignaturesClientImpl(MethodSignatures.MethodSignaturesClient grpcClient, MethodSignaturesSettings settings)
+        /// <param name="logger">Optional <see cref="mel::ILogger"/> to use within this client.</param>
+        public MethodSignaturesClientImpl(MethodSignatures.MethodSignaturesClient grpcClient, MethodSignaturesSettings settings, mel::ILogger logger)
         {
             GrpcClient = grpcClient;
             MethodSignaturesSettings effectiveSettings = settings ?? MethodSignaturesSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings);
-            _callSimpleMethod = clientHelper.BuildApiCall<SimpleRequest, Response>(grpcClient.SimpleMethodAsync, grpcClient.SimpleMethod, effectiveSettings.SimpleMethodSettings);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            _callSimpleMethod = clientHelper.BuildApiCall<SimpleRequest, Response>("SimpleMethod", grpcClient.SimpleMethodAsync, grpcClient.SimpleMethod, effectiveSettings.SimpleMethodSettings);
             Modify_ApiCall(ref _callSimpleMethod);
             Modify_SimpleMethodApiCall(ref _callSimpleMethod);
-            _callPrimitiveArgs = clientHelper.BuildApiCall<PrimitiveRequest, Response>(grpcClient.PrimitiveArgsAsync, grpcClient.PrimitiveArgs, effectiveSettings.PrimitiveArgsSettings);
+            _callPrimitiveArgs = clientHelper.BuildApiCall<PrimitiveRequest, Response>("PrimitiveArgs", grpcClient.PrimitiveArgsAsync, grpcClient.PrimitiveArgs, effectiveSettings.PrimitiveArgsSettings);
             Modify_ApiCall(ref _callPrimitiveArgs);
             Modify_PrimitiveArgsApiCall(ref _callPrimitiveArgs);
-            _callStringArgs = clientHelper.BuildApiCall<StringRequest, Response>(grpcClient.StringArgsAsync, grpcClient.StringArgs, effectiveSettings.StringArgsSettings);
+            _callStringArgs = clientHelper.BuildApiCall<StringRequest, Response>("StringArgs", grpcClient.StringArgsAsync, grpcClient.StringArgs, effectiveSettings.StringArgsSettings);
             Modify_ApiCall(ref _callStringArgs);
             Modify_StringArgsApiCall(ref _callStringArgs);
-            _callBytesArgs = clientHelper.BuildApiCall<BytesRequest, Response>(grpcClient.BytesArgsAsync, grpcClient.BytesArgs, effectiveSettings.BytesArgsSettings);
+            _callBytesArgs = clientHelper.BuildApiCall<BytesRequest, Response>("BytesArgs", grpcClient.BytesArgsAsync, grpcClient.BytesArgs, effectiveSettings.BytesArgsSettings);
             Modify_ApiCall(ref _callBytesArgs);
             Modify_BytesArgsApiCall(ref _callBytesArgs);
-            _callMessageArgs = clientHelper.BuildApiCall<MessageRequest, Response>(grpcClient.MessageArgsAsync, grpcClient.MessageArgs, effectiveSettings.MessageArgsSettings);
+            _callMessageArgs = clientHelper.BuildApiCall<MessageRequest, Response>("MessageArgs", grpcClient.MessageArgsAsync, grpcClient.MessageArgs, effectiveSettings.MessageArgsSettings);
             Modify_ApiCall(ref _callMessageArgs);
             Modify_MessageArgsApiCall(ref _callMessageArgs);
-            _callMapArgs = clientHelper.BuildApiCall<MapRequest, Response>(grpcClient.MapArgsAsync, grpcClient.MapArgs, effectiveSettings.MapArgsSettings);
+            _callMapArgs = clientHelper.BuildApiCall<MapRequest, Response>("MapArgs", grpcClient.MapArgsAsync, grpcClient.MapArgs, effectiveSettings.MapArgsSettings);
             Modify_ApiCall(ref _callMapArgs);
             Modify_MapArgsApiCall(ref _callMapArgs);
-            _callEnumArgs = clientHelper.BuildApiCall<EnumRequest, Response>(grpcClient.EnumArgsAsync, grpcClient.EnumArgs, effectiveSettings.EnumArgsSettings);
+            _callEnumArgs = clientHelper.BuildApiCall<EnumRequest, Response>("EnumArgs", grpcClient.EnumArgsAsync, grpcClient.EnumArgs, effectiveSettings.EnumArgsSettings);
             Modify_ApiCall(ref _callEnumArgs);
             Modify_EnumArgsApiCall(ref _callEnumArgs);
-            _callNestedArgs = clientHelper.BuildApiCall<NestedRequest, Response>(grpcClient.NestedArgsAsync, grpcClient.NestedArgs, effectiveSettings.NestedArgsSettings);
+            _callNestedArgs = clientHelper.BuildApiCall<NestedRequest, Response>("NestedArgs", grpcClient.NestedArgsAsync, grpcClient.NestedArgs, effectiveSettings.NestedArgsSettings);
             Modify_ApiCall(ref _callNestedArgs);
             Modify_NestedArgsApiCall(ref _callNestedArgs);
-            _callWktArgs = clientHelper.BuildApiCall<WktRequest, Response>(grpcClient.WktArgsAsync, grpcClient.WktArgs, effectiveSettings.WktArgsSettings);
+            _callWktArgs = clientHelper.BuildApiCall<WktRequest, Response>("WktArgs", grpcClient.WktArgsAsync, grpcClient.WktArgs, effectiveSettings.WktArgsSettings);
             Modify_ApiCall(ref _callWktArgs);
             Modify_WktArgsApiCall(ref _callWktArgs);
             OnConstruction(grpcClient, effectiveSettings, clientHelper);

--- a/Google.Api.Generator.Tests/ProtoTests/Mixins/Testing.Mixins.Tests/MixinServiceClientTest.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Mixins/Testing.Mixins.Tests/MixinServiceClientTest.g.cs
@@ -31,15 +31,13 @@ namespace Testing.Mixins.Tests
         [xunit::FactAttribute]
         public void MethodRequestObject()
         {
-            // TEST_START
             moq::Mock<MixinService.MixinServiceClient> mockGrpcClient = new moq::Mock<MixinService.MixinServiceClient>(moq::MockBehavior.Strict);
             mockGrpcClient.Setup(x => x.CreateLocationsClient()).Returns(new moq::Mock<gcl::Locations.LocationsClient>().Object);
             mockGrpcClient.Setup(x => x.CreateIAMPolicyClient()).Returns(new moq::Mock<gciv::IAMPolicy.IAMPolicyClient>().Object);
-            // TEST_END
             Request request = new Request { };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.Method(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            MixinServiceClient client = new MixinServiceClientImpl(mockGrpcClient.Object, null);
+            MixinServiceClient client = new MixinServiceClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.Method(request);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -48,15 +46,13 @@ namespace Testing.Mixins.Tests
         [xunit::FactAttribute]
         public async stt::Task MethodRequestObjectAsync()
         {
-            // TEST_START
             moq::Mock<MixinService.MixinServiceClient> mockGrpcClient = new moq::Mock<MixinService.MixinServiceClient>(moq::MockBehavior.Strict);
             mockGrpcClient.Setup(x => x.CreateLocationsClient()).Returns(new moq::Mock<gcl::Locations.LocationsClient>().Object);
             mockGrpcClient.Setup(x => x.CreateIAMPolicyClient()).Returns(new moq::Mock<gciv::IAMPolicy.IAMPolicyClient>().Object);
-            // TEST_END
             Request request = new Request { };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.MethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            MixinServiceClient client = new MixinServiceClientImpl(mockGrpcClient.Object, null);
+            MixinServiceClient client = new MixinServiceClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.MethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.MethodAsync(request, st::CancellationToken.None);

--- a/Google.Api.Generator.Tests/ProtoTests/Mixins/Testing.Mixins/MixinServiceClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Mixins/Testing.Mixins/MixinServiceClient.g.cs
@@ -21,6 +21,7 @@ using gcl = Google.Cloud.Location;
 using proto = Google.Protobuf;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
+using mel = Microsoft.Extensions.Logging;
 using sys = System;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -120,14 +121,14 @@ namespace Testing.Mixins
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return MixinServiceClient.Create(callInvoker, Settings);
+            return MixinServiceClient.Create(callInvoker, Settings, Logger);
         }
 
         private async stt::Task<MixinServiceClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return MixinServiceClient.Create(callInvoker, Settings);
+            return MixinServiceClient.Create(callInvoker, Settings, Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>
@@ -185,8 +186,9 @@ namespace Testing.Mixins
         /// The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.
         /// </param>
         /// <param name="settings">Optional <see cref="MixinServiceSettings"/>.</param>
+        /// <param name="logger">Optional <see cref="mel::ILogger"/>.</param>
         /// <returns>The created <see cref="MixinServiceClient"/>.</returns>
-        internal static MixinServiceClient Create(grpccore::CallInvoker callInvoker, MixinServiceSettings settings = null)
+        internal static MixinServiceClient Create(grpccore::CallInvoker callInvoker, MixinServiceSettings settings = null, mel::ILogger logger = null)
         {
             gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
             grpcinter::Interceptor interceptor = settings?.Interceptor;
@@ -195,7 +197,7 @@ namespace Testing.Mixins
                 callInvoker = grpcinter::CallInvokerExtensions.Intercept(callInvoker, interceptor);
             }
             MixinService.MixinServiceClient grpcClient = new MixinService.MixinServiceClient(callInvoker);
-            return new MixinServiceClientImpl(grpcClient, settings);
+            return new MixinServiceClientImpl(grpcClient, settings, logger);
         }
 
         /// <summary>
@@ -260,14 +262,15 @@ namespace Testing.Mixins
         /// </summary>
         /// <param name="grpcClient">The underlying gRPC client.</param>
         /// <param name="settings">The base <see cref="MixinServiceSettings"/> used within this client.</param>
-        public MixinServiceClientImpl(MixinService.MixinServiceClient grpcClient, MixinServiceSettings settings)
+        /// <param name="logger">Optional <see cref="mel::ILogger"/> to use within this client.</param>
+        public MixinServiceClientImpl(MixinService.MixinServiceClient grpcClient, MixinServiceSettings settings, mel::ILogger logger)
         {
             GrpcClient = grpcClient;
             MixinServiceSettings effectiveSettings = settings ?? MixinServiceSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings);
-            LocationsClient = new gcl::LocationsClientImpl(grpcClient.CreateLocationsClient(), effectiveSettings.LocationsSettings);
-            IAMPolicyClient = new gciv::IAMPolicyClientImpl(grpcClient.CreateIAMPolicyClient(), effectiveSettings.IAMPolicySettings);
-            _callMethod = clientHelper.BuildApiCall<Request, Response>(grpcClient.MethodAsync, grpcClient.Method, effectiveSettings.MethodSettings);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            LocationsClient = new gcl::LocationsClientImpl(grpcClient.CreateLocationsClient(), effectiveSettings.LocationsSettings, logger);
+            IAMPolicyClient = new gciv::IAMPolicyClientImpl(grpcClient.CreateIAMPolicyClient(), effectiveSettings.IAMPolicySettings, logger);
+            _callMethod = clientHelper.BuildApiCall<Request, Response>("Method", grpcClient.MethodAsync, grpcClient.Method, effectiveSettings.MethodSettings);
             Modify_ApiCall(ref _callMethod);
             Modify_MethodApiCall(ref _callMethod);
             OnConstruction(grpcClient, effectiveSettings, clientHelper);

--- a/Google.Api.Generator.Tests/ProtoTests/Mixins/Testing.Mixins/Testing.Mixins.csproj
+++ b/Google.Api.Generator.Tests/ProtoTests/Mixins/Testing.Mixins/Testing.Mixins.csproj
@@ -39,11 +39,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.0.0-alpha01, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.0.0-alpha02, 5.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.41.0, 3.0.0)" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.0.0-alpha01, 3.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0-alpha01, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.0.0-alpha02, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0-alpha02, 4.0.0)" />
   </ItemGroup>
 
 </Project>

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/ResourceNameSeparatorFakes.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/ResourceNameSeparatorFakes.cs
@@ -14,6 +14,7 @@
 
 using Google.Api.Gax.Grpc;
 using Grpc.Core;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -49,7 +50,7 @@ namespace Testing.ResourceNameSeparator
 
     public class ResourceNameSeparatorClientImpl : ResourceNameSeparatorClient
     {
-        public ResourceNameSeparatorClientImpl(ResourceNameSeparator.ResourceNameSeparatorClient client, object settings) => _client = client;
+        public ResourceNameSeparatorClientImpl(ResourceNameSeparator.ResourceNameSeparatorClient client, object settings, ILogger logger) => _client = client;
         private ResourceNameSeparator.ResourceNameSeparatorClient _client;
         public override Response Method1(Request request) => _client.Method1(request, default);
         public override Task<Response> Method1Async(Request request, CallSettings settings = null) => _client.Method1Async(request, default).ResponseAsync;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.Tests/ResourceNameSeparatorClientTest.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.Tests/ResourceNameSeparatorClientTest.g.cs
@@ -37,7 +37,7 @@ namespace Testing.ResourceNameSeparator.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.Method1(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNameSeparatorClient client = new ResourceNameSeparatorClientImpl(mockGrpcClient.Object, null);
+            ResourceNameSeparatorClient client = new ResourceNameSeparatorClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.Method1(request);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -54,7 +54,7 @@ namespace Testing.ResourceNameSeparator.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.Method1Async(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNameSeparatorClient client = new ResourceNameSeparatorClientImpl(mockGrpcClient.Object, null);
+            ResourceNameSeparatorClient client = new ResourceNameSeparatorClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.Method1Async(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.Method1Async(request, st::CancellationToken.None);
@@ -73,7 +73,7 @@ namespace Testing.ResourceNameSeparator.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.Method1(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNameSeparatorClient client = new ResourceNameSeparatorClientImpl(mockGrpcClient.Object, null);
+            ResourceNameSeparatorClient client = new ResourceNameSeparatorClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.Method1(request.Name, request.Ref);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -90,7 +90,7 @@ namespace Testing.ResourceNameSeparator.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.Method1Async(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNameSeparatorClient client = new ResourceNameSeparatorClientImpl(mockGrpcClient.Object, null);
+            ResourceNameSeparatorClient client = new ResourceNameSeparatorClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.Method1Async(request.Name, request.Ref, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.Method1Async(request.Name, request.Ref, st::CancellationToken.None);
@@ -109,7 +109,7 @@ namespace Testing.ResourceNameSeparator.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.Method1(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNameSeparatorClient client = new ResourceNameSeparatorClientImpl(mockGrpcClient.Object, null);
+            ResourceNameSeparatorClient client = new ResourceNameSeparatorClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.Method1(request.RequestName, request.RefAsRequestName);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -126,7 +126,7 @@ namespace Testing.ResourceNameSeparator.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.Method1Async(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNameSeparatorClient client = new ResourceNameSeparatorClientImpl(mockGrpcClient.Object, null);
+            ResourceNameSeparatorClient client = new ResourceNameSeparatorClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.Method1Async(request.RequestName, request.RefAsRequestName, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.Method1Async(request.RequestName, request.RefAsRequestName, st::CancellationToken.None);

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.Tests/ResourceNamesClientTest.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.Tests/ResourceNamesClientTest.g.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Google LLC
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.SinglePatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.SinglePatternMethod(request);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -73,7 +73,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.SinglePatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.SinglePatternMethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.SinglePatternMethodAsync(request, st::CancellationToken.None);
@@ -101,7 +101,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.SinglePatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.SinglePatternMethod(request.RealName, request.Ref, request.RepeatedRef, request.ValueRef, request.RepeatedValueRef);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -127,7 +127,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.SinglePatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.SinglePatternMethodAsync(request.RealName, request.Ref, request.RepeatedRef, request.ValueRef, request.RepeatedValueRef, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.SinglePatternMethodAsync(request.RealName, request.Ref, request.RepeatedRef, request.ValueRef, request.RepeatedValueRef, st::CancellationToken.None);
@@ -155,7 +155,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.SinglePatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.SinglePatternMethod(request.RealNameAsSinglePatternName, request.RefAsSinglePatternName, request.RepeatedRefAsSinglePatternNames, request.ValueRefAsSinglePatternName, request.RepeatedValueRefAsSinglePatternNames);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -181,7 +181,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.SinglePatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.SinglePatternMethodAsync(request.RealNameAsSinglePatternName, request.RefAsSinglePatternName, request.RepeatedRefAsSinglePatternNames, request.ValueRefAsSinglePatternName, request.RepeatedValueRefAsSinglePatternNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.SinglePatternMethodAsync(request.RealNameAsSinglePatternName, request.RefAsSinglePatternName, request.RepeatedRefAsSinglePatternNames, request.ValueRefAsSinglePatternName, request.RepeatedValueRefAsSinglePatternNames, st::CancellationToken.None);
@@ -201,7 +201,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.DeprecatedPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.DeprecatedPatternMethod(request);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -219,7 +219,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.DeprecatedPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.DeprecatedPatternMethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.DeprecatedPatternMethodAsync(request, st::CancellationToken.None);
@@ -239,7 +239,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.DeprecatedPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
 #pragma warning disable CS0612
             Response response = client.DeprecatedPatternMethod(request.Name);
 #pragma warning restore CS0612
@@ -259,7 +259,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.DeprecatedPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
 #pragma warning disable CS0612
             Response responseCallSettings = await client.DeprecatedPatternMethodAsync(request.Name, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
 #pragma warning restore CS0612
@@ -283,7 +283,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.DeprecatedPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
 #pragma warning disable CS0612
             Response response = client.DeprecatedPatternMethod(request.DeprecatedPatternName);
 #pragma warning restore CS0612
@@ -303,7 +303,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.DeprecatedPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
 #pragma warning disable CS0612
             Response responseCallSettings = await client.DeprecatedPatternMethodAsync(request.DeprecatedPatternName, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
 #pragma warning restore CS0612
@@ -335,7 +335,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardOnlyPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.WildcardOnlyPatternMethod(request);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -361,7 +361,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardOnlyPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.WildcardOnlyPatternMethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.WildcardOnlyPatternMethodAsync(request, st::CancellationToken.None);
@@ -389,7 +389,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardOnlyPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.WildcardOnlyPatternMethod(request.Name, request.Ref, request.RepeatedRef, request.RefSugar, request.RepeatedRefSugar);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -415,7 +415,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardOnlyPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.WildcardOnlyPatternMethodAsync(request.Name, request.Ref, request.RepeatedRef, request.RefSugar, request.RepeatedRefSugar, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.WildcardOnlyPatternMethodAsync(request.Name, request.Ref, request.RepeatedRef, request.RefSugar, request.RepeatedRefSugar, st::CancellationToken.None);
@@ -443,7 +443,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardOnlyPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.WildcardOnlyPatternMethod(request.ResourceName, request.RefAsResourceName, request.RepeatedRefAsResourceNames, request.RefSugarAsResourceName, request.RepeatedRefSugarAsResourceNames);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -469,7 +469,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardOnlyPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.WildcardOnlyPatternMethodAsync(request.ResourceName, request.RefAsResourceName, request.RepeatedRefAsResourceNames, request.RefSugarAsResourceName, request.RepeatedRefSugarAsResourceNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.WildcardOnlyPatternMethodAsync(request.ResourceName, request.RefAsResourceName, request.RepeatedRefAsResourceNames, request.RefSugarAsResourceName, request.RepeatedRefSugarAsResourceNames, st::CancellationToken.None);
@@ -492,7 +492,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.WildcardMultiPatternMethod(request);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -513,7 +513,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.WildcardMultiPatternMethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.WildcardMultiPatternMethodAsync(request, st::CancellationToken.None);
@@ -536,7 +536,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.WildcardMultiPatternMethod(request.Name, request.Ref, request.RepeatedRef);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -557,7 +557,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.WildcardMultiPatternMethodAsync(request.Name, request.Ref, request.RepeatedRef, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.WildcardMultiPatternMethodAsync(request.Name, request.Ref, request.RepeatedRef, st::CancellationToken.None);
@@ -580,7 +580,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.WildcardMultiPatternMethod(request.WildcardMultiPatternName, request.RefAsWildcardMultiPatternName, request.RepeatedRefAsWildcardMultiPatternNames);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -601,7 +601,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.WildcardMultiPatternMethodAsync(request.WildcardMultiPatternName, request.RefAsWildcardMultiPatternName, request.RepeatedRefAsWildcardMultiPatternNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.WildcardMultiPatternMethodAsync(request.WildcardMultiPatternName, request.RefAsWildcardMultiPatternName, request.RepeatedRefAsWildcardMultiPatternNames, st::CancellationToken.None);
@@ -624,7 +624,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.WildcardMultiPatternMethod(request.WildcardMultiPatternName, request.RefAsWildcardMultiPatternName, request.RepeatedRefAsResourceNames);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -645,7 +645,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.WildcardMultiPatternMethodAsync(request.WildcardMultiPatternName, request.RefAsWildcardMultiPatternName, request.RepeatedRefAsResourceNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.WildcardMultiPatternMethodAsync(request.WildcardMultiPatternName, request.RefAsWildcardMultiPatternName, request.RepeatedRefAsResourceNames, st::CancellationToken.None);
@@ -668,7 +668,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.WildcardMultiPatternMethod(request.WildcardMultiPatternName, request.RefAsResourceName, request.RepeatedRefAsWildcardMultiPatternNames);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -689,7 +689,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.WildcardMultiPatternMethodAsync(request.WildcardMultiPatternName, request.RefAsResourceName, request.RepeatedRefAsWildcardMultiPatternNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.WildcardMultiPatternMethodAsync(request.WildcardMultiPatternName, request.RefAsResourceName, request.RepeatedRefAsWildcardMultiPatternNames, st::CancellationToken.None);
@@ -712,7 +712,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.WildcardMultiPatternMethod(request.WildcardMultiPatternName, request.RefAsResourceName, request.RepeatedRefAsResourceNames);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -733,7 +733,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.WildcardMultiPatternMethodAsync(request.WildcardMultiPatternName, request.RefAsResourceName, request.RepeatedRefAsResourceNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.WildcardMultiPatternMethodAsync(request.WildcardMultiPatternName, request.RefAsResourceName, request.RepeatedRefAsResourceNames, st::CancellationToken.None);
@@ -756,7 +756,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.WildcardMultiPatternMethod(request.ResourceName, request.RefAsWildcardMultiPatternName, request.RepeatedRefAsWildcardMultiPatternNames);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -777,7 +777,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.WildcardMultiPatternMethodAsync(request.ResourceName, request.RefAsWildcardMultiPatternName, request.RepeatedRefAsWildcardMultiPatternNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.WildcardMultiPatternMethodAsync(request.ResourceName, request.RefAsWildcardMultiPatternName, request.RepeatedRefAsWildcardMultiPatternNames, st::CancellationToken.None);
@@ -800,7 +800,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.WildcardMultiPatternMethod(request.ResourceName, request.RefAsWildcardMultiPatternName, request.RepeatedRefAsResourceNames);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -821,7 +821,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.WildcardMultiPatternMethodAsync(request.ResourceName, request.RefAsWildcardMultiPatternName, request.RepeatedRefAsResourceNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.WildcardMultiPatternMethodAsync(request.ResourceName, request.RefAsWildcardMultiPatternName, request.RepeatedRefAsResourceNames, st::CancellationToken.None);
@@ -844,7 +844,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.WildcardMultiPatternMethod(request.ResourceName, request.RefAsResourceName, request.RepeatedRefAsWildcardMultiPatternNames);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -865,7 +865,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.WildcardMultiPatternMethodAsync(request.ResourceName, request.RefAsResourceName, request.RepeatedRefAsWildcardMultiPatternNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.WildcardMultiPatternMethodAsync(request.ResourceName, request.RefAsResourceName, request.RepeatedRefAsWildcardMultiPatternNames, st::CancellationToken.None);
@@ -888,7 +888,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.WildcardMultiPatternMethod(request.ResourceName, request.RefAsResourceName, request.RepeatedRefAsResourceNames);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -909,7 +909,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.WildcardMultiPatternMethodAsync(request.ResourceName, request.RefAsResourceName, request.RepeatedRefAsResourceNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.WildcardMultiPatternMethodAsync(request.ResourceName, request.RefAsResourceName, request.RepeatedRefAsResourceNames, st::CancellationToken.None);
@@ -932,7 +932,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMultipleMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.WildcardMultiPatternMultipleMethod(request);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -953,7 +953,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMultipleMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.WildcardMultiPatternMultipleMethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.WildcardMultiPatternMultipleMethodAsync(request, st::CancellationToken.None);
@@ -975,7 +975,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMultipleMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.WildcardMultiPatternMultipleMethod(request.Ref, request.RepeatedRef);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -995,7 +995,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMultipleMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.WildcardMultiPatternMultipleMethodAsync(request.Ref, request.RepeatedRef, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.WildcardMultiPatternMultipleMethodAsync(request.Ref, request.RepeatedRef, st::CancellationToken.None);
@@ -1017,7 +1017,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMultipleMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.WildcardMultiPatternMultipleMethod(request.RefAsWildcardMultiPatternMultipleName, request.RepeatedRefAsWildcardMultiPatternMultipleNames);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -1037,7 +1037,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMultipleMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.WildcardMultiPatternMultipleMethodAsync(request.RefAsWildcardMultiPatternMultipleName, request.RepeatedRefAsWildcardMultiPatternMultipleNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.WildcardMultiPatternMultipleMethodAsync(request.RefAsWildcardMultiPatternMultipleName, request.RepeatedRefAsWildcardMultiPatternMultipleNames, st::CancellationToken.None);
@@ -1059,7 +1059,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMultipleMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.WildcardMultiPatternMultipleMethod(request.RefAsWildcardMultiPatternMultipleName, request.RepeatedRefAsResourceNames);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -1079,7 +1079,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMultipleMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.WildcardMultiPatternMultipleMethodAsync(request.RefAsWildcardMultiPatternMultipleName, request.RepeatedRefAsResourceNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.WildcardMultiPatternMultipleMethodAsync(request.RefAsWildcardMultiPatternMultipleName, request.RepeatedRefAsResourceNames, st::CancellationToken.None);
@@ -1101,7 +1101,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMultipleMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.WildcardMultiPatternMultipleMethod(request.RefAsResourceName, request.RepeatedRefAsWildcardMultiPatternMultipleNames);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -1121,7 +1121,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMultipleMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.WildcardMultiPatternMultipleMethodAsync(request.RefAsResourceName, request.RepeatedRefAsWildcardMultiPatternMultipleNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.WildcardMultiPatternMultipleMethodAsync(request.RefAsResourceName, request.RepeatedRefAsWildcardMultiPatternMultipleNames, st::CancellationToken.None);
@@ -1143,7 +1143,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMultipleMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.WildcardMultiPatternMultipleMethod(request.RefAsResourceName, request.RepeatedRefAsResourceNames);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -1163,7 +1163,7 @@ namespace Testing.ResourceNames.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.WildcardMultiPatternMultipleMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null);
+            ResourceNamesClient client = new ResourceNamesClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.WildcardMultiPatternMultipleMethodAsync(request.RefAsResourceName, request.RepeatedRefAsResourceNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.WildcardMultiPatternMultipleMethodAsync(request.RefAsResourceName, request.RepeatedRefAsResourceNames, st::CancellationToken.None);

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames/ResourceNamesClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames/ResourceNamesClient.g.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Google LLC
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ using gaxgrpc = Google.Api.Gax.Grpc;
 using proto = Google.Protobuf;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
+using mel = Microsoft.Extensions.Logging;
 using sys = System;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -160,14 +161,14 @@ namespace Testing.ResourceNames
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return ResourceNamesClient.Create(callInvoker, Settings);
+            return ResourceNamesClient.Create(callInvoker, Settings, Logger);
         }
 
         private async stt::Task<ResourceNamesClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return ResourceNamesClient.Create(callInvoker, Settings);
+            return ResourceNamesClient.Create(callInvoker, Settings, Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>
@@ -218,8 +219,9 @@ namespace Testing.ResourceNames
         /// The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.
         /// </param>
         /// <param name="settings">Optional <see cref="ResourceNamesSettings"/>.</param>
+        /// <param name="logger">Optional <see cref="mel::ILogger"/>.</param>
         /// <returns>The created <see cref="ResourceNamesClient"/>.</returns>
-        internal static ResourceNamesClient Create(grpccore::CallInvoker callInvoker, ResourceNamesSettings settings = null)
+        internal static ResourceNamesClient Create(grpccore::CallInvoker callInvoker, ResourceNamesSettings settings = null, mel::ILogger logger = null)
         {
             gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
             grpcinter::Interceptor interceptor = settings?.Interceptor;
@@ -228,7 +230,7 @@ namespace Testing.ResourceNames
                 callInvoker = grpcinter::CallInvokerExtensions.Intercept(callInvoker, interceptor);
             }
             ResourceNames.ResourceNamesClient grpcClient = new ResourceNames.ResourceNamesClient(callInvoker);
-            return new ResourceNamesClientImpl(grpcClient, settings);
+            return new ResourceNamesClientImpl(grpcClient, settings, logger);
         }
 
         /// <summary>
@@ -1492,24 +1494,25 @@ namespace Testing.ResourceNames
         /// </summary>
         /// <param name="grpcClient">The underlying gRPC client.</param>
         /// <param name="settings">The base <see cref="ResourceNamesSettings"/> used within this client.</param>
-        public ResourceNamesClientImpl(ResourceNames.ResourceNamesClient grpcClient, ResourceNamesSettings settings)
+        /// <param name="logger">Optional <see cref="mel::ILogger"/> to use within this client.</param>
+        public ResourceNamesClientImpl(ResourceNames.ResourceNamesClient grpcClient, ResourceNamesSettings settings, mel::ILogger logger)
         {
             GrpcClient = grpcClient;
             ResourceNamesSettings effectiveSettings = settings ?? ResourceNamesSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings);
-            _callSinglePatternMethod = clientHelper.BuildApiCall<SinglePattern, Response>(grpcClient.SinglePatternMethodAsync, grpcClient.SinglePatternMethod, effectiveSettings.SinglePatternMethodSettings);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            _callSinglePatternMethod = clientHelper.BuildApiCall<SinglePattern, Response>("SinglePatternMethod", grpcClient.SinglePatternMethodAsync, grpcClient.SinglePatternMethod, effectiveSettings.SinglePatternMethodSettings);
             Modify_ApiCall(ref _callSinglePatternMethod);
             Modify_SinglePatternMethodApiCall(ref _callSinglePatternMethod);
-            _callDeprecatedPatternMethod = clientHelper.BuildApiCall<DeprecatedPattern, Response>(grpcClient.DeprecatedPatternMethodAsync, grpcClient.DeprecatedPatternMethod, effectiveSettings.DeprecatedPatternMethodSettings);
+            _callDeprecatedPatternMethod = clientHelper.BuildApiCall<DeprecatedPattern, Response>("DeprecatedPatternMethod", grpcClient.DeprecatedPatternMethodAsync, grpcClient.DeprecatedPatternMethod, effectiveSettings.DeprecatedPatternMethodSettings);
             Modify_ApiCall(ref _callDeprecatedPatternMethod);
             Modify_DeprecatedPatternMethodApiCall(ref _callDeprecatedPatternMethod);
-            _callWildcardOnlyPatternMethod = clientHelper.BuildApiCall<WildcardOnlyPattern, Response>(grpcClient.WildcardOnlyPatternMethodAsync, grpcClient.WildcardOnlyPatternMethod, effectiveSettings.WildcardOnlyPatternMethodSettings);
+            _callWildcardOnlyPatternMethod = clientHelper.BuildApiCall<WildcardOnlyPattern, Response>("WildcardOnlyPatternMethod", grpcClient.WildcardOnlyPatternMethodAsync, grpcClient.WildcardOnlyPatternMethod, effectiveSettings.WildcardOnlyPatternMethodSettings);
             Modify_ApiCall(ref _callWildcardOnlyPatternMethod);
             Modify_WildcardOnlyPatternMethodApiCall(ref _callWildcardOnlyPatternMethod);
-            _callWildcardMultiPatternMethod = clientHelper.BuildApiCall<WildcardMultiPattern, Response>(grpcClient.WildcardMultiPatternMethodAsync, grpcClient.WildcardMultiPatternMethod, effectiveSettings.WildcardMultiPatternMethodSettings);
+            _callWildcardMultiPatternMethod = clientHelper.BuildApiCall<WildcardMultiPattern, Response>("WildcardMultiPatternMethod", grpcClient.WildcardMultiPatternMethodAsync, grpcClient.WildcardMultiPatternMethod, effectiveSettings.WildcardMultiPatternMethodSettings);
             Modify_ApiCall(ref _callWildcardMultiPatternMethod);
             Modify_WildcardMultiPatternMethodApiCall(ref _callWildcardMultiPatternMethod);
-            _callWildcardMultiPatternMultipleMethod = clientHelper.BuildApiCall<WildcardMultiPatternMultiple, Response>(grpcClient.WildcardMultiPatternMultipleMethodAsync, grpcClient.WildcardMultiPatternMultipleMethod, effectiveSettings.WildcardMultiPatternMultipleMethodSettings);
+            _callWildcardMultiPatternMultipleMethod = clientHelper.BuildApiCall<WildcardMultiPatternMultiple, Response>("WildcardMultiPatternMultipleMethod", grpcClient.WildcardMultiPatternMultipleMethodAsync, grpcClient.WildcardMultiPatternMultipleMethod, effectiveSettings.WildcardMultiPatternMultipleMethodSettings);
             Modify_ApiCall(ref _callWildcardMultiPatternMultipleMethod);
             Modify_WildcardMultiPatternMultipleMethodApiCall(ref _callWildcardMultiPatternMultipleMethod);
             OnConstruction(grpcClient, effectiveSettings, clientHelper);

--- a/Google.Api.Generator.Tests/ProtoTests/RoutingHeaders/Testing.RoutingHeaders/RoutingHeadersClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/RoutingHeaders/Testing.RoutingHeaders/RoutingHeadersClient.g.cs
@@ -15,6 +15,7 @@
 // Generated code. DO NOT EDIT!
 
 using gaxgrpc = Google.Api.Gax.Grpc;
+using mel = Microsoft.Extensions.Logging;
 using proto = Google.Protobuf;
 using sysnet = System.Net;
 using sys = System;
@@ -53,36 +54,36 @@ namespace Testing.RoutingHeaders
         private readonly gaxgrpc::ApiServerStreamingCall<SimpleRequest, Response> _callServerStreamingMethod;
 
         // TEST_START
-        public RoutingHeadersClientImpl(RoutingHeaders.RoutingHeadersClient grpcClient, RoutingHeadersSettings settings)
+        public RoutingHeadersClientImpl(RoutingHeaders.RoutingHeadersClient grpcClient, RoutingHeadersSettings settings, mel::ILogger logger)
         {
             GrpcClient = grpcClient;
             RoutingHeadersSettings effectiveSettings = settings ?? RoutingHeadersSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings);
-            _callNoUrlMethod = clientHelper.BuildApiCall<SimpleRequest, Response>(grpcClient.NoUrlMethodAsync, grpcClient.NoUrlMethod, effectiveSettings.NoUrlMethodSettings);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            _callNoUrlMethod = clientHelper.BuildApiCall<SimpleRequest, Response>("NoUrlMethod", grpcClient.NoUrlMethodAsync, grpcClient.NoUrlMethod, effectiveSettings.NoUrlMethodSettings);
             Modify_ApiCall(ref _callNoUrlMethod);
             Modify_NoUrlMethodApiCall(ref _callNoUrlMethod);
-            _callGetMethod = clientHelper.BuildApiCall<SimpleRequest, Response>(grpcClient.GetMethodAsync, grpcClient.GetMethod, effectiveSettings.GetMethodSettings).WithGoogleRequestParam("name", request => request.Name);
+            _callGetMethod = clientHelper.BuildApiCall<SimpleRequest, Response>("GetMethod", grpcClient.GetMethodAsync, grpcClient.GetMethod, effectiveSettings.GetMethodSettings).WithGoogleRequestParam("name", request => request.Name);
             Modify_ApiCall(ref _callGetMethod);
             Modify_GetMethodApiCall(ref _callGetMethod);
-            _callPostMethod = clientHelper.BuildApiCall<SimpleRequest, Response>(grpcClient.PostMethodAsync, grpcClient.PostMethod, effectiveSettings.PostMethodSettings).WithGoogleRequestParam("name", request => request.Name);
+            _callPostMethod = clientHelper.BuildApiCall<SimpleRequest, Response>("PostMethod", grpcClient.PostMethodAsync, grpcClient.PostMethod, effectiveSettings.PostMethodSettings).WithGoogleRequestParam("name", request => request.Name);
             Modify_ApiCall(ref _callPostMethod);
             Modify_PostMethodApiCall(ref _callPostMethod);
-            _callPutMethod = clientHelper.BuildApiCall<SimpleRequest, Response>(grpcClient.PutMethodAsync, grpcClient.PutMethod, effectiveSettings.PutMethodSettings).WithGoogleRequestParam("name", request => request.Name);
+            _callPutMethod = clientHelper.BuildApiCall<SimpleRequest, Response>("PutMethod", grpcClient.PutMethodAsync, grpcClient.PutMethod, effectiveSettings.PutMethodSettings).WithGoogleRequestParam("name", request => request.Name);
             Modify_ApiCall(ref _callPutMethod);
             Modify_PutMethodApiCall(ref _callPutMethod);
-            _callPatchMethod = clientHelper.BuildApiCall<SimpleRequest, Response>(grpcClient.PatchMethodAsync, grpcClient.PatchMethod, effectiveSettings.PatchMethodSettings).WithGoogleRequestParam("name", request => request.Name);
+            _callPatchMethod = clientHelper.BuildApiCall<SimpleRequest, Response>("PatchMethod", grpcClient.PatchMethodAsync, grpcClient.PatchMethod, effectiveSettings.PatchMethodSettings).WithGoogleRequestParam("name", request => request.Name);
             Modify_ApiCall(ref _callPatchMethod);
             Modify_PatchMethodApiCall(ref _callPatchMethod);
-            _callDeleteMethod = clientHelper.BuildApiCall<SimpleRequest, Response>(grpcClient.DeleteMethodAsync, grpcClient.DeleteMethod, effectiveSettings.DeleteMethodSettings).WithGoogleRequestParam("name", request => request.Name);
+            _callDeleteMethod = clientHelper.BuildApiCall<SimpleRequest, Response>("DeleteMethod", grpcClient.DeleteMethodAsync, grpcClient.DeleteMethod, effectiveSettings.DeleteMethodSettings).WithGoogleRequestParam("name", request => request.Name);
             Modify_ApiCall(ref _callDeleteMethod);
             Modify_DeleteMethodApiCall(ref _callDeleteMethod);
-            _callGetNoTemplateMethod = clientHelper.BuildApiCall<SimpleRequest, Response>(grpcClient.GetNoTemplateMethodAsync, grpcClient.GetNoTemplateMethod, effectiveSettings.GetNoTemplateMethodSettings).WithGoogleRequestParam("name", request => request.Name);
+            _callGetNoTemplateMethod = clientHelper.BuildApiCall<SimpleRequest, Response>("GetNoTemplateMethod", grpcClient.GetNoTemplateMethodAsync, grpcClient.GetNoTemplateMethod, effectiveSettings.GetNoTemplateMethodSettings).WithGoogleRequestParam("name", request => request.Name);
             Modify_ApiCall(ref _callGetNoTemplateMethod);
             Modify_GetNoTemplateMethodApiCall(ref _callGetNoTemplateMethod);
-            _callNestedMultiMethod = clientHelper.BuildApiCall<NestedRequest, Response>(grpcClient.NestedMultiMethodAsync, grpcClient.NestedMultiMethod, effectiveSettings.NestedMultiMethodSettings).WithGoogleRequestParam("nest1.nest2.name", request => request.Nest1?.Nest2?.Name).WithGoogleRequestParam("name", request => request.Name);
+            _callNestedMultiMethod = clientHelper.BuildApiCall<NestedRequest, Response>("NestedMultiMethod", grpcClient.NestedMultiMethodAsync, grpcClient.NestedMultiMethod, effectiveSettings.NestedMultiMethodSettings).WithGoogleRequestParam("nest1.nest2.name", request => request.Nest1?.Nest2?.Name).WithGoogleRequestParam("name", request => request.Name);
             Modify_ApiCall(ref _callNestedMultiMethod);
             Modify_NestedMultiMethodApiCall(ref _callNestedMultiMethod);
-            _callServerStreamingMethod = clientHelper.BuildApiCall<SimpleRequest, Response>(grpcClient.ServerStreamingMethod, effectiveSettings.ServerStreamingMethodSettings).WithGoogleRequestParam("name", request => request.Name);
+            _callServerStreamingMethod = clientHelper.BuildApiCall<SimpleRequest, Response>("ServerStreamingMethod", grpcClient.ServerStreamingMethod, effectiveSettings.ServerStreamingMethodSettings).WithGoogleRequestParam("name", request => request.Name);
             Modify_ApiCall(ref _callServerStreamingMethod);
             Modify_ServerStreamingMethodApiCall(ref _callServerStreamingMethod);
             OnConstruction(grpcClient, effectiveSettings, clientHelper);

--- a/Google.Api.Generator.Tests/ProtoTests/RoutingHeadersExplicit/Testing.RoutingHeadersExplicit/RoutingHeadersExplicitClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/RoutingHeadersExplicit/Testing.RoutingHeadersExplicit/RoutingHeadersExplicitClient.g.cs
@@ -15,6 +15,7 @@
 // Generated code. DO NOT EDIT!
 
 using gaxgrpc = Google.Api.Gax.Grpc;
+using mel = Microsoft.Extensions.Logging;
 using proto = Google.Protobuf;
 using sysnet = System.Net;
 using sys = System;
@@ -59,58 +60,58 @@ namespace Testing.RoutingHeadersExplicit
         private readonly gaxgrpc::ApiCall<NestedRequest, Response> _callComplex;
 
 
-        public RoutingHeadersExplicitClientImpl(RoutingHeadersExplicit.RoutingHeadersExplicitClient grpcClient, RoutingHeadersExplicitSettings settings)
+        public RoutingHeadersExplicitClientImpl(RoutingHeadersExplicit.RoutingHeadersExplicitClient grpcClient, RoutingHeadersExplicitSettings settings, mel::ILogger logger)
         {
             // TEST_START
             GrpcClient = grpcClient;
             RoutingHeadersExplicitSettings effectiveSettings = settings ?? RoutingHeadersExplicitSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings);
-            _callNoRouting = clientHelper.BuildApiCall<SimpleRequest, Response>(grpcClient.NoRoutingAsync, grpcClient.NoRouting, effectiveSettings.NoRoutingSettings);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            _callNoRouting = clientHelper.BuildApiCall<SimpleRequest, Response>("NoRouting", grpcClient.NoRoutingAsync, grpcClient.NoRouting, effectiveSettings.NoRoutingSettings);
             Modify_ApiCall(ref _callNoRouting);
             Modify_NoRoutingApiCall(ref _callNoRouting);
-            _callPlainNoTemplate = clientHelper.BuildApiCall<SimpleRequest, Response>(grpcClient.PlainNoTemplateAsync, grpcClient.PlainNoTemplate, effectiveSettings.PlainNoTemplateSettings).WithGoogleRequestParam("name", request => request.Name);
+            _callPlainNoTemplate = clientHelper.BuildApiCall<SimpleRequest, Response>("PlainNoTemplate", grpcClient.PlainNoTemplateAsync, grpcClient.PlainNoTemplate, effectiveSettings.PlainNoTemplateSettings).WithGoogleRequestParam("name", request => request.Name);
             Modify_ApiCall(ref _callPlainNoTemplate);
             Modify_PlainNoTemplateApiCall(ref _callPlainNoTemplate);
-            _callPlainNoExtraction = clientHelper.BuildApiCall<SimpleRequest, Response>(grpcClient.PlainNoExtractionAsync, grpcClient.PlainNoExtraction, effectiveSettings.PlainNoExtractionSettings).WithGoogleRequestParam("name", request => request.Name);
+            _callPlainNoExtraction = clientHelper.BuildApiCall<SimpleRequest, Response>("PlainNoExtraction", grpcClient.PlainNoExtractionAsync, grpcClient.PlainNoExtraction, effectiveSettings.PlainNoExtractionSettings).WithGoogleRequestParam("name", request => request.Name);
             Modify_ApiCall(ref _callPlainNoExtraction);
             Modify_PlainNoExtractionApiCall(ref _callPlainNoExtraction);
-            _callPlainFullField = clientHelper.BuildApiCall<SimpleRequest, Response>(grpcClient.PlainFullFieldAsync, grpcClient.PlainFullField, effectiveSettings.PlainFullFieldSettings).WithExtractedGoogleRequestParam(new gaxgrpc::RoutingHeaderExtractor<SimpleRequest>().WithExtractedParameter("table_name", "^(projects/[^/]+/instances/[^/]+/tables/[^/]+)/?$", request => request.Name));
+            _callPlainFullField = clientHelper.BuildApiCall<SimpleRequest, Response>("PlainFullField", grpcClient.PlainFullFieldAsync, grpcClient.PlainFullField, effectiveSettings.PlainFullFieldSettings).WithExtractedGoogleRequestParam(new gaxgrpc::RoutingHeaderExtractor<SimpleRequest>().WithExtractedParameter("table_name", "^(projects/[^/]+/instances/[^/]+/tables/[^/]+)/?$", request => request.Name));
             Modify_ApiCall(ref _callPlainFullField);
             Modify_PlainFullFieldApiCall(ref _callPlainFullField);
-            _callPlainExtract = clientHelper.BuildApiCall<SimpleRequest, Response>(grpcClient.PlainExtractAsync, grpcClient.PlainExtract, effectiveSettings.PlainExtractSettings).WithExtractedGoogleRequestParam(new gaxgrpc::RoutingHeaderExtractor<SimpleRequest>().WithExtractedParameter("table_name", "^projects/[^/]+/instances/[^/]+/(tables/[^/]+)/?$", request => request.Name));
+            _callPlainExtract = clientHelper.BuildApiCall<SimpleRequest, Response>("PlainExtract", grpcClient.PlainExtractAsync, grpcClient.PlainExtract, effectiveSettings.PlainExtractSettings).WithExtractedGoogleRequestParam(new gaxgrpc::RoutingHeaderExtractor<SimpleRequest>().WithExtractedParameter("table_name", "^projects/[^/]+/instances/[^/]+/(tables/[^/]+)/?$", request => request.Name));
             Modify_ApiCall(ref _callPlainExtract);
             Modify_PlainExtractApiCall(ref _callPlainExtract);
-            _callNested = clientHelper.BuildApiCall<NestedRequest, Response>(grpcClient.NestedAsync, grpcClient.Nested, effectiveSettings.NestedSettings).WithExtractedGoogleRequestParam(new gaxgrpc::RoutingHeaderExtractor<NestedRequest>().WithExtractedParameter("nest1.name", "^(.+)$", request => request.Nest1?.Name).WithExtractedParameter("nest1.nest2.name", "^(.+)$", request => request.Nest1?.Nest2?.Name));
+            _callNested = clientHelper.BuildApiCall<NestedRequest, Response>("Nested", grpcClient.NestedAsync, grpcClient.Nested, effectiveSettings.NestedSettings).WithExtractedGoogleRequestParam(new gaxgrpc::RoutingHeaderExtractor<NestedRequest>().WithExtractedParameter("nest1.name", "^(.+)$", request => request.Nest1?.Name).WithExtractedParameter("nest1.nest2.name", "^(.+)$", request => request.Nest1?.Nest2?.Name));
             Modify_ApiCall(ref _callNested);
             Modify_NestedApiCall(ref _callNested);
-            _callComplex = clientHelper.BuildApiCall<NestedRequest, Response>(grpcClient.ComplexAsync, grpcClient.Complex, effectiveSettings.ComplexSettings).WithExtractedGoogleRequestParam(new gaxgrpc::RoutingHeaderExtractor<NestedRequest>().WithExtractedParameter("table_location", "^projects/[^/]+/(instances/[^/]+)/tables/[^/]+/?$", request => request.TableName).WithExtractedParameter("table_location", "^(regions/[^/]+/zones/[^/]+)/tables/[^/]+/?$", request => request.TableName).WithExtractedParameter("routing_id", "^(projects/[^/]+)(?:/.*)?$", request => request.TableName).WithExtractedParameter("routing_id", "^(.+)$", request => request.AppProfileId).WithExtractedParameter("routing_id", "^profiles/([^/]+)/?$", request => request.AppProfileId));
+            _callComplex = clientHelper.BuildApiCall<NestedRequest, Response>("Complex", grpcClient.ComplexAsync, grpcClient.Complex, effectiveSettings.ComplexSettings).WithExtractedGoogleRequestParam(new gaxgrpc::RoutingHeaderExtractor<NestedRequest>().WithExtractedParameter("table_location", "^projects/[^/]+/(instances/[^/]+)/tables/[^/]+/?$", request => request.TableName).WithExtractedParameter("table_location", "^(regions/[^/]+/zones/[^/]+)/tables/[^/]+/?$", request => request.TableName).WithExtractedParameter("routing_id", "^(projects/[^/]+)(?:/.*)?$", request => request.TableName).WithExtractedParameter("routing_id", "^(.+)$", request => request.AppProfileId).WithExtractedParameter("routing_id", "^profiles/([^/]+)/?$", request => request.AppProfileId));
             Modify_ApiCall(ref _callComplex);
             Modify_ComplexApiCall(ref _callComplex);
             OnConstruction(grpcClient, effectiveSettings, clientHelper);
             // TEST_END
 
             // for the easier reading, the above calls but indented
-            _callPlainNoTemplate = clientHelper.BuildApiCall<SimpleRequest, Response>(grpcClient.PlainNoTemplateAsync, grpcClient.PlainNoTemplate, effectiveSettings.PlainNoTemplateSettings)
+            _callPlainNoTemplate = clientHelper.BuildApiCall<SimpleRequest, Response>("PlainNoTemplate", grpcClient.PlainNoTemplateAsync, grpcClient.PlainNoTemplate, effectiveSettings.PlainNoTemplateSettings)
                 .WithGoogleRequestParam("name", request => request.Name);
 
             _callPlainNoExtraction = clientHelper
-                .BuildApiCall<SimpleRequest, Response>(grpcClient.PlainNoExtractionAsync, grpcClient.PlainNoExtraction, effectiveSettings.PlainNoExtractionSettings)
+                .BuildApiCall<SimpleRequest, Response>("PlainNoExtraction", grpcClient.PlainNoExtractionAsync, grpcClient.PlainNoExtraction, effectiveSettings.PlainNoExtractionSettings)
                 .WithGoogleRequestParam("name", request => request.Name);
 
             _callPlainFullField = clientHelper
-                .BuildApiCall<SimpleRequest, Response>(grpcClient.PlainFullFieldAsync, grpcClient.PlainFullField, effectiveSettings.PlainFullFieldSettings)
+                .BuildApiCall<SimpleRequest, Response>("PlainFullField", grpcClient.PlainFullFieldAsync, grpcClient.PlainFullField, effectiveSettings.PlainFullFieldSettings)
                 .WithExtractedGoogleRequestParam(new gaxgrpc::RoutingHeaderExtractor<SimpleRequest>()
                     .WithExtractedParameter("table_name",
                         "^(projects/[^/]+/instances/[^/]+/tables/[^/]+)/?$", request => request.Name));
 
             _callPlainExtract = clientHelper
-                .BuildApiCall<SimpleRequest, Response>(grpcClient.PlainExtractAsync, grpcClient.PlainExtract, effectiveSettings.PlainExtractSettings)
+                .BuildApiCall<SimpleRequest, Response>("", grpcClient.PlainExtractAsync, grpcClient.PlainExtract, effectiveSettings.PlainExtractSettings)
                 .WithExtractedGoogleRequestParam(new gaxgrpc::RoutingHeaderExtractor<SimpleRequest>()
                     .WithExtractedParameter("table_name",
                         "^projects/[^/]+/instances/[^/]+/(tables/[^/]+)/?$", request => request.Name));
 
             _callNested = clientHelper
-                .BuildApiCall<NestedRequest, Response>(grpcClient.NestedAsync, grpcClient.Nested, effectiveSettings.NestedSettings)
+                .BuildApiCall<NestedRequest, Response>("", grpcClient.NestedAsync, grpcClient.Nested, effectiveSettings.NestedSettings)
                 .WithExtractedGoogleRequestParam(new gaxgrpc::RoutingHeaderExtractor<NestedRequest>()
                     .WithExtractedParameter("nest1.name",
                         "^(.+)$", request => request.Nest1?.Name)
@@ -118,7 +119,7 @@ namespace Testing.RoutingHeadersExplicit
                         "^(.+)$", request => request.Nest1?.Nest2?.Name));
 
             _callComplex = clientHelper
-                .BuildApiCall<NestedRequest, Response>(grpcClient.ComplexAsync, grpcClient.Complex, effectiveSettings.ComplexSettings)
+                .BuildApiCall<NestedRequest, Response>("", grpcClient.ComplexAsync, grpcClient.Complex, effectiveSettings.ComplexSettings)
                 .WithExtractedGoogleRequestParam(new gaxgrpc::RoutingHeaderExtractor<NestedRequest>()
                     .WithExtractedParameter("table_location",
                         "^projects/[^/]+/(instances/[^/]+)/tables/[^/]+/?$", request => request.TableName)

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/ComplianceClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/ComplianceClient.g.cs
@@ -19,6 +19,7 @@ using gaxgrpc = Google.Api.Gax.Grpc;
 using proto = Google.Protobuf;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
+using mel = Microsoft.Extensions.Logging;
 using sys = System;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -194,14 +195,14 @@ namespace Google.Showcase.V1Beta1
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return ComplianceClient.Create(callInvoker, Settings);
+            return ComplianceClient.Create(callInvoker, Settings, Logger);
         }
 
         private async stt::Task<ComplianceClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return ComplianceClient.Create(callInvoker, Settings);
+            return ComplianceClient.Create(callInvoker, Settings, Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>
@@ -254,8 +255,9 @@ namespace Google.Showcase.V1Beta1
         /// The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.
         /// </param>
         /// <param name="settings">Optional <see cref="ComplianceSettings"/>.</param>
+        /// <param name="logger">Optional <see cref="mel::ILogger"/>.</param>
         /// <returns>The created <see cref="ComplianceClient"/>.</returns>
-        internal static ComplianceClient Create(grpccore::CallInvoker callInvoker, ComplianceSettings settings = null)
+        internal static ComplianceClient Create(grpccore::CallInvoker callInvoker, ComplianceSettings settings = null, mel::ILogger logger = null)
         {
             gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
             grpcinter::Interceptor interceptor = settings?.Interceptor;
@@ -264,7 +266,7 @@ namespace Google.Showcase.V1Beta1
                 callInvoker = grpcinter::CallInvokerExtensions.Intercept(callInvoker, interceptor);
             }
             Compliance.ComplianceClient grpcClient = new Compliance.ComplianceClient(callInvoker);
-            return new ComplianceClientImpl(grpcClient, settings);
+            return new ComplianceClientImpl(grpcClient, settings, logger);
         }
 
         /// <summary>
@@ -546,33 +548,34 @@ namespace Google.Showcase.V1Beta1
         /// </summary>
         /// <param name="grpcClient">The underlying gRPC client.</param>
         /// <param name="settings">The base <see cref="ComplianceSettings"/> used within this client.</param>
-        public ComplianceClientImpl(Compliance.ComplianceClient grpcClient, ComplianceSettings settings)
+        /// <param name="logger">Optional <see cref="mel::ILogger"/> to use within this client.</param>
+        public ComplianceClientImpl(Compliance.ComplianceClient grpcClient, ComplianceSettings settings, mel::ILogger logger)
         {
             GrpcClient = grpcClient;
             ComplianceSettings effectiveSettings = settings ?? ComplianceSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings);
-            _callRepeatDataBody = clientHelper.BuildApiCall<RepeatRequest, RepeatResponse>(grpcClient.RepeatDataBodyAsync, grpcClient.RepeatDataBody, effectiveSettings.RepeatDataBodySettings);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            _callRepeatDataBody = clientHelper.BuildApiCall<RepeatRequest, RepeatResponse>("RepeatDataBody", grpcClient.RepeatDataBodyAsync, grpcClient.RepeatDataBody, effectiveSettings.RepeatDataBodySettings);
             Modify_ApiCall(ref _callRepeatDataBody);
             Modify_RepeatDataBodyApiCall(ref _callRepeatDataBody);
-            _callRepeatDataBodyInfo = clientHelper.BuildApiCall<RepeatRequest, RepeatResponse>(grpcClient.RepeatDataBodyInfoAsync, grpcClient.RepeatDataBodyInfo, effectiveSettings.RepeatDataBodyInfoSettings);
+            _callRepeatDataBodyInfo = clientHelper.BuildApiCall<RepeatRequest, RepeatResponse>("RepeatDataBodyInfo", grpcClient.RepeatDataBodyInfoAsync, grpcClient.RepeatDataBodyInfo, effectiveSettings.RepeatDataBodyInfoSettings);
             Modify_ApiCall(ref _callRepeatDataBodyInfo);
             Modify_RepeatDataBodyInfoApiCall(ref _callRepeatDataBodyInfo);
-            _callRepeatDataQuery = clientHelper.BuildApiCall<RepeatRequest, RepeatResponse>(grpcClient.RepeatDataQueryAsync, grpcClient.RepeatDataQuery, effectiveSettings.RepeatDataQuerySettings);
+            _callRepeatDataQuery = clientHelper.BuildApiCall<RepeatRequest, RepeatResponse>("RepeatDataQuery", grpcClient.RepeatDataQueryAsync, grpcClient.RepeatDataQuery, effectiveSettings.RepeatDataQuerySettings);
             Modify_ApiCall(ref _callRepeatDataQuery);
             Modify_RepeatDataQueryApiCall(ref _callRepeatDataQuery);
-            _callRepeatDataSimplePath = clientHelper.BuildApiCall<RepeatRequest, RepeatResponse>(grpcClient.RepeatDataSimplePathAsync, grpcClient.RepeatDataSimplePath, effectiveSettings.RepeatDataSimplePathSettings).WithGoogleRequestParam("info.f_string", request => request.Info?.FString);
+            _callRepeatDataSimplePath = clientHelper.BuildApiCall<RepeatRequest, RepeatResponse>("RepeatDataSimplePath", grpcClient.RepeatDataSimplePathAsync, grpcClient.RepeatDataSimplePath, effectiveSettings.RepeatDataSimplePathSettings).WithGoogleRequestParam("info.f_string", request => request.Info?.FString);
             Modify_ApiCall(ref _callRepeatDataSimplePath);
             Modify_RepeatDataSimplePathApiCall(ref _callRepeatDataSimplePath);
-            _callRepeatDataPathResource = clientHelper.BuildApiCall<RepeatRequest, RepeatResponse>(grpcClient.RepeatDataPathResourceAsync, grpcClient.RepeatDataPathResource, effectiveSettings.RepeatDataPathResourceSettings).WithGoogleRequestParam("info.f_string", request => request.Info?.FString).WithGoogleRequestParam("info.f_child.f_string", request => request.Info?.FChild?.FString);
+            _callRepeatDataPathResource = clientHelper.BuildApiCall<RepeatRequest, RepeatResponse>("RepeatDataPathResource", grpcClient.RepeatDataPathResourceAsync, grpcClient.RepeatDataPathResource, effectiveSettings.RepeatDataPathResourceSettings).WithGoogleRequestParam("info.f_string", request => request.Info?.FString).WithGoogleRequestParam("info.f_child.f_string", request => request.Info?.FChild?.FString);
             Modify_ApiCall(ref _callRepeatDataPathResource);
             Modify_RepeatDataPathResourceApiCall(ref _callRepeatDataPathResource);
-            _callRepeatDataPathTrailingResource = clientHelper.BuildApiCall<RepeatRequest, RepeatResponse>(grpcClient.RepeatDataPathTrailingResourceAsync, grpcClient.RepeatDataPathTrailingResource, effectiveSettings.RepeatDataPathTrailingResourceSettings).WithGoogleRequestParam("info.f_string", request => request.Info?.FString).WithGoogleRequestParam("info.f_child.f_string", request => request.Info?.FChild?.FString);
+            _callRepeatDataPathTrailingResource = clientHelper.BuildApiCall<RepeatRequest, RepeatResponse>("RepeatDataPathTrailingResource", grpcClient.RepeatDataPathTrailingResourceAsync, grpcClient.RepeatDataPathTrailingResource, effectiveSettings.RepeatDataPathTrailingResourceSettings).WithGoogleRequestParam("info.f_string", request => request.Info?.FString).WithGoogleRequestParam("info.f_child.f_string", request => request.Info?.FChild?.FString);
             Modify_ApiCall(ref _callRepeatDataPathTrailingResource);
             Modify_RepeatDataPathTrailingResourceApiCall(ref _callRepeatDataPathTrailingResource);
-            _callRepeatDataBodyPut = clientHelper.BuildApiCall<RepeatRequest, RepeatResponse>(grpcClient.RepeatDataBodyPutAsync, grpcClient.RepeatDataBodyPut, effectiveSettings.RepeatDataBodyPutSettings);
+            _callRepeatDataBodyPut = clientHelper.BuildApiCall<RepeatRequest, RepeatResponse>("RepeatDataBodyPut", grpcClient.RepeatDataBodyPutAsync, grpcClient.RepeatDataBodyPut, effectiveSettings.RepeatDataBodyPutSettings);
             Modify_ApiCall(ref _callRepeatDataBodyPut);
             Modify_RepeatDataBodyPutApiCall(ref _callRepeatDataBodyPut);
-            _callRepeatDataBodyPatch = clientHelper.BuildApiCall<RepeatRequest, RepeatResponse>(grpcClient.RepeatDataBodyPatchAsync, grpcClient.RepeatDataBodyPatch, effectiveSettings.RepeatDataBodyPatchSettings);
+            _callRepeatDataBodyPatch = clientHelper.BuildApiCall<RepeatRequest, RepeatResponse>("RepeatDataBodyPatch", grpcClient.RepeatDataBodyPatchAsync, grpcClient.RepeatDataBodyPatch, effectiveSettings.RepeatDataBodyPatchSettings);
             Modify_ApiCall(ref _callRepeatDataBodyPatch);
             Modify_RepeatDataBodyPatchApiCall(ref _callRepeatDataBodyPatch);
             OnConstruction(grpcClient, effectiveSettings, clientHelper);

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/EchoClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/EchoClient.g.cs
@@ -21,6 +21,7 @@ using proto = Google.Protobuf;
 using gr = Google.Rpc;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
+using mel = Microsoft.Extensions.Logging;
 using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
@@ -243,14 +244,14 @@ namespace Google.Showcase.V1Beta1
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return EchoClient.Create(callInvoker, Settings);
+            return EchoClient.Create(callInvoker, Settings, Logger);
         }
 
         private async stt::Task<EchoClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return EchoClient.Create(callInvoker, Settings);
+            return EchoClient.Create(callInvoker, Settings, Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>
@@ -308,8 +309,9 @@ namespace Google.Showcase.V1Beta1
         /// The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.
         /// </param>
         /// <param name="settings">Optional <see cref="EchoSettings"/>.</param>
+        /// <param name="logger">Optional <see cref="mel::ILogger"/>.</param>
         /// <returns>The created <see cref="EchoClient"/>.</returns>
-        internal static EchoClient Create(grpccore::CallInvoker callInvoker, EchoSettings settings = null)
+        internal static EchoClient Create(grpccore::CallInvoker callInvoker, EchoSettings settings = null, mel::ILogger logger = null)
         {
             gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
             grpcinter::Interceptor interceptor = settings?.Interceptor;
@@ -318,7 +320,7 @@ namespace Google.Showcase.V1Beta1
                 callInvoker = grpcinter::CallInvokerExtensions.Intercept(callInvoker, interceptor);
             }
             Echo.EchoClient grpcClient = new Echo.EchoClient(callInvoker);
-            return new EchoClientImpl(grpcClient, settings);
+            return new EchoClientImpl(grpcClient, settings, logger);
         }
 
         /// <summary>
@@ -630,37 +632,38 @@ namespace Google.Showcase.V1Beta1
         /// </summary>
         /// <param name="grpcClient">The underlying gRPC client.</param>
         /// <param name="settings">The base <see cref="EchoSettings"/> used within this client.</param>
-        public EchoClientImpl(Echo.EchoClient grpcClient, EchoSettings settings)
+        /// <param name="logger">Optional <see cref="mel::ILogger"/> to use within this client.</param>
+        public EchoClientImpl(Echo.EchoClient grpcClient, EchoSettings settings, mel::ILogger logger)
         {
             GrpcClient = grpcClient;
             EchoSettings effectiveSettings = settings ?? EchoSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings);
-            WaitOperationsClient = new lro::OperationsClientImpl(grpcClient.CreateOperationsClient(), effectiveSettings.WaitOperationsSettings);
-            _callEchoCall = clientHelper.BuildApiCall<EchoRequest, EchoResponse>(grpcClient.EchoCallAsync, grpcClient.EchoCall, effectiveSettings.EchoCallSettings).WithExtractedGoogleRequestParam(new gaxgrpc::RoutingHeaderExtractor<EchoRequest>().WithExtractedParameter("header", "^(.+)$", request => request.Header).WithExtractedParameter("routing_id", "^(.+)$", request => request.Header).WithExtractedParameter("table_name", "^(regions/[^/]+/zones/[^/]+(?:/.*)?)$", request => request.Header).WithExtractedParameter("table_name", "^(projects/[^/]+/instances/[^/]+(?:/.*)?)$", request => request.Header).WithExtractedParameter("super_id", "^(projects/[^/]+)(?:/.*)?$", request => request.Header).WithExtractedParameter("instance_id", "^projects/[^/]+/(instances/[^/]+)(?:/.*)?$", request => request.Header).WithExtractedParameter("baz", "^(.+)$", request => request.OtherHeader).WithExtractedParameter("qux", "^(projects/[^/]+)(?:/.*)?$", request => request.OtherHeader));
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            WaitOperationsClient = new lro::OperationsClientImpl(grpcClient.CreateOperationsClient(), effectiveSettings.WaitOperationsSettings, logger);
+            _callEchoCall = clientHelper.BuildApiCall<EchoRequest, EchoResponse>("EchoCall", grpcClient.EchoCallAsync, grpcClient.EchoCall, effectiveSettings.EchoCallSettings).WithExtractedGoogleRequestParam(new gaxgrpc::RoutingHeaderExtractor<EchoRequest>().WithExtractedParameter("header", "^(.+)$", request => request.Header).WithExtractedParameter("routing_id", "^(.+)$", request => request.Header).WithExtractedParameter("table_name", "^(regions/[^/]+/zones/[^/]+(?:/.*)?)$", request => request.Header).WithExtractedParameter("table_name", "^(projects/[^/]+/instances/[^/]+(?:/.*)?)$", request => request.Header).WithExtractedParameter("super_id", "^(projects/[^/]+)(?:/.*)?$", request => request.Header).WithExtractedParameter("instance_id", "^projects/[^/]+/(instances/[^/]+)(?:/.*)?$", request => request.Header).WithExtractedParameter("baz", "^(.+)$", request => request.OtherHeader).WithExtractedParameter("qux", "^(projects/[^/]+)(?:/.*)?$", request => request.OtherHeader));
             Modify_ApiCall(ref _callEchoCall);
             Modify_EchoCallApiCall(ref _callEchoCall);
-            _callExpand = clientHelper.BuildApiCall<ExpandRequest, EchoResponse>(grpcClient.Expand, effectiveSettings.ExpandSettings);
+            _callExpand = clientHelper.BuildApiCall<ExpandRequest, EchoResponse>("Expand", grpcClient.Expand, effectiveSettings.ExpandSettings);
             Modify_ApiCall(ref _callExpand);
             Modify_ExpandApiCall(ref _callExpand);
-            _callCollect = clientHelper.BuildApiCall<EchoRequest, EchoResponse>(grpcClient.Collect, effectiveSettings.CollectSettings, effectiveSettings.CollectStreamingSettings);
+            _callCollect = clientHelper.BuildApiCall<EchoRequest, EchoResponse>("Collect", grpcClient.Collect, effectiveSettings.CollectSettings, effectiveSettings.CollectStreamingSettings);
             Modify_ApiCall(ref _callCollect);
             Modify_CollectApiCall(ref _callCollect);
-            _callChat = clientHelper.BuildApiCall<EchoRequest, EchoResponse>(grpcClient.Chat, effectiveSettings.ChatSettings, effectiveSettings.ChatStreamingSettings);
+            _callChat = clientHelper.BuildApiCall<EchoRequest, EchoResponse>("Chat", grpcClient.Chat, effectiveSettings.ChatSettings, effectiveSettings.ChatStreamingSettings);
             Modify_ApiCall(ref _callChat);
             Modify_ChatApiCall(ref _callChat);
-            _callPagedExpand = clientHelper.BuildApiCall<PagedExpandRequest, PagedExpandResponse>(grpcClient.PagedExpandAsync, grpcClient.PagedExpand, effectiveSettings.PagedExpandSettings);
+            _callPagedExpand = clientHelper.BuildApiCall<PagedExpandRequest, PagedExpandResponse>("PagedExpand", grpcClient.PagedExpandAsync, grpcClient.PagedExpand, effectiveSettings.PagedExpandSettings);
             Modify_ApiCall(ref _callPagedExpand);
             Modify_PagedExpandApiCall(ref _callPagedExpand);
-            _callPagedExpandLegacy = clientHelper.BuildApiCall<PagedExpandLegacyRequest, PagedExpandResponse>(grpcClient.PagedExpandLegacyAsync, grpcClient.PagedExpandLegacy, effectiveSettings.PagedExpandLegacySettings);
+            _callPagedExpandLegacy = clientHelper.BuildApiCall<PagedExpandLegacyRequest, PagedExpandResponse>("PagedExpandLegacy", grpcClient.PagedExpandLegacyAsync, grpcClient.PagedExpandLegacy, effectiveSettings.PagedExpandLegacySettings);
             Modify_ApiCall(ref _callPagedExpandLegacy);
             Modify_PagedExpandLegacyApiCall(ref _callPagedExpandLegacy);
-            _callPagedExpandLegacyMapped = clientHelper.BuildApiCall<PagedExpandRequest, PagedExpandLegacyMappedResponse>(grpcClient.PagedExpandLegacyMappedAsync, grpcClient.PagedExpandLegacyMapped, effectiveSettings.PagedExpandLegacyMappedSettings);
+            _callPagedExpandLegacyMapped = clientHelper.BuildApiCall<PagedExpandRequest, PagedExpandLegacyMappedResponse>("PagedExpandLegacyMapped", grpcClient.PagedExpandLegacyMappedAsync, grpcClient.PagedExpandLegacyMapped, effectiveSettings.PagedExpandLegacyMappedSettings);
             Modify_ApiCall(ref _callPagedExpandLegacyMapped);
             Modify_PagedExpandLegacyMappedApiCall(ref _callPagedExpandLegacyMapped);
-            _callWait = clientHelper.BuildApiCall<WaitRequest, lro::Operation>(grpcClient.WaitAsync, grpcClient.Wait, effectiveSettings.WaitSettings);
+            _callWait = clientHelper.BuildApiCall<WaitRequest, lro::Operation>("Wait", grpcClient.WaitAsync, grpcClient.Wait, effectiveSettings.WaitSettings);
             Modify_ApiCall(ref _callWait);
             Modify_WaitApiCall(ref _callWait);
-            _callBlock = clientHelper.BuildApiCall<BlockRequest, BlockResponse>(grpcClient.BlockAsync, grpcClient.Block, effectiveSettings.BlockSettings);
+            _callBlock = clientHelper.BuildApiCall<BlockRequest, BlockResponse>("Block", grpcClient.BlockAsync, grpcClient.Block, effectiveSettings.BlockSettings);
             Modify_ApiCall(ref _callBlock);
             Modify_BlockApiCall(ref _callBlock);
             OnConstruction(grpcClient, effectiveSettings, clientHelper);

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/Google.Showcase.V1Beta1.csproj
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/Google.Showcase.V1Beta1.csproj
@@ -39,10 +39,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.0.0-alpha01, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.0.0-alpha02, 5.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.41.0, 3.0.0)" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
-    <PackageReference Include="Google.LongRunning" Version="[3.0.0-alpha01, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.0.0-alpha02, 4.0.0)" />
   </ItemGroup>
 
 </Project>

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/IdentityClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/IdentityClient.g.cs
@@ -20,6 +20,7 @@ using proto = Google.Protobuf;
 using wkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
+using mel = Microsoft.Extensions.Logging;
 using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
@@ -156,14 +157,14 @@ namespace Google.Showcase.V1Beta1
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return IdentityClient.Create(callInvoker, Settings);
+            return IdentityClient.Create(callInvoker, Settings, Logger);
         }
 
         private async stt::Task<IdentityClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return IdentityClient.Create(callInvoker, Settings);
+            return IdentityClient.Create(callInvoker, Settings, Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>
@@ -215,8 +216,9 @@ namespace Google.Showcase.V1Beta1
         /// The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.
         /// </param>
         /// <param name="settings">Optional <see cref="IdentitySettings"/>.</param>
+        /// <param name="logger">Optional <see cref="mel::ILogger"/>.</param>
         /// <returns>The created <see cref="IdentityClient"/>.</returns>
-        internal static IdentityClient Create(grpccore::CallInvoker callInvoker, IdentitySettings settings = null)
+        internal static IdentityClient Create(grpccore::CallInvoker callInvoker, IdentitySettings settings = null, mel::ILogger logger = null)
         {
             gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
             grpcinter::Interceptor interceptor = settings?.Interceptor;
@@ -225,7 +227,7 @@ namespace Google.Showcase.V1Beta1
                 callInvoker = grpcinter::CallInvokerExtensions.Intercept(callInvoker, interceptor);
             }
             Identity.IdentityClient grpcClient = new Identity.IdentityClient(callInvoker);
-            return new IdentityClientImpl(grpcClient, settings);
+            return new IdentityClientImpl(grpcClient, settings, logger);
         }
 
         /// <summary>
@@ -722,24 +724,25 @@ namespace Google.Showcase.V1Beta1
         /// </summary>
         /// <param name="grpcClient">The underlying gRPC client.</param>
         /// <param name="settings">The base <see cref="IdentitySettings"/> used within this client.</param>
-        public IdentityClientImpl(Identity.IdentityClient grpcClient, IdentitySettings settings)
+        /// <param name="logger">Optional <see cref="mel::ILogger"/> to use within this client.</param>
+        public IdentityClientImpl(Identity.IdentityClient grpcClient, IdentitySettings settings, mel::ILogger logger)
         {
             GrpcClient = grpcClient;
             IdentitySettings effectiveSettings = settings ?? IdentitySettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings);
-            _callCreateUser = clientHelper.BuildApiCall<CreateUserRequest, User>(grpcClient.CreateUserAsync, grpcClient.CreateUser, effectiveSettings.CreateUserSettings);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            _callCreateUser = clientHelper.BuildApiCall<CreateUserRequest, User>("CreateUser", grpcClient.CreateUserAsync, grpcClient.CreateUser, effectiveSettings.CreateUserSettings);
             Modify_ApiCall(ref _callCreateUser);
             Modify_CreateUserApiCall(ref _callCreateUser);
-            _callGetUser = clientHelper.BuildApiCall<GetUserRequest, User>(grpcClient.GetUserAsync, grpcClient.GetUser, effectiveSettings.GetUserSettings).WithGoogleRequestParam("name", request => request.Name);
+            _callGetUser = clientHelper.BuildApiCall<GetUserRequest, User>("GetUser", grpcClient.GetUserAsync, grpcClient.GetUser, effectiveSettings.GetUserSettings).WithGoogleRequestParam("name", request => request.Name);
             Modify_ApiCall(ref _callGetUser);
             Modify_GetUserApiCall(ref _callGetUser);
-            _callUpdateUser = clientHelper.BuildApiCall<UpdateUserRequest, User>(grpcClient.UpdateUserAsync, grpcClient.UpdateUser, effectiveSettings.UpdateUserSettings).WithGoogleRequestParam("user.name", request => request.User?.Name);
+            _callUpdateUser = clientHelper.BuildApiCall<UpdateUserRequest, User>("UpdateUser", grpcClient.UpdateUserAsync, grpcClient.UpdateUser, effectiveSettings.UpdateUserSettings).WithGoogleRequestParam("user.name", request => request.User?.Name);
             Modify_ApiCall(ref _callUpdateUser);
             Modify_UpdateUserApiCall(ref _callUpdateUser);
-            _callDeleteUser = clientHelper.BuildApiCall<DeleteUserRequest, wkt::Empty>(grpcClient.DeleteUserAsync, grpcClient.DeleteUser, effectiveSettings.DeleteUserSettings).WithGoogleRequestParam("name", request => request.Name);
+            _callDeleteUser = clientHelper.BuildApiCall<DeleteUserRequest, wkt::Empty>("DeleteUser", grpcClient.DeleteUserAsync, grpcClient.DeleteUser, effectiveSettings.DeleteUserSettings).WithGoogleRequestParam("name", request => request.Name);
             Modify_ApiCall(ref _callDeleteUser);
             Modify_DeleteUserApiCall(ref _callDeleteUser);
-            _callListUsers = clientHelper.BuildApiCall<ListUsersRequest, ListUsersResponse>(grpcClient.ListUsersAsync, grpcClient.ListUsers, effectiveSettings.ListUsersSettings);
+            _callListUsers = clientHelper.BuildApiCall<ListUsersRequest, ListUsersResponse>("ListUsers", grpcClient.ListUsersAsync, grpcClient.ListUsers, effectiveSettings.ListUsersSettings);
             Modify_ApiCall(ref _callListUsers);
             Modify_ListUsersApiCall(ref _callListUsers);
             OnConstruction(grpcClient, effectiveSettings, clientHelper);

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/MessagingClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/MessagingClient.g.cs
@@ -21,6 +21,7 @@ using proto = Google.Protobuf;
 using wkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
+using mel = Microsoft.Extensions.Logging;
 using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
@@ -309,14 +310,14 @@ namespace Google.Showcase.V1Beta1
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return MessagingClient.Create(callInvoker, Settings);
+            return MessagingClient.Create(callInvoker, Settings, Logger);
         }
 
         private async stt::Task<MessagingClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return MessagingClient.Create(callInvoker, Settings);
+            return MessagingClient.Create(callInvoker, Settings, Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>
@@ -371,8 +372,9 @@ namespace Google.Showcase.V1Beta1
         /// The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.
         /// </param>
         /// <param name="settings">Optional <see cref="MessagingSettings"/>.</param>
+        /// <param name="logger">Optional <see cref="mel::ILogger"/>.</param>
         /// <returns>The created <see cref="MessagingClient"/>.</returns>
-        internal static MessagingClient Create(grpccore::CallInvoker callInvoker, MessagingSettings settings = null)
+        internal static MessagingClient Create(grpccore::CallInvoker callInvoker, MessagingSettings settings = null, mel::ILogger logger = null)
         {
             gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
             grpcinter::Interceptor interceptor = settings?.Interceptor;
@@ -381,7 +383,7 @@ namespace Google.Showcase.V1Beta1
                 callInvoker = grpcinter::CallInvokerExtensions.Intercept(callInvoker, interceptor);
             }
             Messaging.MessagingClient grpcClient = new Messaging.MessagingClient(callInvoker);
-            return new MessagingClientImpl(grpcClient, settings);
+            return new MessagingClientImpl(grpcClient, settings, logger);
         }
 
         /// <summary>
@@ -1713,52 +1715,53 @@ namespace Google.Showcase.V1Beta1
         /// </summary>
         /// <param name="grpcClient">The underlying gRPC client.</param>
         /// <param name="settings">The base <see cref="MessagingSettings"/> used within this client.</param>
-        public MessagingClientImpl(Messaging.MessagingClient grpcClient, MessagingSettings settings)
+        /// <param name="logger">Optional <see cref="mel::ILogger"/> to use within this client.</param>
+        public MessagingClientImpl(Messaging.MessagingClient grpcClient, MessagingSettings settings, mel::ILogger logger)
         {
             GrpcClient = grpcClient;
             MessagingSettings effectiveSettings = settings ?? MessagingSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings);
-            SearchBlurbsOperationsClient = new lro::OperationsClientImpl(grpcClient.CreateOperationsClient(), effectiveSettings.SearchBlurbsOperationsSettings);
-            _callCreateRoom = clientHelper.BuildApiCall<CreateRoomRequest, Room>(grpcClient.CreateRoomAsync, grpcClient.CreateRoom, effectiveSettings.CreateRoomSettings);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            SearchBlurbsOperationsClient = new lro::OperationsClientImpl(grpcClient.CreateOperationsClient(), effectiveSettings.SearchBlurbsOperationsSettings, logger);
+            _callCreateRoom = clientHelper.BuildApiCall<CreateRoomRequest, Room>("CreateRoom", grpcClient.CreateRoomAsync, grpcClient.CreateRoom, effectiveSettings.CreateRoomSettings);
             Modify_ApiCall(ref _callCreateRoom);
             Modify_CreateRoomApiCall(ref _callCreateRoom);
-            _callGetRoom = clientHelper.BuildApiCall<GetRoomRequest, Room>(grpcClient.GetRoomAsync, grpcClient.GetRoom, effectiveSettings.GetRoomSettings).WithGoogleRequestParam("name", request => request.Name);
+            _callGetRoom = clientHelper.BuildApiCall<GetRoomRequest, Room>("GetRoom", grpcClient.GetRoomAsync, grpcClient.GetRoom, effectiveSettings.GetRoomSettings).WithGoogleRequestParam("name", request => request.Name);
             Modify_ApiCall(ref _callGetRoom);
             Modify_GetRoomApiCall(ref _callGetRoom);
-            _callUpdateRoom = clientHelper.BuildApiCall<UpdateRoomRequest, Room>(grpcClient.UpdateRoomAsync, grpcClient.UpdateRoom, effectiveSettings.UpdateRoomSettings).WithGoogleRequestParam("room.name", request => request.Room?.Name);
+            _callUpdateRoom = clientHelper.BuildApiCall<UpdateRoomRequest, Room>("UpdateRoom", grpcClient.UpdateRoomAsync, grpcClient.UpdateRoom, effectiveSettings.UpdateRoomSettings).WithGoogleRequestParam("room.name", request => request.Room?.Name);
             Modify_ApiCall(ref _callUpdateRoom);
             Modify_UpdateRoomApiCall(ref _callUpdateRoom);
-            _callDeleteRoom = clientHelper.BuildApiCall<DeleteRoomRequest, wkt::Empty>(grpcClient.DeleteRoomAsync, grpcClient.DeleteRoom, effectiveSettings.DeleteRoomSettings).WithGoogleRequestParam("name", request => request.Name);
+            _callDeleteRoom = clientHelper.BuildApiCall<DeleteRoomRequest, wkt::Empty>("DeleteRoom", grpcClient.DeleteRoomAsync, grpcClient.DeleteRoom, effectiveSettings.DeleteRoomSettings).WithGoogleRequestParam("name", request => request.Name);
             Modify_ApiCall(ref _callDeleteRoom);
             Modify_DeleteRoomApiCall(ref _callDeleteRoom);
-            _callListRooms = clientHelper.BuildApiCall<ListRoomsRequest, ListRoomsResponse>(grpcClient.ListRoomsAsync, grpcClient.ListRooms, effectiveSettings.ListRoomsSettings);
+            _callListRooms = clientHelper.BuildApiCall<ListRoomsRequest, ListRoomsResponse>("ListRooms", grpcClient.ListRoomsAsync, grpcClient.ListRooms, effectiveSettings.ListRoomsSettings);
             Modify_ApiCall(ref _callListRooms);
             Modify_ListRoomsApiCall(ref _callListRooms);
-            _callCreateBlurb = clientHelper.BuildApiCall<CreateBlurbRequest, Blurb>(grpcClient.CreateBlurbAsync, grpcClient.CreateBlurb, effectiveSettings.CreateBlurbSettings).WithGoogleRequestParam("parent", request => request.Parent);
+            _callCreateBlurb = clientHelper.BuildApiCall<CreateBlurbRequest, Blurb>("CreateBlurb", grpcClient.CreateBlurbAsync, grpcClient.CreateBlurb, effectiveSettings.CreateBlurbSettings).WithGoogleRequestParam("parent", request => request.Parent);
             Modify_ApiCall(ref _callCreateBlurb);
             Modify_CreateBlurbApiCall(ref _callCreateBlurb);
-            _callGetBlurb = clientHelper.BuildApiCall<GetBlurbRequest, Blurb>(grpcClient.GetBlurbAsync, grpcClient.GetBlurb, effectiveSettings.GetBlurbSettings).WithGoogleRequestParam("name", request => request.Name);
+            _callGetBlurb = clientHelper.BuildApiCall<GetBlurbRequest, Blurb>("GetBlurb", grpcClient.GetBlurbAsync, grpcClient.GetBlurb, effectiveSettings.GetBlurbSettings).WithGoogleRequestParam("name", request => request.Name);
             Modify_ApiCall(ref _callGetBlurb);
             Modify_GetBlurbApiCall(ref _callGetBlurb);
-            _callUpdateBlurb = clientHelper.BuildApiCall<UpdateBlurbRequest, Blurb>(grpcClient.UpdateBlurbAsync, grpcClient.UpdateBlurb, effectiveSettings.UpdateBlurbSettings).WithGoogleRequestParam("blurb.name", request => request.Blurb?.Name);
+            _callUpdateBlurb = clientHelper.BuildApiCall<UpdateBlurbRequest, Blurb>("UpdateBlurb", grpcClient.UpdateBlurbAsync, grpcClient.UpdateBlurb, effectiveSettings.UpdateBlurbSettings).WithGoogleRequestParam("blurb.name", request => request.Blurb?.Name);
             Modify_ApiCall(ref _callUpdateBlurb);
             Modify_UpdateBlurbApiCall(ref _callUpdateBlurb);
-            _callDeleteBlurb = clientHelper.BuildApiCall<DeleteBlurbRequest, wkt::Empty>(grpcClient.DeleteBlurbAsync, grpcClient.DeleteBlurb, effectiveSettings.DeleteBlurbSettings).WithGoogleRequestParam("name", request => request.Name);
+            _callDeleteBlurb = clientHelper.BuildApiCall<DeleteBlurbRequest, wkt::Empty>("DeleteBlurb", grpcClient.DeleteBlurbAsync, grpcClient.DeleteBlurb, effectiveSettings.DeleteBlurbSettings).WithGoogleRequestParam("name", request => request.Name);
             Modify_ApiCall(ref _callDeleteBlurb);
             Modify_DeleteBlurbApiCall(ref _callDeleteBlurb);
-            _callListBlurbs = clientHelper.BuildApiCall<ListBlurbsRequest, ListBlurbsResponse>(grpcClient.ListBlurbsAsync, grpcClient.ListBlurbs, effectiveSettings.ListBlurbsSettings).WithGoogleRequestParam("parent", request => request.Parent);
+            _callListBlurbs = clientHelper.BuildApiCall<ListBlurbsRequest, ListBlurbsResponse>("ListBlurbs", grpcClient.ListBlurbsAsync, grpcClient.ListBlurbs, effectiveSettings.ListBlurbsSettings).WithGoogleRequestParam("parent", request => request.Parent);
             Modify_ApiCall(ref _callListBlurbs);
             Modify_ListBlurbsApiCall(ref _callListBlurbs);
-            _callSearchBlurbs = clientHelper.BuildApiCall<SearchBlurbsRequest, lro::Operation>(grpcClient.SearchBlurbsAsync, grpcClient.SearchBlurbs, effectiveSettings.SearchBlurbsSettings).WithGoogleRequestParam("parent", request => request.Parent);
+            _callSearchBlurbs = clientHelper.BuildApiCall<SearchBlurbsRequest, lro::Operation>("SearchBlurbs", grpcClient.SearchBlurbsAsync, grpcClient.SearchBlurbs, effectiveSettings.SearchBlurbsSettings).WithGoogleRequestParam("parent", request => request.Parent);
             Modify_ApiCall(ref _callSearchBlurbs);
             Modify_SearchBlurbsApiCall(ref _callSearchBlurbs);
-            _callStreamBlurbs = clientHelper.BuildApiCall<StreamBlurbsRequest, StreamBlurbsResponse>(grpcClient.StreamBlurbs, effectiveSettings.StreamBlurbsSettings).WithGoogleRequestParam("name", request => request.Name);
+            _callStreamBlurbs = clientHelper.BuildApiCall<StreamBlurbsRequest, StreamBlurbsResponse>("StreamBlurbs", grpcClient.StreamBlurbs, effectiveSettings.StreamBlurbsSettings).WithGoogleRequestParam("name", request => request.Name);
             Modify_ApiCall(ref _callStreamBlurbs);
             Modify_StreamBlurbsApiCall(ref _callStreamBlurbs);
-            _callSendBlurbs = clientHelper.BuildApiCall<CreateBlurbRequest, SendBlurbsResponse>(grpcClient.SendBlurbs, effectiveSettings.SendBlurbsSettings, effectiveSettings.SendBlurbsStreamingSettings);
+            _callSendBlurbs = clientHelper.BuildApiCall<CreateBlurbRequest, SendBlurbsResponse>("SendBlurbs", grpcClient.SendBlurbs, effectiveSettings.SendBlurbsSettings, effectiveSettings.SendBlurbsStreamingSettings);
             Modify_ApiCall(ref _callSendBlurbs);
             Modify_SendBlurbsApiCall(ref _callSendBlurbs);
-            _callConnect = clientHelper.BuildApiCall<ConnectRequest, StreamBlurbsResponse>(grpcClient.Connect, effectiveSettings.ConnectSettings, effectiveSettings.ConnectStreamingSettings);
+            _callConnect = clientHelper.BuildApiCall<ConnectRequest, StreamBlurbsResponse>("Connect", grpcClient.Connect, effectiveSettings.ConnectSettings, effectiveSettings.ConnectStreamingSettings);
             Modify_ApiCall(ref _callConnect);
             Modify_ConnectApiCall(ref _callConnect);
             OnConstruction(grpcClient, effectiveSettings, clientHelper);

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/SequenceServiceClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/SequenceServiceClient.g.cs
@@ -20,6 +20,7 @@ using proto = Google.Protobuf;
 using wkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
+using mel = Microsoft.Extensions.Logging;
 using sys = System;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -130,14 +131,14 @@ namespace Google.Showcase.V1Beta1
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return SequenceServiceClient.Create(callInvoker, Settings);
+            return SequenceServiceClient.Create(callInvoker, Settings, Logger);
         }
 
         private async stt::Task<SequenceServiceClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return SequenceServiceClient.Create(callInvoker, Settings);
+            return SequenceServiceClient.Create(callInvoker, Settings, Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>
@@ -188,8 +189,9 @@ namespace Google.Showcase.V1Beta1
         /// The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.
         /// </param>
         /// <param name="settings">Optional <see cref="SequenceServiceSettings"/>.</param>
+        /// <param name="logger">Optional <see cref="mel::ILogger"/>.</param>
         /// <returns>The created <see cref="SequenceServiceClient"/>.</returns>
-        internal static SequenceServiceClient Create(grpccore::CallInvoker callInvoker, SequenceServiceSettings settings = null)
+        internal static SequenceServiceClient Create(grpccore::CallInvoker callInvoker, SequenceServiceSettings settings = null, mel::ILogger logger = null)
         {
             gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
             grpcinter::Interceptor interceptor = settings?.Interceptor;
@@ -198,7 +200,7 @@ namespace Google.Showcase.V1Beta1
                 callInvoker = grpcinter::CallInvokerExtensions.Intercept(callInvoker, interceptor);
             }
             SequenceService.SequenceServiceClient grpcClient = new SequenceService.SequenceServiceClient(callInvoker);
-            return new SequenceServiceClientImpl(grpcClient, settings);
+            return new SequenceServiceClientImpl(grpcClient, settings, logger);
         }
 
         /// <summary>
@@ -489,18 +491,19 @@ namespace Google.Showcase.V1Beta1
         /// </summary>
         /// <param name="grpcClient">The underlying gRPC client.</param>
         /// <param name="settings">The base <see cref="SequenceServiceSettings"/> used within this client.</param>
-        public SequenceServiceClientImpl(SequenceService.SequenceServiceClient grpcClient, SequenceServiceSettings settings)
+        /// <param name="logger">Optional <see cref="mel::ILogger"/> to use within this client.</param>
+        public SequenceServiceClientImpl(SequenceService.SequenceServiceClient grpcClient, SequenceServiceSettings settings, mel::ILogger logger)
         {
             GrpcClient = grpcClient;
             SequenceServiceSettings effectiveSettings = settings ?? SequenceServiceSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings);
-            _callCreateSequence = clientHelper.BuildApiCall<CreateSequenceRequest, Sequence>(grpcClient.CreateSequenceAsync, grpcClient.CreateSequence, effectiveSettings.CreateSequenceSettings);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            _callCreateSequence = clientHelper.BuildApiCall<CreateSequenceRequest, Sequence>("CreateSequence", grpcClient.CreateSequenceAsync, grpcClient.CreateSequence, effectiveSettings.CreateSequenceSettings);
             Modify_ApiCall(ref _callCreateSequence);
             Modify_CreateSequenceApiCall(ref _callCreateSequence);
-            _callGetSequenceReport = clientHelper.BuildApiCall<GetSequenceReportRequest, SequenceReport>(grpcClient.GetSequenceReportAsync, grpcClient.GetSequenceReport, effectiveSettings.GetSequenceReportSettings).WithGoogleRequestParam("name", request => request.Name);
+            _callGetSequenceReport = clientHelper.BuildApiCall<GetSequenceReportRequest, SequenceReport>("GetSequenceReport", grpcClient.GetSequenceReportAsync, grpcClient.GetSequenceReport, effectiveSettings.GetSequenceReportSettings).WithGoogleRequestParam("name", request => request.Name);
             Modify_ApiCall(ref _callGetSequenceReport);
             Modify_GetSequenceReportApiCall(ref _callGetSequenceReport);
-            _callAttemptSequence = clientHelper.BuildApiCall<AttemptSequenceRequest, wkt::Empty>(grpcClient.AttemptSequenceAsync, grpcClient.AttemptSequence, effectiveSettings.AttemptSequenceSettings).WithGoogleRequestParam("name", request => request.Name);
+            _callAttemptSequence = clientHelper.BuildApiCall<AttemptSequenceRequest, wkt::Empty>("AttemptSequence", grpcClient.AttemptSequenceAsync, grpcClient.AttemptSequence, effectiveSettings.AttemptSequenceSettings).WithGoogleRequestParam("name", request => request.Name);
             Modify_ApiCall(ref _callAttemptSequence);
             Modify_AttemptSequenceApiCall(ref _callAttemptSequence);
             OnConstruction(grpcClient, effectiveSettings, clientHelper);

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,0 +1,124 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+using gaxgrpc = Google.Api.Gax.Grpc;
+using gpr = Google.Protobuf.Reflection;
+using gsv = Google.Showcase.V1Beta1;
+using sys = System;
+using scg = System.Collections.Generic;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>Static class to provide extension methods to configure API clients.</summary>
+    public static partial class ServiceCollectionExtensions
+    {
+        /// <summary>Adds a singleton <see cref="gsv::ComplianceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddComplianceClient(this IServiceCollection services, sys::Action<gsv::ComplianceClientBuilder> action = null) =>
+            services.AddSingleton(provider =>
+            {
+                gsv::ComplianceClientBuilder builder = new gsv::ComplianceClientBuilder();
+                action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gsv::EchoClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddEchoClient(this IServiceCollection services, sys::Action<gsv::EchoClientBuilder> action = null) =>
+            services.AddSingleton(provider =>
+            {
+                gsv::EchoClientBuilder builder = new gsv::EchoClientBuilder();
+                action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gsv::IdentityClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddIdentityClient(this IServiceCollection services, sys::Action<gsv::IdentityClientBuilder> action = null) =>
+            services.AddSingleton(provider =>
+            {
+                gsv::IdentityClientBuilder builder = new gsv::IdentityClientBuilder();
+                action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gsv::MessagingClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddMessagingClient(this IServiceCollection services, sys::Action<gsv::MessagingClientBuilder> action = null) =>
+            services.AddSingleton(provider =>
+            {
+                gsv::MessagingClientBuilder builder = new gsv::MessagingClientBuilder();
+                action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gsv::SequenceServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSequenceServiceClient(this IServiceCollection services, sys::Action<gsv::SequenceServiceClientBuilder> action = null) =>
+            services.AddSingleton(provider =>
+            {
+                gsv::SequenceServiceClientBuilder builder = new gsv::SequenceServiceClientBuilder();
+                action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gsv::TestingClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTestingClient(this IServiceCollection services, sys::Action<gsv::TestingClientBuilder> action = null) =>
+            services.AddSingleton(provider =>
+            {
+                gsv::TestingClientBuilder builder = new gsv::TestingClientBuilder();
+                action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/TestingClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/TestingClient.g.cs
@@ -20,6 +20,7 @@ using proto = Google.Protobuf;
 using wkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
+using mel = Microsoft.Extensions.Logging;
 using sys = System;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
@@ -195,14 +196,14 @@ namespace Google.Showcase.V1Beta1
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return TestingClient.Create(callInvoker, Settings);
+            return TestingClient.Create(callInvoker, Settings, Logger);
         }
 
         private async stt::Task<TestingClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return TestingClient.Create(callInvoker, Settings);
+            return TestingClient.Create(callInvoker, Settings, Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>
@@ -255,8 +256,9 @@ namespace Google.Showcase.V1Beta1
         /// The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.
         /// </param>
         /// <param name="settings">Optional <see cref="TestingSettings"/>.</param>
+        /// <param name="logger">Optional <see cref="mel::ILogger"/>.</param>
         /// <returns>The created <see cref="TestingClient"/>.</returns>
-        internal static TestingClient Create(grpccore::CallInvoker callInvoker, TestingSettings settings = null)
+        internal static TestingClient Create(grpccore::CallInvoker callInvoker, TestingSettings settings = null, mel::ILogger logger = null)
         {
             gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
             grpcinter::Interceptor interceptor = settings?.Interceptor;
@@ -265,7 +267,7 @@ namespace Google.Showcase.V1Beta1
                 callInvoker = grpcinter::CallInvokerExtensions.Intercept(callInvoker, interceptor);
             }
             Testing.TestingClient grpcClient = new Testing.TestingClient(callInvoker);
-            return new TestingClientImpl(grpcClient, settings);
+            return new TestingClientImpl(grpcClient, settings, logger);
         }
 
         /// <summary>
@@ -541,33 +543,34 @@ namespace Google.Showcase.V1Beta1
         /// </summary>
         /// <param name="grpcClient">The underlying gRPC client.</param>
         /// <param name="settings">The base <see cref="TestingSettings"/> used within this client.</param>
-        public TestingClientImpl(Testing.TestingClient grpcClient, TestingSettings settings)
+        /// <param name="logger">Optional <see cref="mel::ILogger"/> to use within this client.</param>
+        public TestingClientImpl(Testing.TestingClient grpcClient, TestingSettings settings, mel::ILogger logger)
         {
             GrpcClient = grpcClient;
             TestingSettings effectiveSettings = settings ?? TestingSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings);
-            _callCreateSession = clientHelper.BuildApiCall<CreateSessionRequest, Session>(grpcClient.CreateSessionAsync, grpcClient.CreateSession, effectiveSettings.CreateSessionSettings);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            _callCreateSession = clientHelper.BuildApiCall<CreateSessionRequest, Session>("CreateSession", grpcClient.CreateSessionAsync, grpcClient.CreateSession, effectiveSettings.CreateSessionSettings);
             Modify_ApiCall(ref _callCreateSession);
             Modify_CreateSessionApiCall(ref _callCreateSession);
-            _callGetSession = clientHelper.BuildApiCall<GetSessionRequest, Session>(grpcClient.GetSessionAsync, grpcClient.GetSession, effectiveSettings.GetSessionSettings).WithGoogleRequestParam("name", request => request.Name);
+            _callGetSession = clientHelper.BuildApiCall<GetSessionRequest, Session>("GetSession", grpcClient.GetSessionAsync, grpcClient.GetSession, effectiveSettings.GetSessionSettings).WithGoogleRequestParam("name", request => request.Name);
             Modify_ApiCall(ref _callGetSession);
             Modify_GetSessionApiCall(ref _callGetSession);
-            _callListSessions = clientHelper.BuildApiCall<ListSessionsRequest, ListSessionsResponse>(grpcClient.ListSessionsAsync, grpcClient.ListSessions, effectiveSettings.ListSessionsSettings);
+            _callListSessions = clientHelper.BuildApiCall<ListSessionsRequest, ListSessionsResponse>("ListSessions", grpcClient.ListSessionsAsync, grpcClient.ListSessions, effectiveSettings.ListSessionsSettings);
             Modify_ApiCall(ref _callListSessions);
             Modify_ListSessionsApiCall(ref _callListSessions);
-            _callDeleteSession = clientHelper.BuildApiCall<DeleteSessionRequest, wkt::Empty>(grpcClient.DeleteSessionAsync, grpcClient.DeleteSession, effectiveSettings.DeleteSessionSettings).WithGoogleRequestParam("name", request => request.Name);
+            _callDeleteSession = clientHelper.BuildApiCall<DeleteSessionRequest, wkt::Empty>("DeleteSession", grpcClient.DeleteSessionAsync, grpcClient.DeleteSession, effectiveSettings.DeleteSessionSettings).WithGoogleRequestParam("name", request => request.Name);
             Modify_ApiCall(ref _callDeleteSession);
             Modify_DeleteSessionApiCall(ref _callDeleteSession);
-            _callReportSession = clientHelper.BuildApiCall<ReportSessionRequest, ReportSessionResponse>(grpcClient.ReportSessionAsync, grpcClient.ReportSession, effectiveSettings.ReportSessionSettings).WithGoogleRequestParam("name", request => request.Name);
+            _callReportSession = clientHelper.BuildApiCall<ReportSessionRequest, ReportSessionResponse>("ReportSession", grpcClient.ReportSessionAsync, grpcClient.ReportSession, effectiveSettings.ReportSessionSettings).WithGoogleRequestParam("name", request => request.Name);
             Modify_ApiCall(ref _callReportSession);
             Modify_ReportSessionApiCall(ref _callReportSession);
-            _callListTests = clientHelper.BuildApiCall<ListTestsRequest, ListTestsResponse>(grpcClient.ListTestsAsync, grpcClient.ListTests, effectiveSettings.ListTestsSettings).WithGoogleRequestParam("parent", request => request.Parent);
+            _callListTests = clientHelper.BuildApiCall<ListTestsRequest, ListTestsResponse>("ListTests", grpcClient.ListTestsAsync, grpcClient.ListTests, effectiveSettings.ListTestsSettings).WithGoogleRequestParam("parent", request => request.Parent);
             Modify_ApiCall(ref _callListTests);
             Modify_ListTestsApiCall(ref _callListTests);
-            _callDeleteTest = clientHelper.BuildApiCall<DeleteTestRequest, wkt::Empty>(grpcClient.DeleteTestAsync, grpcClient.DeleteTest, effectiveSettings.DeleteTestSettings).WithGoogleRequestParam("name", request => request.Name);
+            _callDeleteTest = clientHelper.BuildApiCall<DeleteTestRequest, wkt::Empty>("DeleteTest", grpcClient.DeleteTestAsync, grpcClient.DeleteTest, effectiveSettings.DeleteTestSettings).WithGoogleRequestParam("name", request => request.Name);
             Modify_ApiCall(ref _callDeleteTest);
             Modify_DeleteTestApiCall(ref _callDeleteTest);
-            _callVerifyTest = clientHelper.BuildApiCall<VerifyTestRequest, VerifyTestResponse>(grpcClient.VerifyTestAsync, grpcClient.VerifyTest, effectiveSettings.VerifyTestSettings).WithGoogleRequestParam("name", request => request.Name);
+            _callVerifyTest = clientHelper.BuildApiCall<VerifyTestRequest, VerifyTestResponse>("VerifyTest", grpcClient.VerifyTestAsync, grpcClient.VerifyTest, effectiveSettings.VerifyTestSettings).WithGoogleRequestParam("name", request => request.Name);
             Modify_ApiCall(ref _callVerifyTest);
             Modify_VerifyTestApiCall(ref _callVerifyTest);
             OnConstruction(grpcClient, effectiveSettings, clientHelper);

--- a/Google.Api.Generator.Tests/ProtoTests/UnitTests/Testing.UnitTests.Tests/UnitTestsClientTest.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/UnitTests/Testing.UnitTests.Tests/UnitTestsClientTest.g.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Google LLC
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -171,7 +171,7 @@ namespace Testing.UnitTests.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.MethodValues(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            UnitTestsClient client = new UnitTestsClientImpl(mockGrpcClient.Object, null);
+            UnitTestsClient client = new UnitTestsClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.MethodValues(request);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -318,7 +318,7 @@ namespace Testing.UnitTests.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.MethodValuesAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            UnitTestsClient client = new UnitTestsClientImpl(mockGrpcClient.Object, null);
+            UnitTestsClient client = new UnitTestsClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.MethodValuesAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.MethodValuesAsync(request, st::CancellationToken.None);
@@ -337,7 +337,7 @@ namespace Testing.UnitTests.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.MethodValues(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            UnitTestsClient client = new UnitTestsClientImpl(mockGrpcClient.Object, null);
+            UnitTestsClient client = new UnitTestsClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.MethodValues(request.SingleDouble);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -354,7 +354,7 @@ namespace Testing.UnitTests.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.MethodValuesAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            UnitTestsClient client = new UnitTestsClientImpl(mockGrpcClient.Object, null);
+            UnitTestsClient client = new UnitTestsClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.MethodValuesAsync(request.SingleDouble, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.MethodValuesAsync(request.SingleDouble, st::CancellationToken.None);
@@ -397,7 +397,7 @@ namespace Testing.UnitTests.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.MethodValues(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            UnitTestsClient client = new UnitTestsClientImpl(mockGrpcClient.Object, null);
+            UnitTestsClient client = new UnitTestsClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.MethodValues(request.SingleDouble, request.SingleFloat, request.SingleInt32, request.SingleInt64, request.RepeatedBool, request.RepeatedBytes, request.RepeatedResourceName, request.MapIntString, request.SingleWrappedString, request.RepeatedWrappedDouble);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -438,7 +438,7 @@ namespace Testing.UnitTests.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.MethodValuesAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            UnitTestsClient client = new UnitTestsClientImpl(mockGrpcClient.Object, null);
+            UnitTestsClient client = new UnitTestsClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.MethodValuesAsync(request.SingleDouble, request.SingleFloat, request.SingleInt32, request.SingleInt64, request.RepeatedBool, request.RepeatedBytes, request.RepeatedResourceName, request.MapIntString, request.SingleWrappedString, request.RepeatedWrappedDouble, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.MethodValuesAsync(request.SingleDouble, request.SingleFloat, request.SingleInt32, request.SingleInt64, request.RepeatedBool, request.RepeatedBytes, request.RepeatedResourceName, request.MapIntString, request.SingleWrappedString, request.RepeatedWrappedDouble, st::CancellationToken.None);
@@ -481,7 +481,7 @@ namespace Testing.UnitTests.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.MethodValues(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            UnitTestsClient client = new UnitTestsClientImpl(mockGrpcClient.Object, null);
+            UnitTestsClient client = new UnitTestsClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.MethodValues(request.SingleDouble, request.SingleFloat, request.SingleInt32, request.SingleInt64, request.RepeatedBool, request.RepeatedBytes, request.RepeatedResourceNameAsAResourceNames, request.MapIntString, request.SingleWrappedString, request.RepeatedWrappedDouble);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -522,7 +522,7 @@ namespace Testing.UnitTests.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.MethodValuesAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            UnitTestsClient client = new UnitTestsClientImpl(mockGrpcClient.Object, null);
+            UnitTestsClient client = new UnitTestsClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.MethodValuesAsync(request.SingleDouble, request.SingleFloat, request.SingleInt32, request.SingleInt64, request.RepeatedBool, request.RepeatedBytes, request.RepeatedResourceNameAsAResourceNames, request.MapIntString, request.SingleWrappedString, request.RepeatedWrappedDouble, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.MethodValuesAsync(request.SingleDouble, request.SingleFloat, request.SingleInt32, request.SingleInt64, request.RepeatedBool, request.RepeatedBytes, request.RepeatedResourceNameAsAResourceNames, request.MapIntString, request.SingleWrappedString, request.RepeatedWrappedDouble, st::CancellationToken.None);
@@ -555,7 +555,7 @@ namespace Testing.UnitTests.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.MethodValues(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            UnitTestsClient client = new UnitTestsClientImpl(mockGrpcClient.Object, null);
+            UnitTestsClient client = new UnitTestsClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.MethodValues(request.SingleResourceName, request.RepeatedResourceName, request.SingleWildcardResource, request.RepeatedWildcardResource, request.MultiPatternResourceName, request.RepeatedMultiPatternResourceName);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -586,7 +586,7 @@ namespace Testing.UnitTests.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.MethodValuesAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            UnitTestsClient client = new UnitTestsClientImpl(mockGrpcClient.Object, null);
+            UnitTestsClient client = new UnitTestsClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.MethodValuesAsync(request.SingleResourceName, request.RepeatedResourceName, request.SingleWildcardResource, request.RepeatedWildcardResource, request.MultiPatternResourceName, request.RepeatedMultiPatternResourceName, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.MethodValuesAsync(request.SingleResourceName, request.RepeatedResourceName, request.SingleWildcardResource, request.RepeatedWildcardResource, request.MultiPatternResourceName, request.RepeatedMultiPatternResourceName, st::CancellationToken.None);
@@ -619,7 +619,7 @@ namespace Testing.UnitTests.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.MethodValues(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            UnitTestsClient client = new UnitTestsClientImpl(mockGrpcClient.Object, null);
+            UnitTestsClient client = new UnitTestsClientImpl(mockGrpcClient.Object, null, null);
             Response response = client.MethodValues(request.SingleResourceNameAsAResourceName, request.RepeatedResourceNameAsAResourceNames, request.SingleWildcardResourceAsResourceName, request.RepeatedWildcardResourceAsResourceNames, request.MultiPatternResourceNameAsMultiPatternResourceName, request.RepeatedMultiPatternResourceNameAsMultiPatternResourceNames);
             xunit::Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
@@ -650,7 +650,7 @@ namespace Testing.UnitTests.Tests
             };
             Response expectedResponse = new Response { };
             mockGrpcClient.Setup(x => x.MethodValuesAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<Response>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            UnitTestsClient client = new UnitTestsClientImpl(mockGrpcClient.Object, null);
+            UnitTestsClient client = new UnitTestsClientImpl(mockGrpcClient.Object, null, null);
             Response responseCallSettings = await client.MethodValuesAsync(request.SingleResourceNameAsAResourceName, request.RepeatedResourceNameAsAResourceNames, request.SingleWildcardResourceAsResourceName, request.RepeatedWildcardResourceAsResourceNames, request.MultiPatternResourceNameAsMultiPatternResourceName, request.RepeatedMultiPatternResourceNameAsMultiPatternResourceNames, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             xunit::Assert.Same(expectedResponse, responseCallSettings);
             Response responseCancellationToken = await client.MethodValuesAsync(request.SingleResourceNameAsAResourceName, request.RepeatedResourceNameAsAResourceNames, request.SingleWildcardResourceAsResourceName, request.RepeatedWildcardResourceAsResourceNames, request.MultiPatternResourceNameAsMultiPatternResourceName, request.RepeatedMultiPatternResourceNameAsMultiPatternResourceNames, st::CancellationToken.None);

--- a/Google.Api.Generator.Tests/ProtoTests/UnitTests/Testing.UnitTests/UnitTestsClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/UnitTests/Testing.UnitTests/UnitTestsClient.g.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Google LLC
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ using lro = Google.LongRunning;
 using proto = Google.Protobuf;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
+using mel = Microsoft.Extensions.Logging;
 using sys = System;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
@@ -136,14 +137,14 @@ namespace Testing.UnitTests
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return UnitTestsClient.Create(callInvoker, Settings);
+            return UnitTestsClient.Create(callInvoker, Settings, Logger);
         }
 
         private async stt::Task<UnitTestsClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return UnitTestsClient.Create(callInvoker, Settings);
+            return UnitTestsClient.Create(callInvoker, Settings, Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>
@@ -195,8 +196,9 @@ namespace Testing.UnitTests
         /// The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.
         /// </param>
         /// <param name="settings">Optional <see cref="UnitTestsSettings"/>.</param>
+        /// <param name="logger">Optional <see cref="mel::ILogger"/>.</param>
         /// <returns>The created <see cref="UnitTestsClient"/>.</returns>
-        internal static UnitTestsClient Create(grpccore::CallInvoker callInvoker, UnitTestsSettings settings = null)
+        internal static UnitTestsClient Create(grpccore::CallInvoker callInvoker, UnitTestsSettings settings = null, mel::ILogger logger = null)
         {
             gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
             grpcinter::Interceptor interceptor = settings?.Interceptor;
@@ -205,7 +207,7 @@ namespace Testing.UnitTests
                 callInvoker = grpcinter::CallInvokerExtensions.Intercept(callInvoker, interceptor);
             }
             UnitTests.UnitTestsClient grpcClient = new UnitTests.UnitTestsClient(callInvoker);
-            return new UnitTestsClientImpl(grpcClient, settings);
+            return new UnitTestsClientImpl(grpcClient, settings, logger);
         }
 
         /// <summary>
@@ -801,16 +803,17 @@ namespace Testing.UnitTests
         /// </summary>
         /// <param name="grpcClient">The underlying gRPC client.</param>
         /// <param name="settings">The base <see cref="UnitTestsSettings"/> used within this client.</param>
-        public UnitTestsClientImpl(UnitTests.UnitTestsClient grpcClient, UnitTestsSettings settings)
+        /// <param name="logger">Optional <see cref="mel::ILogger"/> to use within this client.</param>
+        public UnitTestsClientImpl(UnitTests.UnitTestsClient grpcClient, UnitTestsSettings settings, mel::ILogger logger)
         {
             GrpcClient = grpcClient;
             UnitTestsSettings effectiveSettings = settings ?? UnitTestsSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings);
-            MethodLroOperationsClient = new lro::OperationsClientImpl(grpcClient.CreateOperationsClient(), effectiveSettings.MethodLroOperationsSettings);
-            _callMethodValues = clientHelper.BuildApiCall<ValuesRequest, Response>(grpcClient.MethodValuesAsync, grpcClient.MethodValues, effectiveSettings.MethodValuesSettings);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            MethodLroOperationsClient = new lro::OperationsClientImpl(grpcClient.CreateOperationsClient(), effectiveSettings.MethodLroOperationsSettings, logger);
+            _callMethodValues = clientHelper.BuildApiCall<ValuesRequest, Response>("MethodValues", grpcClient.MethodValuesAsync, grpcClient.MethodValues, effectiveSettings.MethodValuesSettings);
             Modify_ApiCall(ref _callMethodValues);
             Modify_MethodValuesApiCall(ref _callMethodValues);
-            _callMethodLro = clientHelper.BuildApiCall<LroRequest, lro::Operation>(grpcClient.MethodLroAsync, grpcClient.MethodLro, effectiveSettings.MethodLroSettings);
+            _callMethodLro = clientHelper.BuildApiCall<LroRequest, lro::Operation>("MethodLro", grpcClient.MethodLroAsync, grpcClient.MethodLro, effectiveSettings.MethodLroSettings);
             Modify_ApiCall(ref _callMethodLro);
             Modify_MethodLroApiCall(ref _callMethodLro);
             OnConstruction(grpcClient, effectiveSettings, clientHelper);

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.Tests/VoidReturnClientTest.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.Tests/VoidReturnClientTest.g.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Google LLC
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ namespace Testing.VoidReturn.Tests
             };
             wkt::Empty expectedResponse = new wkt::Empty { };
             mockGrpcClient.Setup(x => x.VoidMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            VoidReturnClient client = new VoidReturnClientImpl(mockGrpcClient.Object, null);
+            VoidReturnClient client = new VoidReturnClientImpl(mockGrpcClient.Object, null, null);
             client.VoidMethod(request);
             mockGrpcClient.VerifyAll();
         }
@@ -56,7 +56,7 @@ namespace Testing.VoidReturn.Tests
             };
             wkt::Empty expectedResponse = new wkt::Empty { };
             mockGrpcClient.Setup(x => x.VoidMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<wkt::Empty>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            VoidReturnClient client = new VoidReturnClientImpl(mockGrpcClient.Object, null);
+            VoidReturnClient client = new VoidReturnClientImpl(mockGrpcClient.Object, null, null);
             await client.VoidMethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             await client.VoidMethodAsync(request, st::CancellationToken.None);
             mockGrpcClient.VerifyAll();
@@ -73,7 +73,7 @@ namespace Testing.VoidReturn.Tests
             };
             wkt::Empty expectedResponse = new wkt::Empty { };
             mockGrpcClient.Setup(x => x.VoidMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            VoidReturnClient client = new VoidReturnClientImpl(mockGrpcClient.Object, null);
+            VoidReturnClient client = new VoidReturnClientImpl(mockGrpcClient.Object, null, null);
             client.VoidMethod(request.Name);
             mockGrpcClient.VerifyAll();
         }
@@ -89,7 +89,7 @@ namespace Testing.VoidReturn.Tests
             };
             wkt::Empty expectedResponse = new wkt::Empty { };
             mockGrpcClient.Setup(x => x.VoidMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<wkt::Empty>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            VoidReturnClient client = new VoidReturnClientImpl(mockGrpcClient.Object, null);
+            VoidReturnClient client = new VoidReturnClientImpl(mockGrpcClient.Object, null, null);
             await client.VoidMethodAsync(request.Name, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             await client.VoidMethodAsync(request.Name, st::CancellationToken.None);
             mockGrpcClient.VerifyAll();
@@ -106,7 +106,7 @@ namespace Testing.VoidReturn.Tests
             };
             wkt::Empty expectedResponse = new wkt::Empty { };
             mockGrpcClient.Setup(x => x.VoidMethod(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(expectedResponse);
-            VoidReturnClient client = new VoidReturnClientImpl(mockGrpcClient.Object, null);
+            VoidReturnClient client = new VoidReturnClientImpl(mockGrpcClient.Object, null, null);
             client.VoidMethod(request.ResourceName);
             mockGrpcClient.VerifyAll();
         }
@@ -122,7 +122,7 @@ namespace Testing.VoidReturn.Tests
             };
             wkt::Empty expectedResponse = new wkt::Empty { };
             mockGrpcClient.Setup(x => x.VoidMethodAsync(request, moq::It.IsAny<grpccore::CallOptions>())).Returns(new grpccore::AsyncUnaryCall<wkt::Empty>(stt::Task.FromResult(expectedResponse), null, null, null, null));
-            VoidReturnClient client = new VoidReturnClientImpl(mockGrpcClient.Object, null);
+            VoidReturnClient client = new VoidReturnClientImpl(mockGrpcClient.Object, null, null);
             await client.VoidMethodAsync(request.ResourceName, gaxgrpc::CallSettings.FromCancellationToken(st::CancellationToken.None));
             await client.VoidMethodAsync(request.ResourceName, st::CancellationToken.None);
             mockGrpcClient.VerifyAll();

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn/VoidReturnClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn/VoidReturnClient.g.cs
@@ -119,7 +119,8 @@ namespace Testing.VoidReturn
 
     public sealed partial class VoidReturnClientImpl : VoidReturnClient
     {
-        public VoidReturnClientImpl(VoidReturn.VoidReturnClient grpcClient, object callSettings) => throw new sys::NotImplementedException();
+        public VoidReturnClientImpl(VoidReturn.VoidReturnClient grpcClient, object callSettings, object logger) =>
+            throw new sys::NotImplementedException();
 
         private readonly gaxgrpc::ApiCall<Request, wkt::Empty> _callVoidMethod = null;
 

--- a/Google.Api.Generator.Utils/Google.Api.Generator.Utils.csproj
+++ b/Google.Api.Generator.Utils/Google.Api.Generator.Utils.csproj
@@ -6,6 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
-    <PackageReference Include="Google.Api.Gax" Version="4.0.0-alpha01" />
+    <PackageReference Include="Google.Api.Gax" Version="4.0.0-alpha02" />
   </ItemGroup>
 </Project>

--- a/Google.Api.Generator/CodeGenerator.cs
+++ b/Google.Api.Generator/CodeGenerator.cs
@@ -312,16 +312,24 @@ namespace Google.Api.Generator
                     var serviceSnippetsCsprojContent = CsProjGenerator.GenerateSnippets(ns);
                     var serviceSnippetsCsProjFilename = $"{serviceSnippetsPathPrefix}{ns}.Snippets.csproj";
                     yield return new ResultFile(serviceSnippetsCsProjFilename, serviceSnippetsCsprojContent);
+
+                    // Generate dependency injection extension methods
+                    var dependencyInjectionExtensionsContent = ServiceCollectionExtensionsGenerator.GenerateExtensions(ctx, packageServiceDetails);
+                    var dependencyInjectionExtensionsFilename = $"{clientPathPrefix}{ServiceCollectionExtensionsGenerator.FileName}";
+                    yield return new ResultFile(dependencyInjectionExtensionsFilename, dependencyInjectionExtensionsContent);
+
                     // Generate snippet metadata (only for snippet-per-file snippets).
                     // All services in this package have the same package information, namespace etc. so, we
                     // just pick the first one
                     var serviceDetails = packageServiceDetails.First();
                     var snippetIndexJsonContent = SnippetCodeGenerator.GenerateSnippetIndexJson(snippets, serviceDetails);
                     yield return new ResultFile($"{snippetsPathPrefix}snippet_metadata_{serviceDetails.ProtoPackage}.json", snippetIndexJsonContent);
+
                     // Generate snippet-per-file snippets csproj.
                     var snippetsCsprojContent = CsProjGenerator.GenerateSnippets(ns);
                     var snippetsCsProjFilename = $"{snippetsPathPrefix}{ns}.GeneratedSnippets.csproj";
                     yield return new ResultFile(snippetsCsProjFilename, snippetsCsprojContent);
+
                     // Generate unit-tests csproj.
                     var unitTestsCsprojContent = CsProjGenerator.GenerateUnitTests(ns);
                     var unitTestsCsprojFilename = $"{unitTestsPathPrefix}{ns}.Tests.csproj";

--- a/Google.Api.Generator/Generation/CsProjGenerator.cs
+++ b/Google.Api.Generator/Generation/CsProjGenerator.cs
@@ -22,11 +22,11 @@ namespace Google.Api.Generator.Generation
 {
     internal static class CsProjGenerator
     {
-        private const string GaxGrpcVersion = "[4.0.0-alpha01, 5.0.0)";
+        private const string GaxGrpcVersion = "[4.0.0-alpha02, 5.0.0)";
         private const string GrpcCoreVersion = "[2.41.0, 3.0.0)";
-        private const string LroVersion = "[3.0.0-alpha01, 4.0.0)";
-        private const string IamVersion = "[3.0.0-alpha01, 4.0.0)";
-        private const string LocationVersion = "[2.0.0-alpha01, 3.0.0)";
+        private const string LroVersion = "[3.0.0-alpha02, 4.0.0)";
+        private const string IamVersion = "[3.0.0-alpha02, 4.0.0)";
+        private const string LocationVersion = "[2.0.0-alpha02, 3.0.0)";
         private const string ReferenceAssembliesVersion = "1.0.2";
         private const string SystemLinqAsyncVersion = "5.1.0";
         private const string TestSdkVersion = "17.1.0";

--- a/Google.Api.Generator/Generation/ServiceAbstractClientClassCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceAbstractClientClassCodeGenerator.cs
@@ -19,6 +19,7 @@ using Google.Api.Generator.Utils.Roslyn;
 using Grpc.Core;
 using Grpc.Core.Interceptors;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -104,21 +105,23 @@ namespace Google.Api.Generator.Generation
         {
             var callInvoker = Parameter(_ctx.Type<CallInvoker>(), "callInvoker");
             var settings = Parameter(_ctx.Type(_svc.SettingsTyp), "settings", @default: Null);
+            var logger = Parameter(_ctx.Type<ILogger>(), "logger", @default: Null);
             var interceptor = Local(_ctx.Type<Interceptor>(), "interceptor");
             var grpcClient = Local(_ctx.Type(_svc.GrpcClientTyp), "grpcClient");
-            return Method(Internal | Static, _ctx.CurrentType, "Create")(callInvoker, settings)
+            return Method(Internal | Static, _ctx.CurrentType, "Create")(callInvoker, settings, logger)
                 .WithBody(
                     _ctx.Type(typeof(GaxPreconditions)).Call(nameof(GaxPreconditions.CheckNotNull))(callInvoker, Nameof(callInvoker)),
                     interceptor.WithInitializer(settings.Access("Interceptor", conditional: true)),
                     If(interceptor.NotEqualTo(Null)).Then(
                         callInvoker.Assign(_ctx.Type(typeof(CallInvokerExtensions)).Call(nameof(CallInvokerExtensions.Intercept))(callInvoker, interceptor))),
                     grpcClient.WithInitializer(New(_ctx.Type(_svc.GrpcClientTyp))(callInvoker)),
-                    Return(New(_ctx.Type(_svc.ClientImplTyp))(grpcClient, settings))
+                    Return(New(_ctx.Type(_svc.ClientImplTyp))(grpcClient, settings, logger))
                 )
                 .WithXmlDoc(
                     XmlDoc.Summary("Creates a ", _ctx.CurrentType, " which uses the specified call invoker for remote operations."),
                     XmlDoc.Param(callInvoker, "The ", callInvoker.Type, " for remote operations. Must not be null."),
                     XmlDoc.Param(settings, "Optional ", settings.Type, "."),
+                    XmlDoc.Param(logger, "Optional ", logger.Type, "."),
                     XmlDoc.Returns("The created ", _ctx.CurrentType, "."));
         }
 

--- a/Google.Api.Generator/Generation/ServiceBuilderCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceBuilderCodeGenerator.cs
@@ -17,6 +17,7 @@ using Google.Api.Generator.Utils;
 using Google.Api.Generator.Utils.Roslyn;
 using Grpc.Core;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -101,22 +102,24 @@ namespace Google.Api.Generator.Generation
         private MethodDeclarationSyntax BuildImpl()
         {
             var callInvoker = Local(_ctx.Type<CallInvoker>(), "callInvoker");
+            var logger = Property(Public, _ctx.Type<ILogger>(), nameof(ClientBuilderBase<string>.Logger));
             return Method(Private, _ctx.Type(_svc.ClientAbstractTyp), "BuildImpl")()
                 .WithBody(
                     This.Call("Validate")(),
                     callInvoker.WithInitializer(This.Call("CreateCallInvoker")()),
-                    Return(_ctx.Type(_svc.ClientAbstractTyp).Call("Create")(callInvoker, Settings())));
+                    Return(_ctx.Type(_svc.ClientAbstractTyp).Call("Create")(callInvoker, Settings(), logger)));
         }
 
         private MethodDeclarationSyntax BuildAsyncImpl()
         {
             var cancellationToken = Parameter(_ctx.Type<CancellationToken>(), "cancellationToken");
             var callInvoker = Local(_ctx.Type<CallInvoker>(), "callInvoker");
+            var logger = Property(Public, _ctx.Type<ILogger>(), nameof(ClientBuilderBase<string>.Logger));
             return Method(Private | Async, _ctx.Type(Typ.Generic(typeof(Task<>), _svc.ClientAbstractTyp)), "BuildAsyncImpl")(cancellationToken)
                 .WithBody(
                     This.Call("Validate")(),
                     callInvoker.WithInitializer(Await(This.Call("CreateCallInvokerAsync")(cancellationToken).ConfigureAwait())),
-                    Return(_ctx.Type(_svc.ClientAbstractTyp).Call("Create")(callInvoker, Settings())));
+                    Return(_ctx.Type(_svc.ClientAbstractTyp).Call("Create")(callInvoker, Settings(), logger)));
         }
 
         private MethodDeclarationSyntax GetChannelPool() =>

--- a/Google.Api.Generator/Generation/ServiceCollectionExtensionsGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceCollectionExtensionsGenerator.cs
@@ -1,0 +1,78 @@
+﻿// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Generator.Utils;
+using Google.Api.Generator.Utils.Roslyn;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using static Google.Api.Generator.Utils.Roslyn.Modifier;
+using static Google.Api.Generator.Utils.Roslyn.RoslynBuilder;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Google.Api.Generator.Generation
+{
+    internal class ServiceCollectionExtensionsGenerator
+    {
+        internal const string ClassName = "ServiceCollectionExtensions";
+        internal const string FileName = ClassName + ".g.cs";
+
+        public static CompilationUnitSyntax GenerateExtensions(SourceFileContext ctx, List<ServiceDetails> packageServiceDetails)
+        {
+            var ns = typeof(IServiceCollection).Namespace;
+            var namespaceDeclaration = Namespace(ns);
+            using (ctx.InNamespace(namespaceDeclaration))
+            {
+                var cls = Class(Public | Static | Partial, Typ.Manual(ns, ClassName))
+                    .WithXmlDoc(XmlDoc.Summary("Static class to provide extension methods to configure API clients."));
+
+                cls = cls.AddMembers(packageServiceDetails.Select(m => GenerateMethod(ctx, m)).ToArray());
+                namespaceDeclaration = namespaceDeclaration.AddMembers(cls);
+            }
+            return ctx.CreateCompilationUnit(namespaceDeclaration);
+        }
+
+        private static MethodDeclarationSyntax GenerateMethod(SourceFileContext ctx, ServiceDetails service)
+        {
+            var name = $"Add{service.ClientAbstractTyp.Name}";
+            var serviceCollection = ctx.Type<IServiceCollection>();
+            var services = Parameter(serviceCollection, "services")
+                .WithModifiers(SyntaxTokenList.Create(Token(SyntaxKind.ThisKeyword).WithTrailingSpace()));
+            var actionType = ctx.Type(Typ.Generic(typeof(Action<>), service.BuilderTyp));
+            var action = Parameter(actionType, "action", @default: Null);
+
+            var builderType = ctx.Type(service.BuilderTyp);
+            var builder = Local(builderType, "builder");
+
+            var provider = Parameter(ctx.Type<IServiceProvider>(), "provider");
+            var lambda = Lambda(provider)(
+                    builder.WithInitializer(New(builderType)()),
+                    action.Call("Invoke", true)(builder),
+                    Return(builder.Call("Build")(provider))
+                );
+
+            return Method(Public | Static, serviceCollection, name)(services, action)
+                .WithBody(services.Call("AddSingleton")(lambda))
+                .WithXmlDoc(
+                    XmlDoc.Summary("Adds a singleton ", ctx.Type(service.ClientAbstractTyp), " to ", services, "."),
+                    XmlDoc.Param(services, "The service collection to add the client to. The services are used to configure the client when requested."),
+                    XmlDoc.Param(action, "An optional action to invoke on the client builder. This is invoked before services from ", services, " are used.")
+                );
+        }
+    }
+}

--- a/Google.Api.Generator/Generation/UnitTestCodeGeneration.cs
+++ b/Google.Api.Generator/Generation/UnitTestCodeGeneration.cs
@@ -286,7 +286,7 @@ namespace Google.Api.Generator.Generation
                         MockGrpcClient.Call(nameof(Mock<string>.Setup))(
                             Lambda(X)(X.Call(Method.SyncMethodName)(Request, Ctx.Type(typeof(It)).Call(nameof(It.IsAny), Ctx.Type<CallOptions>())())))
                             .Call(nameof(IReturns<string, int>.Returns))(ExpectedResponse),
-                        Client.WithInitializer(New(Ctx.Type(Svc.ClientImplTyp))(MockGrpcClient.Access(nameof(Mock.Object)), Null)),
+                        Client.WithInitializer(New(Ctx.Type(Svc.ClientImplTyp))(MockGrpcClient.Access(nameof(Mock.Object)), Null, Null)),
                         callAndVerify,
                         MockGrpcClient.Call(nameof(Mock.VerifyAll))()
                     );
@@ -324,7 +324,7 @@ namespace Google.Api.Generator.Generation
                             Lambda(X)(X.Call(Method.AsyncMethodName)(Request, Ctx.Type(typeof(It)).Call(nameof(It.IsAny), Ctx.Type<CallOptions>())())))
                             .Call(nameof(IReturns<string, int>.Returns))(New(Ctx.Type(Typ.Generic(typeof(AsyncUnaryCall<>), Method.ResponseTyp)))(
                                 Ctx.Type<Task>().Call(nameof(Task.FromResult))(ExpectedResponse), Null, Null, Null, Null)),
-                        Client.WithInitializer(New(Ctx.Type(Svc.ClientImplTyp))(MockGrpcClient.Access(nameof(Mock.Object)), Null)),
+                        Client.WithInitializer(New(Ctx.Type(Svc.ClientImplTyp))(MockGrpcClient.Access(nameof(Mock.Object)), Null, Null)),
                         callAndVerify,
                         MockGrpcClient.Call(nameof(Mock.VerifyAll))()
                     );

--- a/Google.Api.Generator/Google.Api.Generator.csproj
+++ b/Google.Api.Generator/Google.Api.Generator.csproj
@@ -9,10 +9,10 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Google.Api.CommonProtos" Version="2.5.0" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="4.0.0-alpha01" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="3.0.0-alpha01" />
-    <PackageReference Include="Google.Cloud.Location" Version="2.0.0-alpha01" />
-    <PackageReference Include="Google.LongRunning" Version="3.0.0-alpha01" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="4.0.0-alpha02" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="3.0.0-alpha02" />
+    <PackageReference Include="Google.Cloud.Location" Version="2.0.0-alpha02" />
+    <PackageReference Include="Google.LongRunning" Version="3.0.0-alpha02" />
     <PackageReference Include="Google.Protobuf" Version="3.20.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
     <PackageReference Include="Moq" Version="4.17.2" />


### PR DESCRIPTION
There are two change commits and two test commits. The first change is required in order to get everything compiling now that loggers have been introduced; the second adds extension methods for dependency injection.