### PR TITLE
chore: First pass at Showcase integration tests

### DIFF
--- a/Generator.sln
+++ b/Generator.sln
@@ -15,7 +15,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Api.Generator.Rest.T
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Api.Generator.Testing", "Google.Api.Generator.Testing\Google.Api.Generator.Testing.csproj", "{7B7E19A1-38E8-460A-BC86-90FC9AADC483}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Api.Generator.Utils.Tests", "Google.Api.Generator.Utils.Tests\Google.Api.Generator.Utils.Tests.csproj", "{98EC3797-5ED8-4364-832A-E147CAF4F3F3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Api.Generator.Utils.Tests", "Google.Api.Generator.Utils.Tests\Google.Api.Generator.Utils.Tests.csproj", "{98EC3797-5ED8-4364-832A-E147CAF4F3F3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Api.Generator.IntegrationTests", "Google.Api.Generator.IntegrationTests\Google.Api.Generator.IntegrationTests.csproj", "{BE12E385-1974-4852-8CEE-FE9F3B02F8E0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -51,6 +53,10 @@ Global
 		{98EC3797-5ED8-4364-832A-E147CAF4F3F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{98EC3797-5ED8-4364-832A-E147CAF4F3F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{98EC3797-5ED8-4364-832A-E147CAF4F3F3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE12E385-1974-4852-8CEE-FE9F3B02F8E0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE12E385-1974-4852-8CEE-FE9F3B02F8E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE12E385-1974-4852-8CEE-FE9F3B02F8E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE12E385-1974-4852-8CEE-FE9F3B02F8E0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Google.Api.Generator.IntegrationTests/ComplianceRestTest.cs
+++ b/Google.Api.Generator.IntegrationTests/ComplianceRestTest.cs
@@ -1,0 +1,101 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax.Grpc;
+using Google.Protobuf;
+using Google.Showcase.V1Beta1;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Google.Api.Generator.IntegrationTests
+{
+    /// <summary>
+    /// Compliance test for the REST transport.
+    /// </summary>
+    public class ComplianceRestTest : ShowcaseTestBase<ComplianceClient, ComplianceClientBuilder>
+    {
+        private static ComplianceSuite s_testFile = TestResources.ParseJson<ComplianceSuite>("compliance_suite.json");
+        public static IEnumerable<object[]> Tests =>
+            from grp in s_testFile.Group
+            from rpc in grp.Rpcs
+            from req in grp.Requests
+            select new object[] { new SerializableTest(grp.Name, rpc, req) };
+
+        [SkippableTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void GetEnum(bool unknownEnum)
+        {
+            var client = CreateClient();
+            var response = client.GetEnum(new EnumRequest { UnknownEnum = unknownEnum });
+            Assert.Equal(!unknownEnum, Enum.IsDefined(typeof(Continent), response.Continent));
+        }
+
+        [SkippableTheory]
+        [MemberData(nameof(Tests))]
+        public void Transcoding(SerializableTest test)
+        {
+            // See https://github.com/googleapis/gapic-showcase/issues/1203
+            Skip.If(test.Request.Name == "Extreme values");
+
+            var rpc = test.Rpc;
+            var request = test.Request;
+            var client = CreateClient();
+            var parts = rpc.Split('.');
+
+            // Check that we're asked for a Compliance RPC...
+            Assert.Equal("Compliance", parts[0]);
+
+            var method = client.GetType().GetMethod(parts[1], new[] { typeof(RepeatRequest), typeof(CallSettings) });
+            var response = (RepeatResponse) method.Invoke(client, new object[] { request, null });
+            Assert.NotEmpty(response.BindingUri);
+            Assert.Equal(request.Info, response.Request.Info);
+        }
+
+        /// <summary>
+        /// XUnit-serializable representation of a transcoding test, so we can easily execute just one at a time from VS.
+        /// </summary>
+        public class SerializableTest : IXunitSerializable
+        {
+            public string GroupName { get; private set; }
+            public RepeatRequest Request { get; private set; }
+            public string Rpc { get; private set; }
+
+            // Used in deserialization
+            public SerializableTest() { }
+
+            public SerializableTest(string groupName, string rpc, RepeatRequest request) =>
+                (GroupName, Rpc, Request) = (groupName, rpc, request);
+
+            public void Deserialize(IXunitSerializationInfo info)
+            {
+                GroupName = info.GetValue<string>(nameof(GroupName));
+                Request = RepeatRequest.Parser.ParseFrom(info.GetValue<byte[]>(nameof(Request)));
+                Rpc = info.GetValue<string>(nameof(Rpc));
+            }
+
+            public void Serialize(IXunitSerializationInfo info)
+            {
+                info.AddValue(nameof(GroupName), GroupName);
+                info.AddValue(nameof(Request), Request.ToByteArray());
+                info.AddValue(nameof(Rpc), Rpc);
+            }
+
+            public override string ToString() => $"{GroupName} / {Rpc} / {Request?.Name}";
+        }
+    }
+}

--- a/Google.Api.Generator.IntegrationTests/EchoTest.cs
+++ b/Google.Api.Generator.IntegrationTests/EchoTest.cs
@@ -1,0 +1,64 @@
+﻿// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Rpc;
+using Google.Showcase.V1Beta1;
+using Grpc.Core;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Api.Generator.IntegrationTests
+{
+    public abstract class EchoTestBase : ShowcaseTestBase<EchoClient, EchoClientBuilder>
+    {
+        [SkippableFact]
+        public void SimpleEcho()
+        {
+            var client = CreateClient();
+            string content = "hello world!";
+            var response = client.Echo(new EchoRequest { Content = content });
+            Assert.Equal(content, response.Content);
+        }
+
+        [SkippableFact]
+        public void EchoError()
+        {
+            var client = CreateClient();
+            var request = new EchoRequest { Error = new Rpc.Status { Code = (int) Code.Cancelled } };
+            var exception = Assert.Throws<RpcException>(() => client.Echo(request));
+            Assert.Equal(request.Error.Code, (int) exception.Status.StatusCode);
+        }
+
+        // Note: header testing is currently at least tricky. (It may be feasible for a gRPC interceptor.)
+        // We'll defer that for now; perhaps in a future version of the server it could check the expected
+        // header values.
+
+        public class EchoRestTest : EchoTestBase { }
+
+        public class EchoGrpcTest : EchoTestBase
+        {
+            // Note: currently only for gRPC as we don't support streaming methods in REST yet.
+            [SkippableFact]
+            public async Task Expand()
+            {
+                string content = "The rain in Spain stays mainly on the plain!";
+                var client = CreateClient();
+                var stream = client.Expand(new ExpandRequest { Content = content });
+                var items = await stream.GetResponseStream().Select(resp => resp.Content).ToListAsync();
+                Assert.Equal(content, string.Join(" ", items));                
+            }
+        }
+    }
+}

--- a/Google.Api.Generator.IntegrationTests/Google.Api.Generator.IntegrationTests.csproj
+++ b/Google.Api.Generator.IntegrationTests/Google.Api.Generator.IntegrationTests.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Google.Api.Generator.Tests\Google.Api.Generator.Tests.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Google.Api.Generator.IntegrationTests/ShowcaseTestBase.cs
+++ b/Google.Api.Generator.IntegrationTests/ShowcaseTestBase.cs
@@ -1,0 +1,66 @@
+﻿// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax.Grpc;
+using Google.Api.Gax.Grpc.Rest;
+using Grpc.Core;
+using System;
+using Xunit;
+
+namespace Google.Api.Generator.IntegrationTests
+{
+    /// <summary>
+    /// Base class for all Showcase tests.
+    /// </summary>
+    public abstract class ShowcaseTestBase<TClient, TBuilder>
+        where TBuilder : ClientBuilderBase<TClient>, new()
+    {
+        static ShowcaseTestBase()
+        {
+            AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+        }
+
+        private readonly GrpcAdapter _adapter;
+
+        protected ShowcaseTestBase()
+        {
+            // Normally we'd pass the adapter in as a parameter... but this leads to a load of constructors
+            // that are effectively pointless, when we can determine the adapter based on the name of the class.
+            // (We could add an attribute instead, but just going by convention is simpler.)
+            _adapter = GetType().Name switch
+            {
+                string name when name.EndsWith("RestTest") => RestGrpcAdapter.Default,
+                string name when name.EndsWith("GrpcTest") => GrpcNetClientAdapter.Default,
+                _ => throw new InvalidOperationException("Unable to determine gRPC adapter")
+            };
+        }
+
+        /// <summary>
+        /// Creates a suitable client, throwing an exception resulting in a "skipped" test
+        /// result if the Showcase endpoint hasn't been specified.
+        /// </summary>
+        protected TClient CreateClient()
+        {
+            string endpoint = Environment.GetEnvironmentVariable("SHOWCASE_ENDPOINT");
+            Skip.If(string.IsNullOrEmpty(endpoint));
+
+            return new TBuilder
+            {
+                GrpcAdapter = _adapter,
+                Endpoint = endpoint,
+                ChannelCredentials = ChannelCredentials.Insecure
+            }.Build();
+        }
+    }
+}

--- a/Google.Api.Generator.IntegrationTests/TestResources.cs
+++ b/Google.Api.Generator.IntegrationTests/TestResources.cs
@@ -1,0 +1,52 @@
+﻿// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Protobuf;
+using System;
+using System.IO;
+
+namespace Google.Api.Generator.IntegrationTests
+{
+    internal static class TestResources
+    {
+        internal static T ParseJson<T>(string path) where T : IMessage<T>, new()
+        {
+            var repoRoot = FindRepositoryRootDirectory();
+            var fullPath = Path.Combine(repoRoot, "Google.Api.Generator.IntegrationTests", path);
+            string json = File.ReadAllText(fullPath);
+            return JsonParser.Default.Parse<T>(json);
+        }
+
+        /// <summary>
+        /// Finds the root directory of the repository by looking for common files.
+        /// </summary>
+        public static string FindRepositoryRootDirectory()
+        {
+            var currentDirectory = Path.GetFullPath(".");
+            var directory = new DirectoryInfo(currentDirectory);
+            while (directory != null &&
+                (!File.Exists(Path.Combine(directory.FullName, "LICENSE"))
+                || !Directory.Exists(Path.Combine(directory.FullName, "Google.Api.Generator"))))
+            {
+                directory = directory.Parent;
+            }
+            if (directory == null)
+            {
+                throw new InvalidOperationException("Unable to determine root directory. Please run within gapic-generator-csharp repository.");
+            }
+            return directory.FullName;
+        }
+
+    }
+}

--- a/Google.Api.Generator.IntegrationTests/compliance_suite.json
+++ b/Google.Api.Generator.IntegrationTests/compliance_suite.json
@@ -1,0 +1,240 @@
+{
+  "group": [
+    {
+      "name": "Fully working conversions, no resources",
+      "rpcs": [ "Compliance.RepeatDataBody", "Compliance.RepeatDataBodyPut", "Compliance.RepeatDataBodyPatch", "Compliance.RepeatDataQuery", "Compliance.RepeatDataSimplePath", "Compliance.RepeatDataBodyInfo" ],
+      "requests": [
+        {
+          "name": "Basic data types",
+          "serverVerify": true,
+          "info": {
+            "fString": "Hello",
+            "fInt32": -1,
+            "fSint32": -2,
+            "fSfixed32": -3,
+            "fUint32": 5,
+            "fFixed32": 7,
+            "fInt64": -11,
+            "fSint64": -13,
+            "fSfixed64": -17,
+            "fUint64": 19,
+            "fFixed64": 23,
+            "fDouble": -29e4,
+            "fFloat": -31,
+            "fBool": true,
+            "fKingdom": "ANIMALIA",
+
+            "pString": "Goodbye",
+            "pInt32": -37,
+            "pDouble": -41.43,
+            "pBool": true,
+            "pKingdom": "PLANTAE",
+
+            "fChild": {
+              "fString": "second/bool/salutation"
+            }
+          },
+          "fInt32": -10,
+          "fInt64": -110,
+          "fDouble": -54e4,
+
+          "pInt32": -47,
+          "pInt64": -477,
+          "pDouble": -61.73
+        },
+        {
+          "name": "Basic types, no optional fields",
+          "serverVerify": true,
+          "info": {
+            "fString": "Hello",
+            "fInt32": -1,
+            "fSint32": -2,
+            "fSfixed32": -3,
+            "fUint32": 5,
+            "fFixed32": 7,
+            "fInt64": -11,
+            "fSint64": -13,
+            "fSfixed64": -17,
+            "fUint64": 19,
+            "fFixed64": 23,
+            "fDouble": -29e4,
+            "fFloat": -31,
+            "fBool": true,
+            "fKingdom": "ANIMALIA",
+
+            "fChild": {
+              "fString": "second/bool/salutation"
+            }
+          }
+        },
+
+        {
+          "name": "Zero values for non-string fields",
+          "serverVerify": true,
+          "info": {
+            "fString": "Hello",
+            "fInt32": 0,
+            "fSint32": 0,
+            "fSfixed32": 0,
+            "fUint32": 0,
+            "fFixed32": 0,
+            "fInt64": 0,
+            "fSint64": 0,
+            "fSfixed64": 0,
+            "fUint64": 0,
+            "fFixed64": 0,
+            "fDouble": 0,
+            "fFloat": 0,
+            "fBool": false,
+            "fKingdom": "LIFE_KINGDOM_UNSPECIFIED",
+
+            "pString": "Goodbye",
+            "pInt32": 0,
+            "pDouble": 0,
+            "pBool": false,
+            "pKingdom": "LIFE_KINGDOM_UNSPECIFIED"
+          }
+        },
+        {
+          "name": "Extreme values",
+          "serverVerify": true,
+          "info": {
+            "fString": "non-ASCII+non-printable string ☺ → ← \"\\\/\b\f\r\t\u1234 works, not newlines yet",
+            "fInt32": 2147483647,
+            "fSint32": 2147483647,
+            "fSfixed32": 2147483647,
+            "fUint32": 4294967295,
+            "fFixed32": 4294967295,
+            "fInt64": "9223372036854775807",
+            "fSint64": "9223372036854775807",
+            "fSfixed64": "9223372036854775807",
+            "fUint64": "18446744073709551615",
+            "fFixed64": "18446744073709551615",
+            "fDouble": 1.797693134862315708145274237317043567981e+308,
+            "fFloat": 3.40282346638528859811704183484516925440e+38,
+            "fBool": false,
+
+            "pString": "Goodbye",
+            "pInt32": 2147483647,
+            "pDouble": 1.797693134862315708145274237317043567981e+308,
+            "pBool": false
+          }
+        },
+        {
+          "name": "Strings with spaces",
+          "serverVerify": true,
+          "info": {
+            "fString": "Hello there"
+          }
+        },
+        {
+          "name": "Strings with quotes",
+          "serverVerify": true,
+          "info": {
+            "fString": "Hello \"You\""
+          }
+        },
+        {
+          "name": "Strings with percents",
+          "serverVerify": true,
+          "info": {
+            "fString": "Hello 100%"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Fully working conversions, resources",
+      "rpcs": [ "Compliance.RepeatDataBody", "Compliance.RepeatDataBodyPut", "Compliance.RepeatDataBodyPatch", "Compliance.RepeatDataQuery" ],
+      "requests": [
+        {
+          "name": "Strings with slashes and values that resemble subsequent resource templates",
+          "serverVerify": true,
+          "info": {
+            "fString": "first/hello/second/greetings",
+            "pBool": true,
+
+            "fChild": {
+              "fString": "second/zzz/bool/true"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Binding selection testing",
+      "rpcs": [ "Compliance.RepeatDataPathResource" ],
+      "requests": [
+        {
+          "name": "Binding testing baseline no Uri verification",
+          "serverVerify": true,
+          "info": {
+            "fString": "first/hello",
+            "pBool": true,
+
+            "fChild": {
+              "fString": "second/greetings"
+            }
+          }
+        },
+        {
+          "name": "Binding testing first binding",
+          "serverVerify": true,
+          "info": {
+            "fString": "first/hello",
+            "pBool": true,
+
+            "fChild": {
+              "fString": "second/greetings"
+            }
+          },
+          "intendedBindingUri": "/v1beta1/repeat/{info.f_string=first/*}/{info.f_child.f_string=second/*}/bool/{info.f_bool}:pathresource"
+        },
+        {
+          "name": "Binding testing additional binding",
+          "serverVerify": true,
+          "info": {
+            "fString": "second/greetings",
+            "pBool": true,
+
+            "fChild": {
+              "fString": "first/hello"
+            }
+          },
+          "intendedBindingUri": "/v1beta1/repeat/{info.f_child.f_string=first/*}/{info.f_string=second/*}/bool/{info.f_bool}:childfirstpathresource"
+        }
+      ]
+    },
+    {
+      "name": "Cases that apply to non-path requests",
+      "rpcs": [ "Compliance.RepeatDataBody", "Compliance.RepeatDataBodyPut", "Compliance.RepeatDataBodyPatch", "Compliance.RepeatDataQuery" ],
+      "requests": [
+        {
+          "name": "Zero values for all fields",
+          "serverVerify": true,
+          "info": {
+            "fString": "",
+            "fInt32": 0,
+            "fSint32": 0,
+            "fSfixed32": 0,
+            "fUint32": 0,
+            "fFixed32": 0,
+            "fInt64": 0,
+            "fSint64": 0,
+            "fSfixed64": 0,
+            "fUint64": 0,
+            "fFixed64": 20,
+            "fDouble": 0,
+            "fFloat": 0,
+            "fBool": false,
+
+            "pString": "",
+            "pInt32": 0,
+            "pDouble": 0,
+            "pBool": false
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This is primarily aimed at the data-driven REST compliance tests, but starts building out the Echo tests too, including showing how an abstract test base class can be used to collect common gRPC+REST tests, with concrete subclasses inheriting those tests and adding transport-specific tests.

These tests will not run in GitHub actions, although it's always safe to run the tests - they will all be skipped unless the SHOWCASE_ENDPOINT environment variable is set (typically to http://localhost:7469). In future, we'll add nightly integration tests which stand up a local Showcase server before executing the tests.