### PR TITLE
feat: Sort metadata file descriptors and extension methods

### DIFF
--- a/Google.Api.Generator/Generation/PackageApiMetadataGenerator.cs
+++ b/Google.Api.Generator/Generation/PackageApiMetadataGenerator.cs
@@ -20,6 +20,7 @@ using Google.Api.Generator.Utils.Roslyn;
 using Google.Protobuf.Reflection;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using static Google.Api.Generator.Utils.Roslyn.Modifier;
@@ -51,7 +52,11 @@ namespace Google.Api.Generator.Generation
             var cls = Class(Internal | Static, typ)
                 .WithXmlDoc(XmlDoc.Summary("Static class to provide common access to package-wide API metadata."));
 
-            var yieldStatements = packageFileDescriptors.Select(GenerateYieldStatement).ToArray();
+            var yieldStatements = packageFileDescriptors
+                .OrderBy(p => p.CSharpNamespace(), StringComparer.Ordinal)
+                .ThenBy(p => p.Name, StringComparer.Ordinal)
+                .Select(GenerateYieldStatement)
+                .ToArray();
             var fileDescriptorMethod = Method(Private | Static, ctx.Type(Typ.Of<IEnumerable<FileDescriptor>>()), "GetFileDescriptors")()
                 .WithBlockBody(yieldStatements);
 

--- a/Google.Api.Generator/Generation/ServiceCollectionExtensionsGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceCollectionExtensionsGenerator.cs
@@ -41,7 +41,11 @@ namespace Google.Api.Generator.Generation
                 var cls = Class(Public | Static | Partial, Typ.Manual(ns, ClassName))
                     .WithXmlDoc(XmlDoc.Summary("Static class to provide extension methods to configure API clients."));
 
-                cls = cls.AddMembers(packageServiceDetails.Select(m => GenerateMethod(ctx, m)).ToArray());
+                var extensionMethods = packageServiceDetails
+                    .OrderBy(p => p.ServiceFullName, StringComparer.Ordinal)
+                    .Select(m => GenerateMethod(ctx, m))
+                    .ToArray();
+                cls = cls.AddMembers(extensionMethods);
                 namespaceDeclaration = namespaceDeclaration.AddMembers(cls);
             }
             return ctx.CreateCompilationUnit(namespaceDeclaration);


### PR DESCRIPTION
We're being passed protos in a different order in Bazel vs in our
generation scripts; this change will avoid unnecessary diffs.