### PR TITLE
feat: Support a "transport" option for generation

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/ComplianceClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/ComplianceClient.g.cs
@@ -226,7 +226,7 @@ namespace Google.Showcase.V1Beta1
         public static scg::IReadOnlyList<string> DefaultScopes { get; } = new sco::ReadOnlyCollection<string>(new string[] { });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Compliance.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Compliance.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc | gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/EchoClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/EchoClient.g.cs
@@ -280,7 +280,7 @@ namespace Google.Showcase.V1Beta1
         public static scg::IReadOnlyList<string> DefaultScopes { get; } = new sco::ReadOnlyCollection<string>(new string[] { });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Echo.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Echo.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc | gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/IdentityClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/IdentityClient.g.cs
@@ -187,7 +187,7 @@ namespace Google.Showcase.V1Beta1
         public static scg::IReadOnlyList<string> DefaultScopes { get; } = new sco::ReadOnlyCollection<string>(new string[] { });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Identity.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Identity.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc | gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/MessagingClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/MessagingClient.g.cs
@@ -343,7 +343,7 @@ namespace Google.Showcase.V1Beta1
         public static scg::IReadOnlyList<string> DefaultScopes { get; } = new sco::ReadOnlyCollection<string>(new string[] { });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Messaging.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Messaging.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc | gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/SequenceServiceClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/SequenceServiceClient.g.cs
@@ -160,7 +160,7 @@ namespace Google.Showcase.V1Beta1
         public static scg::IReadOnlyList<string> DefaultScopes { get; } = new sco::ReadOnlyCollection<string>(new string[] { });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(SequenceService.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(SequenceService.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc | gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/TestingClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/TestingClient.g.cs
@@ -227,7 +227,7 @@ namespace Google.Showcase.V1Beta1
         public static scg::IReadOnlyList<string> DefaultScopes { get; } = new sco::ReadOnlyCollection<string>(new string[] { });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Testing.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Testing.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc | gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/Google.Api.Generator/Generation/LroAdaptationGenerator.cs
+++ b/Google.Api.Generator/Generation/LroAdaptationGenerator.cs
@@ -75,7 +75,7 @@ namespace Google.Api.Generator.Generation
         {
             foreach (var service in _fileDesc.Services)
             {
-                var serviceDetails = new ServiceDetails(_catalog, _ctx.Namespace, service, grpcServiceConfig: null, serviceConfig: null);
+                var serviceDetails = new ServiceDetails(_catalog, _ctx.Namespace, service, grpcServiceConfig: null, serviceConfig: null, transports: ApiTransports.None);
                 // Assumption: each method has its own request type.
                 foreach (var method in serviceDetails.Methods.OfType<MethodDetails.NonStandardLro>())
                 {
@@ -119,7 +119,7 @@ namespace Google.Api.Generator.Generation
         {
             foreach (var service in _fileDesc.Services)
             {
-                var serviceDetails = new ServiceDetails(_catalog, _ctx.Namespace, service, grpcServiceConfig: null, serviceConfig: null);
+                var serviceDetails = new ServiceDetails(_catalog, _ctx.Namespace, service, grpcServiceConfig: null, serviceConfig: null, transports: ApiTransports.None);
                 // TODO: Use "is not" and continue when we can guarantee a recent enough version of C#.
                 if (serviceDetails.NonStandardLro is ServiceDetails.NonStandardLroDetails lroDetails)
                 {

--- a/Google.Api.Generator/Generation/ServiceDetails.cs
+++ b/Google.Api.Generator/Generation/ServiceDetails.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Google.Api.Gax;
 
 namespace Google.Api.Generator.Generation
 {
@@ -40,7 +41,7 @@ namespace Google.Api.Generator.Generation
             new MixinDetails(Locations.Descriptor.FullName, typeof(LocationsClient), typeof(LocationsClientImpl), typeof(Locations.LocationsClient), typeof(LocationsSettings)),
         }.ToDictionary(details => details.GrpcServiceName);
 
-        public ServiceDetails(ProtoCatalog catalog, string ns, ServiceDescriptor desc, ServiceConfig grpcServiceConfig, Service serviceConfig)
+        public ServiceDetails(ProtoCatalog catalog, string ns, ServiceDescriptor desc, ServiceConfig grpcServiceConfig, Service serviceConfig, ApiTransports transports)
         {
             Catalog = catalog;
             Namespace = ns;
@@ -84,6 +85,7 @@ namespace Google.Api.Generator.Generation
                 // Don't use mixins within the package that contains that mixin.
                 .Where(mixin => mixin.GapicClientType.Namespace != ns)
                 .ToList() ?? Enumerable.Empty<MixinDetails>();
+            Transports = transports;
         }
 
         /// <summary>The lines of service documentation from the proto.</summary>
@@ -177,6 +179,11 @@ namespace Google.Api.Generator.Generation
         /// The services to be mixed in via additional client properties.
         /// </summary>
         public IEnumerable<MixinDetails> Mixins { get; }
+
+        /// <summary>
+        /// The transports that can be used with this service.
+        /// </summary>
+        public ApiTransports Transports { get; }
 
         /// <summary>
         /// The details of a service responsible for LRO polling for a non-standard LRO implementation.


### PR DESCRIPTION
This will allow generation to specify when we should allow gRPC/REST/both transports

Note that this is "transport" for consistency with other languages, despite effectively being plural.