### PR TITLE
feat: Handle REGAPIC mix-ins

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTest.cs
+++ b/Google.Api.Generator.Tests/ProtoTest.cs
@@ -98,6 +98,11 @@ namespace Google.Api.Generator.Tests
             var protoPaths = testProtoNames.Select(x => Path.Combine("ProtoTests", sourceDir, $"{x}.proto"));
             package = package ?? $"testing.{sourceDir.ToLowerInvariant()}";
 
+            if (serviceConfigPath is string)
+            {
+                serviceConfigPath = Path.Combine(Invoker.GeneratorTestsDir, "ProtoTests", sourceDir, serviceConfigPath);
+            }
+
             var files = Run(protoPaths, package,
                 grpcServiceConfigPath, serviceConfigPath, commonResourcesConfigPaths, transports, requestNumericEnumJsonEncoding);
             // Check output is present.
@@ -261,14 +266,14 @@ namespace Google.Api.Generator.Tests
         public void OptionalFields() => ProtoTestSingle("OptionalFields", ignoreCsProj: true, ignoreUnitTests: true, ignoreSnippets: true);
 
         [Fact]
-        public void Mixins() => ProtoTestSingle("Mixins", ignoreGapicMetadataFile: false, ignoreSnippets: true,
-            serviceConfigPath: Path.Combine(Invoker.GeneratorTestsDir, "ProtoTests", "Mixins", "Mixins.yaml"));
+        public void Mixins() => ProtoTestSingle("Mixins", ignoreGapicMetadataFile: false, ignoreSnippets: true, serviceConfigPath: "Mixins.yaml");
 
         [Fact]
         public void Showcase() => ProtoTestSingle(testProtoNames: new[] { "compliance", "echo", "identity", "messaging", "sequence", "testing" },
             sourceDir: "Showcase/google/showcase/v1beta1",
             outputDir: "Showcase",
             package: "google.showcase.v1beta1",
+            serviceConfigPath: "showcase_v1beta1.yaml",
             transports: ApiTransports.Grpc | ApiTransports.Rest,
             requestNumericEnumJsonEncoding: true,
             ignoreUnitTests: true,

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/ComplianceClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/ComplianceClient.g.cs
@@ -17,6 +17,8 @@
 #pragma warning disable CS8981
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
+using gciv = Google.Cloud.Iam.V1;
+using gcl = Google.Cloud.Location;
 using proto = Google.Protobuf;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
@@ -54,6 +56,8 @@ namespace Google.Showcase.V1Beta1
             RepeatDataBodyPatchSettings = existing.RepeatDataBodyPatchSettings;
             GetEnumSettings = existing.GetEnumSettings;
             VerifyEnumSettings = existing.VerifyEnumSettings;
+            LocationsSettings = existing.LocationsSettings;
+            IAMPolicySettings = existing.IAMPolicySettings;
             OnCopy(existing);
         }
 
@@ -179,6 +183,16 @@ namespace Google.Showcase.V1Beta1
         /// </list>
         /// </remarks>
         public gaxgrpc::CallSettings VerifyEnumSettings { get; set; } = gaxgrpc::CallSettings.FromExpiration(gax::Expiration.None);
+
+        /// <summary>
+        /// The settings to use for the <see cref="gcl::LocationsClient"/> associated with the client.
+        /// </summary>
+        public gcl::LocationsSettings LocationsSettings { get; set; } = gcl::LocationsSettings.GetDefault();
+
+        /// <summary>
+        /// The settings to use for the <see cref="gciv::IAMPolicyClient"/> associated with the client.
+        /// </summary>
+        public gciv::IAMPolicySettings IAMPolicySettings { get; set; } = gciv::IAMPolicySettings.GetDefault();
 
         /// <summary>Creates a deep clone of this object, with all the same property values.</summary>
         /// <returns>A deep clone of this <see cref="ComplianceSettings"/> object.</returns>
@@ -312,6 +326,12 @@ namespace Google.Showcase.V1Beta1
 
         /// <summary>The underlying gRPC Compliance client</summary>
         public virtual Compliance.ComplianceClient GrpcClient => throw new sys::NotImplementedException();
+
+        /// <summary>The <see cref="gcl::LocationsClient"/> associated with this client.</summary>
+        public virtual gcl::LocationsClient LocationsClient => throw new sys::NotImplementedException();
+
+        /// <summary>The <see cref="gciv::IAMPolicyClient"/> associated with this client.</summary>
+        public virtual gciv::IAMPolicyClient IAMPolicyClient => throw new sys::NotImplementedException();
 
         /// <summary>
         /// This method echoes the ComplianceData request. This method exercises
@@ -671,6 +691,8 @@ namespace Google.Showcase.V1Beta1
             GrpcClient = grpcClient;
             ComplianceSettings effectiveSettings = settings ?? ComplianceSettings.GetDefault();
             gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            LocationsClient = new gcl::LocationsClientImpl(grpcClient.CreateLocationsClient(), effectiveSettings.LocationsSettings, logger);
+            IAMPolicyClient = new gciv::IAMPolicyClientImpl(grpcClient.CreateIAMPolicyClient(), effectiveSettings.IAMPolicySettings, logger);
             _callRepeatDataBody = clientHelper.BuildApiCall<RepeatRequest, RepeatResponse>("RepeatDataBody", grpcClient.RepeatDataBodyAsync, grpcClient.RepeatDataBody, effectiveSettings.RepeatDataBodySettings);
             Modify_ApiCall(ref _callRepeatDataBody);
             Modify_RepeatDataBodyApiCall(ref _callRepeatDataBody);
@@ -730,6 +752,12 @@ namespace Google.Showcase.V1Beta1
 
         /// <summary>The underlying gRPC Compliance client</summary>
         public override Compliance.ComplianceClient GrpcClient { get; }
+
+        /// <summary>The <see cref="gcl::LocationsClient"/> associated with this client.</summary>
+        public override gcl::LocationsClient LocationsClient { get; }
+
+        /// <summary>The <see cref="gciv::IAMPolicyClient"/> associated with this client.</summary>
+        public override gciv::IAMPolicyClient IAMPolicyClient { get; }
 
         partial void Modify_RepeatRequest(ref RepeatRequest request, ref gaxgrpc::CallSettings settings);
 
@@ -1007,6 +1035,32 @@ namespace Google.Showcase.V1Beta1
         {
             Modify_EnumResponse(ref request, ref callSettings);
             return _callVerifyEnum.Async(request, callSettings);
+        }
+    }
+
+    public static partial class Compliance
+    {
+        public partial class ComplianceClient
+        {
+            /// <summary>
+            /// Creates a new instance of <see cref="gcl::Locations.LocationsClient"/> using the same call invoker as
+            /// this client.
+            /// </summary>
+            /// <returns>
+            /// A new <see cref="gcl::Locations.LocationsClient"/> for the same target as this client.
+            /// </returns>
+            public virtual gcl::Locations.LocationsClient CreateLocationsClient() =>
+                new gcl::Locations.LocationsClient(CallInvoker);
+
+            /// <summary>
+            /// Creates a new instance of <see cref="gciv::IAMPolicy.IAMPolicyClient"/> using the same call invoker as
+            /// this client.
+            /// </summary>
+            /// <returns>
+            /// A new <see cref="gciv::IAMPolicy.IAMPolicyClient"/> for the same target as this client.
+            /// </returns>
+            public virtual gciv::IAMPolicy.IAMPolicyClient CreateIAMPolicyClient() =>
+                new gciv::IAMPolicy.IAMPolicyClient(CallInvoker);
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/EchoClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/EchoClient.g.cs
@@ -17,6 +17,8 @@
 #pragma warning disable CS8981
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
+using gciv = Google.Cloud.Iam.V1;
+using gcl = Google.Cloud.Location;
 using lro = Google.LongRunning;
 using proto = Google.Protobuf;
 using gr = Google.Rpc;
@@ -60,6 +62,8 @@ namespace Google.Showcase.V1Beta1
             WaitSettings = existing.WaitSettings;
             WaitOperationsSettings = existing.WaitOperationsSettings.Clone();
             BlockSettings = existing.BlockSettings;
+            LocationsSettings = existing.LocationsSettings;
+            IAMPolicySettings = existing.IAMPolicySettings;
             OnCopy(existing);
         }
 
@@ -204,6 +208,16 @@ namespace Google.Showcase.V1Beta1
         /// </remarks>
         public gaxgrpc::CallSettings BlockSettings { get; set; } = gaxgrpc::CallSettings.FromExpiration(gax::Expiration.None);
 
+        /// <summary>
+        /// The settings to use for the <see cref="gcl::LocationsClient"/> associated with the client.
+        /// </summary>
+        public gcl::LocationsSettings LocationsSettings { get; set; } = gcl::LocationsSettings.GetDefault();
+
+        /// <summary>
+        /// The settings to use for the <see cref="gciv::IAMPolicyClient"/> associated with the client.
+        /// </summary>
+        public gciv::IAMPolicySettings IAMPolicySettings { get; set; } = gciv::IAMPolicySettings.GetDefault();
+
         /// <summary>Creates a deep clone of this object, with all the same property values.</summary>
         /// <returns>A deep clone of this <see cref="EchoSettings"/> object.</returns>
         public EchoSettings Clone() => new EchoSettings(this);
@@ -340,6 +354,12 @@ namespace Google.Showcase.V1Beta1
 
         /// <summary>The underlying gRPC Echo client</summary>
         public virtual gsv::Echo.EchoClient GrpcClient => throw new sys::NotImplementedException();
+
+        /// <summary>The <see cref="gcl::LocationsClient"/> associated with this client.</summary>
+        public virtual gcl::LocationsClient LocationsClient => throw new sys::NotImplementedException();
+
+        /// <summary>The <see cref="gciv::IAMPolicyClient"/> associated with this client.</summary>
+        public virtual gciv::IAMPolicyClient IAMPolicyClient => throw new sys::NotImplementedException();
 
         /// <summary>
         /// This method simply echoes the request. This method showcases unary RPCs.
@@ -641,6 +661,8 @@ namespace Google.Showcase.V1Beta1
             EchoSettings effectiveSettings = settings ?? EchoSettings.GetDefault();
             gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
             WaitOperationsClient = new lro::OperationsClientImpl(grpcClient.CreateOperationsClient(), effectiveSettings.WaitOperationsSettings, logger);
+            LocationsClient = new gcl::LocationsClientImpl(grpcClient.CreateLocationsClient(), effectiveSettings.LocationsSettings, logger);
+            IAMPolicyClient = new gciv::IAMPolicyClientImpl(grpcClient.CreateIAMPolicyClient(), effectiveSettings.IAMPolicySettings, logger);
             _callEcho = clientHelper.BuildApiCall<EchoRequest, EchoResponse>("Echo", grpcClient.EchoAsync, grpcClient.Echo, effectiveSettings.EchoSettings_).WithExtractedGoogleRequestParam(new gaxgrpc::RoutingHeaderExtractor<EchoRequest>().WithExtractedParameter("header", "^(.+)$", request => request.Header).WithExtractedParameter("routing_id", "^(.+)$", request => request.Header).WithExtractedParameter("table_name", "^(regions/[^/]+/zones/[^/]+(?:/.*)?)$", request => request.Header).WithExtractedParameter("table_name", "^(projects/[^/]+/instances/[^/]+(?:/.*)?)$", request => request.Header).WithExtractedParameter("super_id", "^(projects/[^/]+)(?:/.*)?$", request => request.Header).WithExtractedParameter("instance_id", "^projects/[^/]+/(instances/[^/]+)(?:/.*)?$", request => request.Header).WithExtractedParameter("baz", "^(.+)$", request => request.OtherHeader).WithExtractedParameter("qux", "^(projects/[^/]+)(?:/.*)?$", request => request.OtherHeader));
             Modify_ApiCall(ref _callEcho);
             Modify_EchoApiCall(ref _callEcho);
@@ -701,6 +723,12 @@ namespace Google.Showcase.V1Beta1
 
         /// <summary>The underlying gRPC Echo client</summary>
         public override gsv::Echo.EchoClient GrpcClient { get; }
+
+        /// <summary>The <see cref="gcl::LocationsClient"/> associated with this client.</summary>
+        public override gcl::LocationsClient LocationsClient { get; }
+
+        /// <summary>The <see cref="gciv::IAMPolicyClient"/> associated with this client.</summary>
+        public override gciv::IAMPolicyClient IAMPolicyClient { get; }
 
         partial void Modify_EchoRequest(ref EchoRequest request, ref gaxgrpc::CallSettings settings);
 
@@ -1074,6 +1102,32 @@ namespace Google.Showcase.V1Beta1
             /// <returns>A new Operations client for the same target as this client.</returns>
             public virtual lro::Operations.OperationsClient CreateOperationsClient() =>
                 new lro::Operations.OperationsClient(CallInvoker);
+        }
+    }
+
+    public static partial class Echo
+    {
+        public partial class EchoClient
+        {
+            /// <summary>
+            /// Creates a new instance of <see cref="gcl::Locations.LocationsClient"/> using the same call invoker as
+            /// this client.
+            /// </summary>
+            /// <returns>
+            /// A new <see cref="gcl::Locations.LocationsClient"/> for the same target as this client.
+            /// </returns>
+            public virtual gcl::Locations.LocationsClient CreateLocationsClient() =>
+                new gcl::Locations.LocationsClient(CallInvoker);
+
+            /// <summary>
+            /// Creates a new instance of <see cref="gciv::IAMPolicy.IAMPolicyClient"/> using the same call invoker as
+            /// this client.
+            /// </summary>
+            /// <returns>
+            /// A new <see cref="gciv::IAMPolicy.IAMPolicyClient"/> for the same target as this client.
+            /// </returns>
+            public virtual gciv::IAMPolicy.IAMPolicyClient CreateIAMPolicyClient() =>
+                new gciv::IAMPolicy.IAMPolicyClient(CallInvoker);
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/Google.Showcase.V1Beta1.csproj
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/Google.Showcase.V1Beta1.csproj
@@ -43,6 +43,8 @@
     <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" Condition="'$(TargetFramework)'=='net462'" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
   </ItemGroup>
 
 </Project>

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/IdentityClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/IdentityClient.g.cs
@@ -17,6 +17,8 @@
 #pragma warning disable CS8981
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
+using gciv = Google.Cloud.Iam.V1;
+using gcl = Google.Cloud.Location;
 using proto = Google.Protobuf;
 using wkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
@@ -51,6 +53,8 @@ namespace Google.Showcase.V1Beta1
             UpdateUserSettings = existing.UpdateUserSettings;
             DeleteUserSettings = existing.DeleteUserSettings;
             ListUsersSettings = existing.ListUsersSettings;
+            LocationsSettings = existing.LocationsSettings;
+            IAMPolicySettings = existing.IAMPolicySettings;
             OnCopy(existing);
         }
 
@@ -115,6 +119,16 @@ namespace Google.Showcase.V1Beta1
         /// </list>
         /// </remarks>
         public gaxgrpc::CallSettings ListUsersSettings { get; set; } = gaxgrpc::CallSettings.FromExpiration(gax::Expiration.None);
+
+        /// <summary>
+        /// The settings to use for the <see cref="gcl::LocationsClient"/> associated with the client.
+        /// </summary>
+        public gcl::LocationsSettings LocationsSettings { get; set; } = gcl::LocationsSettings.GetDefault();
+
+        /// <summary>
+        /// The settings to use for the <see cref="gciv::IAMPolicyClient"/> associated with the client.
+        /// </summary>
+        public gciv::IAMPolicySettings IAMPolicySettings { get; set; } = gciv::IAMPolicySettings.GetDefault();
 
         /// <summary>Creates a deep clone of this object, with all the same property values.</summary>
         /// <returns>A deep clone of this <see cref="IdentitySettings"/> object.</returns>
@@ -246,6 +260,12 @@ namespace Google.Showcase.V1Beta1
 
         /// <summary>The underlying gRPC Identity client</summary>
         public virtual Identity.IdentityClient GrpcClient => throw new sys::NotImplementedException();
+
+        /// <summary>The <see cref="gcl::LocationsClient"/> associated with this client.</summary>
+        public virtual gcl::LocationsClient LocationsClient => throw new sys::NotImplementedException();
+
+        /// <summary>The <see cref="gciv::IAMPolicyClient"/> associated with this client.</summary>
+        public virtual gciv::IAMPolicyClient IAMPolicyClient => throw new sys::NotImplementedException();
 
         /// <summary>
         /// Creates a user.
@@ -731,6 +751,8 @@ namespace Google.Showcase.V1Beta1
             GrpcClient = grpcClient;
             IdentitySettings effectiveSettings = settings ?? IdentitySettings.GetDefault();
             gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            LocationsClient = new gcl::LocationsClientImpl(grpcClient.CreateLocationsClient(), effectiveSettings.LocationsSettings, logger);
+            IAMPolicyClient = new gciv::IAMPolicyClientImpl(grpcClient.CreateIAMPolicyClient(), effectiveSettings.IAMPolicySettings, logger);
             _callCreateUser = clientHelper.BuildApiCall<CreateUserRequest, User>("CreateUser", grpcClient.CreateUserAsync, grpcClient.CreateUser, effectiveSettings.CreateUserSettings);
             Modify_ApiCall(ref _callCreateUser);
             Modify_CreateUserApiCall(ref _callCreateUser);
@@ -765,6 +787,12 @@ namespace Google.Showcase.V1Beta1
 
         /// <summary>The underlying gRPC Identity client</summary>
         public override Identity.IdentityClient GrpcClient { get; }
+
+        /// <summary>The <see cref="gcl::LocationsClient"/> associated with this client.</summary>
+        public override gcl::LocationsClient LocationsClient { get; }
+
+        /// <summary>The <see cref="gciv::IAMPolicyClient"/> associated with this client.</summary>
+        public override gciv::IAMPolicyClient IAMPolicyClient { get; }
 
         partial void Modify_CreateUserRequest(ref CreateUserRequest request, ref gaxgrpc::CallSettings settings);
 
@@ -907,5 +935,31 @@ namespace Google.Showcase.V1Beta1
         public scg::IEnumerator<User> GetEnumerator() => Users.GetEnumerator();
 
         sc::IEnumerator sc::IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    public static partial class Identity
+    {
+        public partial class IdentityClient
+        {
+            /// <summary>
+            /// Creates a new instance of <see cref="gcl::Locations.LocationsClient"/> using the same call invoker as
+            /// this client.
+            /// </summary>
+            /// <returns>
+            /// A new <see cref="gcl::Locations.LocationsClient"/> for the same target as this client.
+            /// </returns>
+            public virtual gcl::Locations.LocationsClient CreateLocationsClient() =>
+                new gcl::Locations.LocationsClient(CallInvoker);
+
+            /// <summary>
+            /// Creates a new instance of <see cref="gciv::IAMPolicy.IAMPolicyClient"/> using the same call invoker as
+            /// this client.
+            /// </summary>
+            /// <returns>
+            /// A new <see cref="gciv::IAMPolicy.IAMPolicyClient"/> for the same target as this client.
+            /// </returns>
+            public virtual gciv::IAMPolicy.IAMPolicyClient CreateIAMPolicyClient() =>
+                new gciv::IAMPolicy.IAMPolicyClient(CallInvoker);
+        }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/MessagingClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/MessagingClient.g.cs
@@ -17,6 +17,8 @@
 #pragma warning disable CS8981
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
+using gciv = Google.Cloud.Iam.V1;
+using gcl = Google.Cloud.Location;
 using lro = Google.LongRunning;
 using proto = Google.Protobuf;
 using wkt = Google.Protobuf.WellKnownTypes;
@@ -64,6 +66,8 @@ namespace Google.Showcase.V1Beta1
             SendBlurbsStreamingSettings = existing.SendBlurbsStreamingSettings;
             ConnectSettings = existing.ConnectSettings;
             ConnectStreamingSettings = existing.ConnectStreamingSettings;
+            LocationsSettings = existing.LocationsSettings;
+            IAMPolicySettings = existing.IAMPolicySettings;
             OnCopy(existing);
         }
 
@@ -269,6 +273,16 @@ namespace Google.Showcase.V1Beta1
         /// <remarks>The default local send queue size is 100.</remarks>
         public gaxgrpc::BidirectionalStreamingSettings ConnectStreamingSettings { get; set; } = new gaxgrpc::BidirectionalStreamingSettings(100);
 
+        /// <summary>
+        /// The settings to use for the <see cref="gcl::LocationsClient"/> associated with the client.
+        /// </summary>
+        public gcl::LocationsSettings LocationsSettings { get; set; } = gcl::LocationsSettings.GetDefault();
+
+        /// <summary>
+        /// The settings to use for the <see cref="gciv::IAMPolicyClient"/> associated with the client.
+        /// </summary>
+        public gciv::IAMPolicySettings IAMPolicySettings { get; set; } = gciv::IAMPolicySettings.GetDefault();
+
         /// <summary>Creates a deep clone of this object, with all the same property values.</summary>
         /// <returns>A deep clone of this <see cref="MessagingSettings"/> object.</returns>
         public MessagingSettings Clone() => new MessagingSettings(this);
@@ -402,6 +416,12 @@ namespace Google.Showcase.V1Beta1
 
         /// <summary>The underlying gRPC Messaging client</summary>
         public virtual Messaging.MessagingClient GrpcClient => throw new sys::NotImplementedException();
+
+        /// <summary>The <see cref="gcl::LocationsClient"/> associated with this client.</summary>
+        public virtual gcl::LocationsClient LocationsClient => throw new sys::NotImplementedException();
+
+        /// <summary>The <see cref="gciv::IAMPolicyClient"/> associated with this client.</summary>
+        public virtual gciv::IAMPolicyClient IAMPolicyClient => throw new sys::NotImplementedException();
 
         /// <summary>
         /// Creates a room.
@@ -1723,6 +1743,8 @@ namespace Google.Showcase.V1Beta1
             MessagingSettings effectiveSettings = settings ?? MessagingSettings.GetDefault();
             gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
             SearchBlurbsOperationsClient = new lro::OperationsClientImpl(grpcClient.CreateOperationsClient(), effectiveSettings.SearchBlurbsOperationsSettings, logger);
+            LocationsClient = new gcl::LocationsClientImpl(grpcClient.CreateLocationsClient(), effectiveSettings.LocationsSettings, logger);
+            IAMPolicyClient = new gciv::IAMPolicyClientImpl(grpcClient.CreateIAMPolicyClient(), effectiveSettings.IAMPolicySettings, logger);
             _callCreateRoom = clientHelper.BuildApiCall<CreateRoomRequest, Room>("CreateRoom", grpcClient.CreateRoomAsync, grpcClient.CreateRoom, effectiveSettings.CreateRoomSettings);
             Modify_ApiCall(ref _callCreateRoom);
             Modify_CreateRoomApiCall(ref _callCreateRoom);
@@ -1808,6 +1830,12 @@ namespace Google.Showcase.V1Beta1
 
         /// <summary>The underlying gRPC Messaging client</summary>
         public override Messaging.MessagingClient GrpcClient { get; }
+
+        /// <summary>The <see cref="gcl::LocationsClient"/> associated with this client.</summary>
+        public override gcl::LocationsClient LocationsClient { get; }
+
+        /// <summary>The <see cref="gciv::IAMPolicyClient"/> associated with this client.</summary>
+        public override gciv::IAMPolicyClient IAMPolicyClient { get; }
 
         partial void Modify_CreateRoomRequest(ref CreateRoomRequest request, ref gaxgrpc::CallSettings settings);
 
@@ -2299,6 +2327,32 @@ namespace Google.Showcase.V1Beta1
             /// <returns>A new Operations client for the same target as this client.</returns>
             public virtual lro::Operations.OperationsClient CreateOperationsClient() =>
                 new lro::Operations.OperationsClient(CallInvoker);
+        }
+    }
+
+    public static partial class Messaging
+    {
+        public partial class MessagingClient
+        {
+            /// <summary>
+            /// Creates a new instance of <see cref="gcl::Locations.LocationsClient"/> using the same call invoker as
+            /// this client.
+            /// </summary>
+            /// <returns>
+            /// A new <see cref="gcl::Locations.LocationsClient"/> for the same target as this client.
+            /// </returns>
+            public virtual gcl::Locations.LocationsClient CreateLocationsClient() =>
+                new gcl::Locations.LocationsClient(CallInvoker);
+
+            /// <summary>
+            /// Creates a new instance of <see cref="gciv::IAMPolicy.IAMPolicyClient"/> using the same call invoker as
+            /// this client.
+            /// </summary>
+            /// <returns>
+            /// A new <see cref="gciv::IAMPolicy.IAMPolicyClient"/> for the same target as this client.
+            /// </returns>
+            public virtual gciv::IAMPolicy.IAMPolicyClient CreateIAMPolicyClient() =>
+                new gciv::IAMPolicy.IAMPolicyClient(CallInvoker);
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/PackageApiMetadata.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/PackageApiMetadata.g.cs
@@ -16,6 +16,10 @@
 
 #pragma warning disable CS8981
 using gaxgrpc = Google.Api.Gax.Grpc;
+using gciv = Google.Cloud.Iam.V1;
+using gcl = Google.Cloud.Location;
+using lro = Google.LongRunning;
+using proto = Google.Protobuf;
 using gpr = Google.Protobuf.Reflection;
 using scg = System.Collections.Generic;
 
@@ -25,10 +29,64 @@ namespace Google.Showcase.V1Beta1
     internal static class PackageApiMetadata
     {
         /// <summary>The <see cref="gaxgrpc::ApiMetadata"/> for services in this package.</summary>
-        internal static gaxgrpc::ApiMetadata ApiMetadata { get; } = new gaxgrpc::ApiMetadata("Google.Showcase.V1Beta1", GetFileDescriptors).WithRequestNumericEnumJsonEncoding(true);
+        internal static gaxgrpc::ApiMetadata ApiMetadata { get; } = new gaxgrpc::ApiMetadata("Google.Showcase.V1Beta1", GetFileDescriptors)
+            .WithRequestNumericEnumJsonEncoding(true)
+            .WithHttpRuleOverrides(new scg::Dictionary<string, proto::ByteString>
+            {
+                {
+                    "google.cloud.location.Locations.GetLocation",
+                    // { "get": "/v1beta1/{name=projects/*/locations/*}" }
+                    proto::ByteString.FromBase64("EiYvdjFiZXRhMS97bmFtZT1wcm9qZWN0cy8qL2xvY2F0aW9ucy8qfQ==")
+                },
+                {
+                    "google.cloud.location.Locations.ListLocations",
+                    // { "get": "/v1beta1/{name=projects/*}/locations" }
+                    proto::ByteString.FromBase64("EiQvdjFiZXRhMS97bmFtZT1wcm9qZWN0cy8qfS9sb2NhdGlvbnM=")
+                },
+                {
+                    "google.iam.v1.IAMPolicy.GetIamPolicy",
+                    // { "get": "/v1beta1/{resource=users/*}:getIamPolicy", "additionalBindings": [ { "get": "/v1beta1/{resource=rooms/*}:getIamPolicy" }, { "get": "/v1beta1/{resource=rooms/*/blurbs/*}:getIamPolicy" }, { "get": "/v1beta1/{resource=sequences/*}:getIamPolicy" } ] }
+                    proto::ByteString.FromBase64("EigvdjFiZXRhMS97cmVzb3VyY2U9dXNlcnMvKn06Z2V0SWFtUG9saWN5WioSKC92MWJldGExL3tyZXNvdXJjZT1yb29tcy8qfTpnZXRJYW1Qb2xpY3laMxIxL3YxYmV0YTEve3Jlc291cmNlPXJvb21zLyovYmx1cmJzLyp9OmdldElhbVBvbGljeVouEiwvdjFiZXRhMS97cmVzb3VyY2U9c2VxdWVuY2VzLyp9OmdldElhbVBvbGljeQ==")
+                },
+                {
+                    "google.iam.v1.IAMPolicy.SetIamPolicy",
+                    // { "post": "/v1beta1/{resource=users/*}:setIamPolicy", "body": "*", "additionalBindings": [ { "post": "/v1beta1/{resource=rooms/*}:setIamPolicy", "body": "*" }, { "post": "/v1beta1/{resource=rooms/*/blurbs/*}:setIamPolicy", "body": "*" }, { "post": "/v1beta1/{resource=sequences/*}:setIamPolicy", "body": "*" } ] }
+                    proto::ByteString.FromBase64("IigvdjFiZXRhMS97cmVzb3VyY2U9dXNlcnMvKn06c2V0SWFtUG9saWN5OgEqWi0iKC92MWJldGExL3tyZXNvdXJjZT1yb29tcy8qfTpzZXRJYW1Qb2xpY3k6ASpaNiIxL3YxYmV0YTEve3Jlc291cmNlPXJvb21zLyovYmx1cmJzLyp9OnNldElhbVBvbGljeToBKloxIiwvdjFiZXRhMS97cmVzb3VyY2U9c2VxdWVuY2VzLyp9OnNldElhbVBvbGljeToBKg==")
+                },
+                {
+                    "google.iam.v1.IAMPolicy.TestIamPermissions",
+                    // { "post": "/v1beta1/{resource=users/*}:testIamPermissions", "body": "*", "additionalBindings": [ { "post": "/v1beta1/{resource=rooms/*}:testIamPermissions", "body": "*" }, { "post": "/v1beta1/{resource=rooms/*/blurbs/*}:testIamPermissions", "body": "*" }, { "post": "/v1beta1/{resource=sequences/*}:testIamPermissions", "body": "*" } ] }
+                    proto::ByteString.FromBase64("Ii4vdjFiZXRhMS97cmVzb3VyY2U9dXNlcnMvKn06dGVzdElhbVBlcm1pc3Npb25zOgEqWjMiLi92MWJldGExL3tyZXNvdXJjZT1yb29tcy8qfTp0ZXN0SWFtUGVybWlzc2lvbnM6ASpaPCI3L3YxYmV0YTEve3Jlc291cmNlPXJvb21zLyovYmx1cmJzLyp9OnRlc3RJYW1QZXJtaXNzaW9uczoBKlo3IjIvdjFiZXRhMS97cmVzb3VyY2U9c2VxdWVuY2VzLyp9OnRlc3RJYW1QZXJtaXNzaW9uczoBKg==")
+                },
+                {
+                    "google.longrunning.Operations.CancelOperation",
+                    // { "post": "/v1beta1/{name=operations/**}:cancel" }
+                    proto::ByteString.FromBase64("IiQvdjFiZXRhMS97bmFtZT1vcGVyYXRpb25zLyoqfTpjYW5jZWw=")
+                },
+                {
+                    "google.longrunning.Operations.DeleteOperation",
+                    // { "delete": "/v1beta1/{name=operations/**}" }
+                    proto::ByteString.FromBase64("Kh0vdjFiZXRhMS97bmFtZT1vcGVyYXRpb25zLyoqfQ==")
+                },
+                {
+                    "google.longrunning.Operations.GetOperation",
+                    // { "get": "/v1beta1/{name=operations/**}" }
+                    proto::ByteString.FromBase64("Eh0vdjFiZXRhMS97bmFtZT1vcGVyYXRpb25zLyoqfQ==")
+                },
+                {
+                    "google.longrunning.Operations.ListOperations",
+                    // { "get": "/v1beta1/operations" }
+                    proto::ByteString.FromBase64("EhMvdjFiZXRhMS9vcGVyYXRpb25z")
+                },
+            });
 
         private static scg::IEnumerable<gpr::FileDescriptor> GetFileDescriptors()
         {
+            yield return gciv::IamPolicyReflection.Descriptor;
+            yield return gciv::OptionsReflection.Descriptor;
+            yield return gciv::PolicyReflection.Descriptor;
+            yield return gcl::LocationsReflection.Descriptor;
+            yield return lro::OperationsReflection.Descriptor;
             yield return ComplianceReflection.Descriptor;
             yield return EchoReflection.Descriptor;
             yield return IdentityReflection.Descriptor;

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/SequenceServiceClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/SequenceServiceClient.g.cs
@@ -17,6 +17,8 @@
 #pragma warning disable CS8981
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
+using gciv = Google.Cloud.Iam.V1;
+using gcl = Google.Cloud.Location;
 using proto = Google.Protobuf;
 using wkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
@@ -48,6 +50,8 @@ namespace Google.Showcase.V1Beta1
             CreateSequenceSettings = existing.CreateSequenceSettings;
             GetSequenceReportSettings = existing.GetSequenceReportSettings;
             AttemptSequenceSettings = existing.AttemptSequenceSettings;
+            LocationsSettings = existing.LocationsSettings;
+            IAMPolicySettings = existing.IAMPolicySettings;
             OnCopy(existing);
         }
 
@@ -88,6 +92,16 @@ namespace Google.Showcase.V1Beta1
         /// </list>
         /// </remarks>
         public gaxgrpc::CallSettings AttemptSequenceSettings { get; set; } = gaxgrpc::CallSettings.FromExpiration(gax::Expiration.None);
+
+        /// <summary>
+        /// The settings to use for the <see cref="gcl::LocationsClient"/> associated with the client.
+        /// </summary>
+        public gcl::LocationsSettings LocationsSettings { get; set; } = gcl::LocationsSettings.GetDefault();
+
+        /// <summary>
+        /// The settings to use for the <see cref="gciv::IAMPolicyClient"/> associated with the client.
+        /// </summary>
+        public gciv::IAMPolicySettings IAMPolicySettings { get; set; } = gciv::IAMPolicySettings.GetDefault();
 
         /// <summary>Creates a deep clone of this object, with all the same property values.</summary>
         /// <returns>A deep clone of this <see cref="SequenceServiceSettings"/> object.</returns>
@@ -219,6 +233,12 @@ namespace Google.Showcase.V1Beta1
 
         /// <summary>The underlying gRPC SequenceService client</summary>
         public virtual SequenceService.SequenceServiceClient GrpcClient => throw new sys::NotImplementedException();
+
+        /// <summary>The <see cref="gcl::LocationsClient"/> associated with this client.</summary>
+        public virtual gcl::LocationsClient LocationsClient => throw new sys::NotImplementedException();
+
+        /// <summary>The <see cref="gciv::IAMPolicyClient"/> associated with this client.</summary>
+        public virtual gciv::IAMPolicyClient IAMPolicyClient => throw new sys::NotImplementedException();
 
         /// <summary>
         /// Creates a sequence.
@@ -498,6 +518,8 @@ namespace Google.Showcase.V1Beta1
             GrpcClient = grpcClient;
             SequenceServiceSettings effectiveSettings = settings ?? SequenceServiceSettings.GetDefault();
             gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            LocationsClient = new gcl::LocationsClientImpl(grpcClient.CreateLocationsClient(), effectiveSettings.LocationsSettings, logger);
+            IAMPolicyClient = new gciv::IAMPolicyClientImpl(grpcClient.CreateIAMPolicyClient(), effectiveSettings.IAMPolicySettings, logger);
             _callCreateSequence = clientHelper.BuildApiCall<CreateSequenceRequest, Sequence>("CreateSequence", grpcClient.CreateSequenceAsync, grpcClient.CreateSequence, effectiveSettings.CreateSequenceSettings);
             Modify_ApiCall(ref _callCreateSequence);
             Modify_CreateSequenceApiCall(ref _callCreateSequence);
@@ -522,6 +544,12 @@ namespace Google.Showcase.V1Beta1
 
         /// <summary>The underlying gRPC SequenceService client</summary>
         public override SequenceService.SequenceServiceClient GrpcClient { get; }
+
+        /// <summary>The <see cref="gcl::LocationsClient"/> associated with this client.</summary>
+        public override gcl::LocationsClient LocationsClient { get; }
+
+        /// <summary>The <see cref="gciv::IAMPolicyClient"/> associated with this client.</summary>
+        public override gciv::IAMPolicyClient IAMPolicyClient { get; }
 
         partial void Modify_CreateSequenceRequest(ref CreateSequenceRequest request, ref gaxgrpc::CallSettings settings);
 
@@ -599,6 +627,32 @@ namespace Google.Showcase.V1Beta1
         {
             Modify_AttemptSequenceRequest(ref request, ref callSettings);
             return _callAttemptSequence.Async(request, callSettings);
+        }
+    }
+
+    public static partial class SequenceService
+    {
+        public partial class SequenceServiceClient
+        {
+            /// <summary>
+            /// Creates a new instance of <see cref="gcl::Locations.LocationsClient"/> using the same call invoker as
+            /// this client.
+            /// </summary>
+            /// <returns>
+            /// A new <see cref="gcl::Locations.LocationsClient"/> for the same target as this client.
+            /// </returns>
+            public virtual gcl::Locations.LocationsClient CreateLocationsClient() =>
+                new gcl::Locations.LocationsClient(CallInvoker);
+
+            /// <summary>
+            /// Creates a new instance of <see cref="gciv::IAMPolicy.IAMPolicyClient"/> using the same call invoker as
+            /// this client.
+            /// </summary>
+            /// <returns>
+            /// A new <see cref="gciv::IAMPolicy.IAMPolicyClient"/> for the same target as this client.
+            /// </returns>
+            public virtual gciv::IAMPolicy.IAMPolicyClient CreateIAMPolicyClient() =>
+                new gciv::IAMPolicy.IAMPolicyClient(CallInvoker);
         }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -16,6 +16,10 @@
 
 #pragma warning disable CS8981
 using gaxgrpc = Google.Api.Gax.Grpc;
+using gciv = Google.Cloud.Iam.V1;
+using gcl = Google.Cloud.Location;
+using lro = Google.LongRunning;
+using proto = Google.Protobuf;
 using gpr = Google.Protobuf.Reflection;
 using gsv = Google.Showcase.V1Beta1;
 using sys = System;

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/TestingClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/TestingClient.g.cs
@@ -17,6 +17,8 @@
 #pragma warning disable CS8981
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
+using gciv = Google.Cloud.Iam.V1;
+using gcl = Google.Cloud.Location;
 using proto = Google.Protobuf;
 using wkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
@@ -54,6 +56,8 @@ namespace Google.Showcase.V1Beta1
             ListTestsSettings = existing.ListTestsSettings;
             DeleteTestSettings = existing.DeleteTestSettings;
             VerifyTestSettings = existing.VerifyTestSettings;
+            LocationsSettings = existing.LocationsSettings;
+            IAMPolicySettings = existing.IAMPolicySettings;
             OnCopy(existing);
         }
 
@@ -154,6 +158,16 @@ namespace Google.Showcase.V1Beta1
         /// </list>
         /// </remarks>
         public gaxgrpc::CallSettings VerifyTestSettings { get; set; } = gaxgrpc::CallSettings.FromExpiration(gax::Expiration.None);
+
+        /// <summary>
+        /// The settings to use for the <see cref="gcl::LocationsClient"/> associated with the client.
+        /// </summary>
+        public gcl::LocationsSettings LocationsSettings { get; set; } = gcl::LocationsSettings.GetDefault();
+
+        /// <summary>
+        /// The settings to use for the <see cref="gciv::IAMPolicyClient"/> associated with the client.
+        /// </summary>
+        public gciv::IAMPolicySettings IAMPolicySettings { get; set; } = gciv::IAMPolicySettings.GetDefault();
 
         /// <summary>Creates a deep clone of this object, with all the same property values.</summary>
         /// <returns>A deep clone of this <see cref="TestingSettings"/> object.</returns>
@@ -286,6 +300,12 @@ namespace Google.Showcase.V1Beta1
 
         /// <summary>The underlying gRPC Testing client</summary>
         public virtual Testing.TestingClient GrpcClient => throw new sys::NotImplementedException();
+
+        /// <summary>The <see cref="gcl::LocationsClient"/> associated with this client.</summary>
+        public virtual gcl::LocationsClient LocationsClient => throw new sys::NotImplementedException();
+
+        /// <summary>The <see cref="gciv::IAMPolicyClient"/> associated with this client.</summary>
+        public virtual gciv::IAMPolicyClient IAMPolicyClient => throw new sys::NotImplementedException();
 
         /// <summary>
         /// Creates a new testing session.
@@ -550,6 +570,8 @@ namespace Google.Showcase.V1Beta1
             GrpcClient = grpcClient;
             TestingSettings effectiveSettings = settings ?? TestingSettings.GetDefault();
             gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            LocationsClient = new gcl::LocationsClientImpl(grpcClient.CreateLocationsClient(), effectiveSettings.LocationsSettings, logger);
+            IAMPolicyClient = new gciv::IAMPolicyClientImpl(grpcClient.CreateIAMPolicyClient(), effectiveSettings.IAMPolicySettings, logger);
             _callCreateSession = clientHelper.BuildApiCall<CreateSessionRequest, Session>("CreateSession", grpcClient.CreateSessionAsync, grpcClient.CreateSession, effectiveSettings.CreateSessionSettings);
             Modify_ApiCall(ref _callCreateSession);
             Modify_CreateSessionApiCall(ref _callCreateSession);
@@ -599,6 +621,12 @@ namespace Google.Showcase.V1Beta1
 
         /// <summary>The underlying gRPC Testing client</summary>
         public override Testing.TestingClient GrpcClient { get; }
+
+        /// <summary>The <see cref="gcl::LocationsClient"/> associated with this client.</summary>
+        public override gcl::LocationsClient LocationsClient { get; }
+
+        /// <summary>The <see cref="gciv::IAMPolicyClient"/> associated with this client.</summary>
+        public override gciv::IAMPolicyClient IAMPolicyClient { get; }
 
         partial void Modify_CreateSessionRequest(ref CreateSessionRequest request, ref gaxgrpc::CallSettings settings);
 
@@ -851,5 +879,31 @@ namespace Google.Showcase.V1Beta1
         public scg::IEnumerator<Test> GetEnumerator() => Tests.GetEnumerator();
 
         sc::IEnumerator sc::IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    public static partial class Testing
+    {
+        public partial class TestingClient
+        {
+            /// <summary>
+            /// Creates a new instance of <see cref="gcl::Locations.LocationsClient"/> using the same call invoker as
+            /// this client.
+            /// </summary>
+            /// <returns>
+            /// A new <see cref="gcl::Locations.LocationsClient"/> for the same target as this client.
+            /// </returns>
+            public virtual gcl::Locations.LocationsClient CreateLocationsClient() =>
+                new gcl::Locations.LocationsClient(CallInvoker);
+
+            /// <summary>
+            /// Creates a new instance of <see cref="gciv::IAMPolicy.IAMPolicyClient"/> using the same call invoker as
+            /// this client.
+            /// </summary>
+            /// <returns>
+            /// A new <see cref="gciv::IAMPolicy.IAMPolicyClient"/> for the same target as this client.
+            /// </returns>
+            public virtual gciv::IAMPolicy.IAMPolicyClient CreateIAMPolicyClient() =>
+                new gciv::IAMPolicy.IAMPolicyClient(CallInvoker);
+        }
     }
 }

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/google/showcase/v1beta1/showcase_v1beta1.yaml
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/google/showcase/v1beta1/showcase_v1beta1.yaml
@@ -1,0 +1,84 @@
+﻿# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+type: google.api.Service
+config_version: 3
+name: showcase.googleapis.com
+title: Client Libraries Showcase API
+
+apis:
+- name: google.showcase.v1beta1.Compliance
+- name: google.showcase.v1beta1.Echo
+- name: google.showcase.v1beta1.Identity
+- name: google.showcase.v1beta1.Messaging
+- name: google.showcase.v1beta1.SequenceService
+- name: google.showcase.v1beta1.Testing
+# Mix-in services
+- name: 'google.cloud.location.Locations'
+- name: 'google.iam.v1.IAMPolicy'
+- name: 'google.longrunning.Operations'
+
+documentation:
+  summary: |-
+    Showcase represents both a model API and an integration testing surface for
+    client library generator consumption.
+backend:
+  rules:
+  - selector: 'google.cloud.location.Locations.*'
+    deadline: 60.0
+  - selector: 'google.iam.v1.IAMPolicy.*'
+    deadline: 60.0
+  - selector: 'google.longrunning.Operations.*'
+    deadline: 60.0
+    
+http:
+  rules:
+  - selector: google.cloud.location.Locations.ListLocations
+    get:  '/v1beta1/{name=projects/*}/locations'
+  - selector: google.cloud.location.Locations.GetLocation
+    get:  '/v1beta1/{name=projects/*/locations/*}'
+  - selector: google.iam.v1.IAMPolicy.SetIamPolicy
+    post: '/v1beta1/{resource=users/*}:setIamPolicy'
+    body: '*'
+    additional_bindings:
+    - post: '/v1beta1/{resource=rooms/*}:setIamPolicy'
+      body: '*'
+    - post: '/v1beta1/{resource=rooms/*/blurbs/*}:setIamPolicy'
+      body: '*'
+    - post: '/v1beta1/{resource=sequences/*}:setIamPolicy'
+      body: '*'
+  - selector: google.iam.v1.IAMPolicy.GetIamPolicy
+    get: '/v1beta1/{resource=users/*}:getIamPolicy'
+    additional_bindings:
+    - get: '/v1beta1/{resource=rooms/*}:getIamPolicy'
+    - get: '/v1beta1/{resource=rooms/*/blurbs/*}:getIamPolicy'
+    - get: '/v1beta1/{resource=sequences/*}:getIamPolicy'
+  - selector: google.iam.v1.IAMPolicy.TestIamPermissions
+    post: '/v1beta1/{resource=users/*}:testIamPermissions'
+    body: '*'
+    additional_bindings:
+    - post: '/v1beta1/{resource=rooms/*}:testIamPermissions'
+      body: '*'
+    - post: '/v1beta1/{resource=rooms/*/blurbs/*}:testIamPermissions'
+      body: '*'
+    - post: '/v1beta1/{resource=sequences/*}:testIamPermissions'
+      body: '*'
+  - selector: google.longrunning.Operations.ListOperations
+    get: '/v1beta1/operations'
+  - selector: google.longrunning.Operations.GetOperation
+    get: '/v1beta1/{name=operations/**}'
+  - selector: google.longrunning.Operations.DeleteOperation
+    delete: '/v1beta1/{name=operations/**}'
+  - selector: google.longrunning.Operations.CancelOperation
+    post: '/v1beta1/{name=operations/**}:cancel'

--- a/Google.Api.Generator.Utils/Formatting/WhitespaceFormatter.cs
+++ b/Google.Api.Generator.Utils/Formatting/WhitespaceFormatter.cs
@@ -86,7 +86,6 @@ namespace Google.Api.Generator.Utils.Formatting
         private SyntaxTriviaList FormatXmlDoc(SyntaxTriviaList trivList) =>
             XmlDocSplitter.Split(_indentTrivia, _maxLineLength, trivList);
 
-
         /// <summary>
         /// Format in code comments by prepending the current indent and appending a new line.
         /// Handles empty and blank space only trivia as well.
@@ -119,7 +118,7 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitCompilationUnit(CompilationUnitSyntax node)
         {
-            node = (CompilationUnitSyntax)base.VisitCompilationUnit(node);
+            node = (CompilationUnitSyntax) base.VisitCompilationUnit(node);
             node = node.WithMembers(List(node.Members.Take(1).Select(m =>
             {
                 // If there's not already a blank line before the namespace, then add one.
@@ -137,7 +136,7 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitUsingDirective(UsingDirectiveSyntax node)
         {
-            node = (UsingDirectiveSyntax)base.VisitUsingDirective(node);
+            node = (UsingDirectiveSyntax) base.VisitUsingDirective(node);
             node = HandleLeadingTrivia(node);
             node = node.WithUsingKeyword(node.UsingKeyword.WithTrailingSpace());
             node = node.WithSemicolonToken(node.SemicolonToken.WithTrailingNewLine());
@@ -146,7 +145,7 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitNameEquals(NameEqualsSyntax node)
         {
-            node = (NameEqualsSyntax)base.VisitNameEquals(node);
+            node = (NameEqualsSyntax) base.VisitNameEquals(node);
             node = node.WithEqualsToken(node.EqualsToken.WithLeadingSpace().WithTrailingSpace());
             return node;
         }
@@ -155,7 +154,7 @@ namespace Google.Api.Generator.Utils.Formatting
         {
             using (WithIndent())
             {
-                node = (NamespaceDeclarationSyntax)base.VisitNamespaceDeclaration(node);
+                node = (NamespaceDeclarationSyntax) base.VisitNamespaceDeclaration(node);
 
                 // If the trivia is not empty, it's probably the start region tag.
                 // We need to do this here to use the correct indent.
@@ -170,7 +169,7 @@ namespace Google.Api.Generator.Utils.Formatting
                 // If the trivia is not empty, it's probably the end region tag.
                 // We need to do this here to use the correct indent.
                 var innerBottomTrivia = node.CloseBraceToken.LeadingTrivia.SelectMany(FormatInCodeComment);
-                node = node.WithCloseBraceToken(node.CloseBraceToken.WithLeadingTrivia(innerBottomTrivia)) ;
+                node = node.WithCloseBraceToken(node.CloseBraceToken.WithLeadingTrivia(innerBottomTrivia));
             }
             node = HandleLeadingTrivia(node);
             node = node.WithNamespaceKeyword(node.NamespaceKeyword.WithTrailingSpace());
@@ -186,7 +185,7 @@ namespace Google.Api.Generator.Utils.Formatting
         {
             using (WithIndent())
             {
-                node = (ClassDeclarationSyntax)base.VisitClassDeclaration(node);
+                node = (ClassDeclarationSyntax) base.VisitClassDeclaration(node);
             }
             node = node.WithLeadingTrivia(FormatXmlDoc(node.GetLeadingTrivia()).Append(_indentTrivia));
             node = node.WithModifiers(TokenList(node.Modifiers.Select(m => m.WithTrailingSpace())));
@@ -201,7 +200,7 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitBaseList(BaseListSyntax node)
         {
-            node = (BaseListSyntax)base.VisitBaseList(node);
+            node = (BaseListSyntax) base.VisitBaseList(node);
             node = node.WithColonToken(node.ColonToken.WithLeadingSpace().WithTrailingSpace());
             node = node.WithTypes(SeparatedList(node.Types, CommaSpaces(node.Types.Count - 1)));
             return node;
@@ -209,7 +208,7 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
         {
-            node = (ConstructorDeclarationSyntax)base.VisitConstructorDeclaration(node);
+            node = (ConstructorDeclarationSyntax) base.VisitConstructorDeclaration(node);
             node = node.WithLeadingTrivia(FormatXmlDoc(node.GetLeadingTrivia()).Append(_indentTrivia));
             node = node.WithModifiers(TokenList(node.Modifiers.Select(m => m.WithTrailingSpace())));
             return node;
@@ -217,7 +216,7 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitConstructorInitializer(ConstructorInitializerSyntax node)
         {
-            node = (ConstructorInitializerSyntax)base.VisitConstructorInitializer(node);
+            node = (ConstructorInitializerSyntax) base.VisitConstructorInitializer(node);
             if (node.HasAnnotation(Annotations.LineBreakAnnotation))
             {
                 using (WithIndent())

--- a/Google.Api.Generator.Utils/Roslyn/RoslynExtensions.cs
+++ b/Google.Api.Generator.Utils/Roslyn/RoslynExtensions.cs
@@ -129,6 +129,21 @@ namespace Google.Api.Generator.Utils.Roslyn
                 }))));
         }
 
+        public static ObjectCreationExpressionSyntax WithCollectionInitializer(
+            this ObjectCreationExpressionSyntax obj, params object[] inits)
+        {
+            if (!obj.ArgumentList.Arguments.Any())
+            {
+                // If calling the parameterless ctor, recreate the `new` expression without an argument list.
+                obj = ObjectCreationExpression(obj.Type);
+            }
+            return obj.WithInitializer(InitializerExpression(SyntaxKind.CollectionInitializerExpression,
+                SeparatedList(inits.Select(init =>
+                    init is object[] sublist
+                    ? InitializerExpression(SyntaxKind.ComplexElementInitializerExpression, SeparatedList(sublist.Select(ToExpression)))
+                    : ToExpression(init)))));
+        }
+
         public static PropertyDeclarationSyntax WithInitializer(this PropertyDeclarationSyntax prop, object code) =>
             prop.WithInitializer(EqualsValueClause(ToExpression(code))).WithSemicolonToken(s_semicolonToken);
 

--- a/Google.Api.Generator/CodeGenerator.cs
+++ b/Google.Api.Generator/CodeGenerator.cs
@@ -308,7 +308,7 @@ namespace Google.Api.Generator
 
                     // Generate the package-wide API metadata
                     var ctx = SourceFileContext.CreateFullyAliased(clock, s_wellknownNamespaceAliases);
-                    var packageApiMetadataContent = PackageApiMetadataGenerator.GeneratePackageApiMetadata(ns, ctx, packageFileDescriptors, hasLro, mixins, requestNumericEnumJsonEncoding);
+                    var packageApiMetadataContent = PackageApiMetadataGenerator.GeneratePackageApiMetadata(ns, ctx, packageFileDescriptors, hasLro, mixins, serviceConfig, requestNumericEnumJsonEncoding);
                     var packageApiMetadataFilename = $"{clientPathPrefix}{PackageApiMetadataGenerator.FileName}";
                     yield return new ResultFile(packageApiMetadataFilename, packageApiMetadataContent);
 

--- a/Google.Api.Generator/CodeGenerator.cs
+++ b/Google.Api.Generator/CodeGenerator.cs
@@ -308,7 +308,7 @@ namespace Google.Api.Generator
 
                     // Generate the package-wide API metadata
                     var ctx = SourceFileContext.CreateFullyAliased(clock, s_wellknownNamespaceAliases);
-                    var packageApiMetadataContent = PackageApiMetadataGenerator.GeneratePackageApiMetadata(ns, ctx, packageFileDescriptors, requestNumericEnumJsonEncoding);
+                    var packageApiMetadataContent = PackageApiMetadataGenerator.GeneratePackageApiMetadata(ns, ctx, packageFileDescriptors, hasLro, mixins, requestNumericEnumJsonEncoding);
                     var packageApiMetadataFilename = $"{clientPathPrefix}{PackageApiMetadataGenerator.FileName}";
                     yield return new ResultFile(packageApiMetadataFilename, packageApiMetadataContent);
 

--- a/Google.Api.Generator/Generation/PackageApiMetadataGenerator.cs
+++ b/Google.Api.Generator/Generation/PackageApiMetadataGenerator.cs
@@ -64,7 +64,8 @@ namespace Google.Api.Generator.Generation
             ExpressionSyntax initializer = New(apiMetadataType)(ns, IdentifierName(fileDescriptorMethod.Identifier));
             if (requestNumericEnumJsonEncoding)
             {
-                initializer = initializer.Call(nameof(ApiMetadata.WithRequestNumericEnumJsonEncoding))(true);
+                var invocation = initializer.Call(nameof(ApiMetadata.WithRequestNumericEnumJsonEncoding))(true);
+                initializer = invocation.WithExpression(invocation.Expression.WithAdditionalAnnotations(Annotations.LineBreakAnnotation));
             }
             var property = AutoProperty(Internal | Static, apiMetadataType, PropertyName)
                 .WithInitializer(initializer)

--- a/Google.Api.Generator/Google.Api.Generator.csproj
+++ b/Google.Api.Generator/Google.Api.Generator.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Google.Api.CommonProtos" Version="2.6.0" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="4.2.0-alpha01" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="4.2.0-alpha05" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="3.0.0" />
     <PackageReference Include="Google.Cloud.Location" Version="2.0.0" />
     <PackageReference Include="Google.LongRunning" Version="3.0.0" />


### PR DESCRIPTION
This requires two overall changes, both to PackageApiMetadata

- Include mix-in file descriptors in the list of descriptors for RestGrpcAdapter to use
- Expose HttpRule overrides from the service config (for mix-ins)

The latter requires https://github.com/googleapis/gax-dotnet/pull/616 to be merged, released, and then the project file updated (hence why this PR fails to build right now).
