### PR TITLE
fix: set DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1

### DIFF
--- a/rules_csharp_gapic/csharp_compiler.bzl
+++ b/rules_csharp_gapic/csharp_compiler.bzl
@@ -32,6 +32,7 @@ DOTNET_CLI_HOME="$(pwd)/local_tmp" \
 DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 \
 DOTNET_CLI_TELEMETRY_OPTOUT=1 \
 DOTNET_NOLOGO=1 \
+DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1 \
 $cmd || $cmd
 
 cp -r src/* {out}/
@@ -60,6 +61,7 @@ DOTNET_CLI_HOME="$(pwd)/local_tmp" \
 DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 \
 DOTNET_CLI_TELEMETRY_OPTOUT=1 \
 DOTNET_NOLOGO=1 \
+DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1 \
 $cmd || $cmd
     """.format(
         csharp_compiler = ctx.file.csharp_compiler.short_path,

--- a/rules_csharp_gapic/csharp_compiler_repo.bzl
+++ b/rules_csharp_gapic/csharp_compiler_repo.bzl
@@ -64,6 +64,7 @@ def _dotnet_restore_impl(ctx):
                 "DOTNET_SKIP_FIRST_TIME_EXPERIENCE": "1",
                 "DOTNET_CLI_TELEMETRY_OPTOUT": "1",
                 "DOTNET_NOLOGO": "1",
+                "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT": "1",
             },
         )
         if res.return_code == 0:


### PR DESCRIPTION
After the recent generator update, the builds started failing locally (while still working in Docker). Adding this environment variable fixes the problem, but please feel free to suggest a better solution if it exists :)