### PR TITLE
tests: Updates Microsoft.Net.Test.Sdk dependencies from 17.2.0 => 17.3.0

### DIFF
--- a/Google.Api.Generator.Rest.Tests/Google.Api.Generator.Rest.Tests.csproj
+++ b/Google.Api.Generator.Rest.Tests/Google.Api.Generator.Rest.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/Google.Api.Generator.Tests/Google.Api.Generator.Tests.csproj
+++ b/Google.Api.Generator.Tests/Google.Api.Generator.Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Api.Gax.Testing" Version="4.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1.Tests/Testing.Basic.V1.Tests.csproj
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1.Tests/Testing.Basic.V1.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/Google.Api.Generator.Tests/ProtoTests/Mixins/Testing.Mixins.Tests/Testing.Mixins.Tests.csproj
+++ b/Google.Api.Generator.Tests/ProtoTests/Mixins/Testing.Mixins.Tests/Testing.Mixins.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/Google.Api.Generator/Generation/CsProjGenerator.cs
+++ b/Google.Api.Generator/Generation/CsProjGenerator.cs
@@ -29,7 +29,7 @@ namespace Google.Api.Generator.Generation
         private const string LocationVersion = "[2.0.0, 3.0.0)";
         private const string ReferenceAssembliesVersion = "1.0.2";
         private const string SystemLinqAsyncVersion = "6.0.1";
-        private const string TestSdkVersion = "17.2.0";
+        private const string TestSdkVersion = "17.3.0";
         private const string XUnitRunnerVersion = "2.4.5";
         private const string XUnitVersion = "2.4.2";
         private const string MoqVersion = "4.18.1";


### PR DESCRIPTION
In both generator and generated code.
(Note this does not affect google-cloud-dotnet as we generate out own projects there).