### PR TITLE
feat: Generator support for REST numeric enums

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTest.cs
+++ b/Google.Api.Generator.Tests/ProtoTest.cs
@@ -29,7 +29,7 @@ namespace Google.Api.Generator.Tests
     public class ProtoTest
     {
         private IEnumerable<ResultFile> Run(IEnumerable<string> protoFilenames, string package,
-            string grpcServiceConfigPath, string serviceConfigPath, IEnumerable<string> commonResourcesConfigPaths, ApiTransports transports)
+            string grpcServiceConfigPath, string serviceConfigPath, IEnumerable<string> commonResourcesConfigPaths, ApiTransports transports, bool requestNumericEnumJsonEncoding)
         {
             var clock = new FakeClock(new DateTime(2019, 1, 1));
             var protoPaths = protoFilenames.Select(x => Path.Combine(Invoker.GeneratorTestsDir, x));
@@ -48,7 +48,7 @@ namespace Google.Api.Generator.Tests
 
                 var descriptorBytes = File.ReadAllBytes(desc.Path);
                 FileDescriptorSet descriptorSet = FileDescriptorSet.Parser.ParseFrom(descriptorBytes);
-                return CodeGenerator.Generate(descriptorSet, package, clock, grpcServiceConfigPath, serviceConfigPath, commonResourcesConfigPaths, transports);
+                return CodeGenerator.Generate(descriptorSet, package, clock, grpcServiceConfigPath, serviceConfigPath, commonResourcesConfigPaths, transports, requestNumericEnumJsonEncoding);
             }
         }
 
@@ -57,12 +57,13 @@ namespace Google.Api.Generator.Tests
         {
             // Test that protoc executes successfully,
             // and the generator processes the descriptors without crashing!
-            Run(new[] { "ProtoTest.proto" }, "testing", null, null, null, ApiTransports.Grpc);
+            Run(new[] { "ProtoTest.proto" }, "testing", null, null, null, ApiTransports.Grpc, requestNumericEnumJsonEncoding: false);
         }
 
         private void ProtoTestSingle(string testProtoName,
             bool ignoreCsProj = false, bool ignoreSnippets = false, bool ignoreUnitTests = false,
-            string grpcServiceConfigPath = null, string serviceConfigPath = null, IEnumerable<string> commonResourcesConfigPaths = null, ApiTransports transports = ApiTransports.Grpc,
+            string grpcServiceConfigPath = null, string serviceConfigPath = null, IEnumerable<string> commonResourcesConfigPaths = null,
+            ApiTransports transports = ApiTransports.Grpc, bool requestNumericEnumJsonEncoding = false,
             bool ignoreGapicMetadataFile = true, bool ignoreApiMetadataFile = true, bool ignoreServiceExtensionsFile = true) =>
             ProtoTestSingle(
                 new[] { testProtoName },
@@ -77,6 +78,7 @@ namespace Google.Api.Generator.Tests
                 serviceConfigPath,
                 commonResourcesConfigPaths,
                 transports,
+                requestNumericEnumJsonEncoding,
                 ignoreGapicMetadataFile,
                 ignoreApiMetadataFile,
                 ignoreServiceExtensionsFile
@@ -84,7 +86,8 @@ namespace Google.Api.Generator.Tests
 
         private void ProtoTestSingle(IEnumerable<string> testProtoNames, string sourceDir = null, string outputDir = null, string package = null,
             bool ignoreCsProj = false, bool ignoreSnippets = false, bool ignoreUnitTests = false,
-            string grpcServiceConfigPath = null, string serviceConfigPath = null, IEnumerable<string> commonResourcesConfigPaths = null, ApiTransports transports = ApiTransports.Grpc,
+            string grpcServiceConfigPath = null, string serviceConfigPath = null, IEnumerable<string> commonResourcesConfigPaths = null,
+            ApiTransports transports = ApiTransports.Grpc, bool requestNumericEnumJsonEncoding = false,
             bool ignoreGapicMetadataFile = true, bool ignoreApiMetadataFile = true, bool ignoreServiceExtensionsFile = true)
         {
             // Confirm each generated file is identical to the expected output.
@@ -96,7 +99,7 @@ namespace Google.Api.Generator.Tests
             package = package ?? $"testing.{sourceDir.ToLowerInvariant()}";
 
             var files = Run(protoPaths, package,
-                grpcServiceConfigPath, serviceConfigPath, commonResourcesConfigPaths, transports);
+                grpcServiceConfigPath, serviceConfigPath, commonResourcesConfigPaths, transports, requestNumericEnumJsonEncoding);
             // Check output is present.
             Assert.NotEmpty(files);
 
@@ -267,6 +270,7 @@ namespace Google.Api.Generator.Tests
             outputDir: "Showcase",
             package: "google.showcase.v1beta1",
             transports: ApiTransports.Grpc | ApiTransports.Rest,
+            requestNumericEnumJsonEncoding: true,
             ignoreUnitTests: true,
             ignoreSnippets: true,
             ignoreApiMetadataFile: false);

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/PackageApiMetadata.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/PackageApiMetadata.g.cs
@@ -25,7 +25,7 @@ namespace Google.Showcase.V1Beta1
     internal static class PackageApiMetadata
     {
         /// <summary>The <see cref="gaxgrpc::ApiMetadata"/> for services in this package.</summary>
-        internal static gaxgrpc::ApiMetadata ApiMetadata { get; } = new gaxgrpc::ApiMetadata("Google.Showcase.V1Beta1", GetFileDescriptors);
+        internal static gaxgrpc::ApiMetadata ApiMetadata { get; } = new gaxgrpc::ApiMetadata("Google.Showcase.V1Beta1", GetFileDescriptors).WithRequestNumericEnumJsonEncoding(true);
 
         private static scg::IEnumerable<gpr::FileDescriptor> GetFileDescriptors()
         {

--- a/Google.Api.Generator/CodeGenerator.cs
+++ b/Google.Api.Generator/CodeGenerator.cs
@@ -94,15 +94,15 @@ namespace Google.Api.Generator
         };
 
         public static IEnumerable<ResultFile> Generate(FileDescriptorSet descriptorSet, string package, IClock clock,
-            string grpcServiceConfigPath, string serviceConfigPath, IEnumerable<string> commonResourcesConfigPaths, ApiTransports transports)
+            string grpcServiceConfigPath, string serviceConfigPath, IEnumerable<string> commonResourcesConfigPaths, ApiTransports transports, bool requestNumericEnumJsonEncoding)
         {
             var descriptors = descriptorSet.File;
             var filesToGenerate = descriptors.Where(x => x.Package == package).Select(x => x.Name).ToList();
-            return Generate(descriptors, filesToGenerate, clock, grpcServiceConfigPath, serviceConfigPath, commonResourcesConfigPaths, transports);
+            return Generate(descriptors, filesToGenerate, clock, grpcServiceConfigPath, serviceConfigPath, commonResourcesConfigPaths, transports, requestNumericEnumJsonEncoding);
         }
 
         public static IEnumerable<ResultFile> Generate(IReadOnlyList<FileDescriptorProto> descriptorProtos, IEnumerable<string> filesToGenerate, IClock clock,
-            string grpcServiceConfigPath, string serviceConfigPath, IEnumerable<string> commonResourcesConfigPaths, ApiTransports transports)
+            string grpcServiceConfigPath, string serviceConfigPath, IEnumerable<string> commonResourcesConfigPaths, ApiTransports transports, bool requestNumericEnumJsonEncoding)
         {
             var descriptors = FileDescriptor.BuildFromByteStrings(descriptorProtos.Select(proto => proto.ToByteString()), s_registry);
             // Load side-loaded configurations; both optional.
@@ -131,7 +131,10 @@ namespace Google.Api.Generator
                         $"Found namespaces '{string.Join(", ", namespaces)}' in package '{singlePackageFileDescs.Key}'.");
                 }
                 var catalog = new ProtoCatalog(singlePackageFileDescs.Key, descriptors, singlePackageFileDescs, commonResourcesConfigs);
-                foreach (var resultFile in GeneratePackage(namespaces[0], singlePackageFileDescs, catalog, clock, grpcServiceConfig, serviceConfig, allServiceDetails, transports))
+                foreach (var resultFile in GeneratePackage(
+                    namespaces[0], singlePackageFileDescs, catalog, clock,
+                    grpcServiceConfig, serviceConfig, allServiceDetails,
+                    transports, requestNumericEnumJsonEncoding))
                 {
                     yield return resultFile;
                 }
@@ -185,7 +188,8 @@ namespace Google.Api.Generator
 
         private static IEnumerable<ResultFile> GeneratePackage(string ns,
             IEnumerable<FileDescriptor> packageFileDescriptors, ProtoCatalog catalog, IClock clock,
-            ServiceConfig grpcServiceConfig, Service serviceConfig, List<ServiceDetails> allServiceDetails, ApiTransports transports)
+            ServiceConfig grpcServiceConfig, Service serviceConfig, List<ServiceDetails> allServiceDetails,
+            ApiTransports transports, bool requestNumericEnumJsonEncoding)
         {
             var clientPathPrefix = $"{ns}{Path.DirectorySeparatorChar}";
             var serviceSnippetsPathPrefix = $"{ns}.Snippets{Path.DirectorySeparatorChar}";
@@ -304,7 +308,7 @@ namespace Google.Api.Generator
 
                     // Generate the package-wide API metadata
                     var ctx = SourceFileContext.CreateFullyAliased(clock, s_wellknownNamespaceAliases);
-                    var packageApiMetadataContent = PackageApiMetadataGenerator.GeneratePackageApiMetadata(ns, ctx, packageFileDescriptors);
+                    var packageApiMetadataContent = PackageApiMetadataGenerator.GeneratePackageApiMetadata(ns, ctx, packageFileDescriptors, requestNumericEnumJsonEncoding);
                     var packageApiMetadataFilename = $"{clientPathPrefix}{PackageApiMetadataGenerator.FileName}";
                     yield return new ResultFile(packageApiMetadataFilename, packageApiMetadataContent);
 

--- a/Google.Api.Generator/Google.Api.Generator.csproj
+++ b/Google.Api.Generator/Google.Api.Generator.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Google.Api.CommonProtos" Version="2.6.0" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="4.0.0" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="4.1.0-alpha01" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="3.0.0" />
     <PackageReference Include="Google.Cloud.Location" Version="2.0.0" />
     <PackageReference Include="Google.LongRunning" Version="3.0.0" />

--- a/Google.Api.Generator/Program.cs
+++ b/Google.Api.Generator/Program.cs
@@ -33,6 +33,7 @@ namespace Google.Api.Generator
         private const string nameServiceConfigYaml = "service-config";
         private const string nameCommonResourcesConfig = "common-resources-config";
         private const string nameTransport = "transport";
+        private const string nameRequestNumericEnumJsonEncoding = "rest-numeric-enums";
 
         private static IImmutableSet<string> s_validParameters = ImmutableHashSet.Create(
             nameGrpcServiceConfig,
@@ -62,6 +63,9 @@ namespace Google.Api.Generator
 
             [Option(nameTransport, Required = false, HelpText = "Plus-separated list of transports to generate for the main API.")]
             public string Transport { get; private set; }
+
+            [Option(nameRequestNumericEnumJsonEncoding, Required = false, HelpText = "Whether to add an alt query parameter to request numeric enums for REST requests")]
+            public bool RequestNumericEnumJsonEncoding { get; private set; }
 
             [Usage]
             public static IEnumerable<Example> Examples => new[]
@@ -180,9 +184,10 @@ namespace Google.Api.Generator
                 var serviceConfigPath = extraParams.GetValueOrDefault(nameServiceConfigYaml)?.SingleOrDefault();
                 var commonResourcesConfigPaths = extraParams.GetValueOrDefault(nameCommonResourcesConfig);
                 var transports = ParseTransports(extraParams.GetValueOrDefault(nameTransport)?.SingleOrDefault());
+                var requestNumericEnumJsonEncoding = extraParams.GetValueOrDefault(nameRequestNumericEnumJsonEncoding)?.SingleOrDefault() == "true";
 
                 var results = CodeGenerator.Generate(codeGenRequest.ProtoFile, codeGenRequest.FileToGenerate,
-                    SystemClock.Instance, grpcServiceConfigPath, serviceConfigPath, commonResourcesConfigPaths, transports);
+                    SystemClock.Instance, grpcServiceConfigPath, serviceConfigPath, commonResourcesConfigPaths, transports, requestNumericEnumJsonEncoding);
 
                 codeGenResponse = new CodeGeneratorResponse
                 {
@@ -242,7 +247,8 @@ namespace Google.Api.Generator
             var fileDescriptorSet = FileDescriptorSet.Parser.ParseFrom(descriptorBytes);
             var transports = ParseTransports(options.Transport);
             var files = CodeGenerator.Generate(fileDescriptorSet, options.Package, SystemClock.Instance,
-                options.GrpcServiceConfig, options.ServiceConfigYaml, options.CommonResourcesConfigs, transports);
+                options.GrpcServiceConfig, options.ServiceConfigYaml, options.CommonResourcesConfigs,
+                transports, options.RequestNumericEnumJsonEncoding);
             foreach (var file in files)
             {
                 var path = Path.Combine(options.Output, file.RelativePath);

--- a/rules_csharp_gapic/csharp_gapic.bzl
+++ b/rules_csharp_gapic/csharp_gapic.bzl
@@ -41,6 +41,7 @@ def csharp_gapic_library(
         grpc_service_config = None,
         common_resources_config = None,
         service_yaml = None,
+        rest_numeric_enums = False,
         generator_binary = "//rules_csharp_gapic:csharp_gapic_generator_binary",
         **kwargs):
     # Build zip file of gapic-generator output
@@ -52,6 +53,8 @@ def csharp_gapic_library(
         plugin_file_args[common_resources_config] = "common-resources-config"
     if service_yaml:
         plugin_file_args[service_yaml] = "service-config"
+    if rest_numeric_enums:
+        plugin_args.append("rest-numeric-enums")
     proto_custom_library(
         name = name_srcjar,
         deps = srcs,


### PR DESCRIPTION
Note that this should not be *used* until GAX 4.1.0 is released.
(But it would be fine to be present and unused.)