### PR TITLE
feat: Use new language-specific settings in service config YAML

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTest.cs
+++ b/Google.Api.Generator.Tests/ProtoTest.cs
@@ -276,6 +276,15 @@ namespace Google.Api.Generator.Tests
             ignoreSnippets: true,
             ignoreApiMetadataFile: false);
 
+        [Fact]
+        public void PublishingSettings() => ProtoTestSingle(
+            new[] { "PublishingSettings", "CommonResourceDef" },
+            ignoreCsProj: true, serviceConfigPath: "ServiceConfig.yaml",
+            commonResourcesConfigPaths: new[]
+            {
+                Path.Combine(Invoker.GeneratorTestsDir, "ProtoTests", "PublishingSettings", "CommonResourceConfig.json")
+            });
+
         // Build tests are testing `csproj` file generation only.
         // All other generated code is effectively "build tested" when this test project is built.
 

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/CommonResourceConfig.json
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/CommonResourceConfig.json
@@ -1,0 +1,16 @@
+﻿{
+  "common_resources": [
+    {
+      "type": "commonresource.example.com/Project",
+      "csharp_package_name": "Common.Package",
+      "csharp_namespace": "PublishingSettingsCommon.Namespace",
+      "csharp_class_name":  "CommonProjectName"
+    },
+    {
+      "type": "commonresource.example.com/Location",
+      "csharp_package_name": "Common.Package",
+      "csharp_namespace": "PublishingSettingsCommon.Namespace",
+      "csharp_class_name":  "CommonLocationName"
+    }
+  ]
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/CommonResourceDef.proto
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/CommonResourceDef.proto
@@ -1,0 +1,19 @@
+﻿syntax = "proto3";
+
+// In different package; so no classes (resource-name or partial) will be generated.
+package testing.publishingsettings.def;
+
+option csharp_namespace = "Testing.PublishingSettingsCommonResource.Def";
+
+import "google/api/resource.proto";
+
+// These are also defined as common resources in CommonResourceConfig.json
+option (google.api.resource_definition) = {
+  type: "commonresource.example.com/Project",
+  pattern: "projects/{project}"
+};
+
+option (google.api.resource_definition) = {
+  type: "commonresource.example.com/Location",
+  pattern: "projects/{project}/locations/{location}"
+};

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/CommonResourceFakes.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/CommonResourceFakes.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace PublishingSettingsCommon.Namespace;
+
+public class CommonProjectName
+{
+    public static CommonProjectName Parse(string s, bool allowUnparsed = false) => throw new NotImplementedException();
+}
+
+public class CommonLocationName
+{
+    public static CommonLocationName Parse(string s, bool allowUnparsed = false) => throw new NotImplementedException();
+
+    public static CommonLocationName FromProjectLocation(string project, string location) => throw new NotImplementedException();
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/PublishingSettings.proto
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/PublishingSettings.proto
@@ -1,0 +1,69 @@
+﻿syntax = "proto3";
+
+package testing.publishingsettings;
+
+option csharp_namespace = "Testing.PublishingSettings";
+
+import "google/api/client.proto";
+import "google/api/resource.proto";
+import "google/api/field_behavior.proto";
+import "google/protobuf/wrappers.proto";
+
+// This is a resource definition we'll rename.
+option (google.api.resource_definition) = {
+  type: "test.googleapis.com/OriginalDatabase"
+  pattern: "databases/{database}"
+};
+
+// This is a resource definition we'll ignore, using the common one instead.
+option (google.api.resource_definition) = {
+  type: "test.googleapis.com/Location"
+  pattern: "projects/{project}/locations/{location}"
+};
+
+// This is a service we expect to be renamed.
+service OriginalServiceName {
+  // Test summary text for AMethod
+  rpc AMethod(Request) returns(Response);
+}
+
+// This is a service with a handwritten signature.
+service ServiceWithHandwrittenSignatures {
+  // Test summary text for AMethod
+  rpc AMethod(Request) returns (Response) {
+    option (google.api.method_signature) = "string_1"; // This has a hand-written equivalent
+    option (google.api.method_signature) = "string_1,string_2";
+  }
+}
+
+// This is a service using resources.
+service ServiceWithResources {
+  // Test summary text for AMethod
+  rpc AMethod(ResourceRequest) returns (Resource);
+}
+
+message Request {
+  string string_1 = 1;
+  string string_2 = 2;
+}
+
+message Response {
+}
+
+message ResourceRequest {
+  string parent = 1 [
+    (google.api.resource_reference) = { child_type: "test.googleapis.com/Resource" }
+  ];
+
+  string database = 2 [
+    (google.api.resource_reference) = { type: "test.googleapis.com/OriginalDatabase" }
+  ];
+}
+
+message Resource {
+  option (google.api.resource) = {
+    type: "test.googleapis.com/Resource"
+    pattern: "projects/{project}/locations/{location}/resources/{resource}"
+  };
+  string name = 1;
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/PublishingSettingsFakes.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/PublishingSettingsFakes.cs
@@ -1,0 +1,105 @@
+﻿// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax.Grpc;
+using Google.Protobuf.Reflection;
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+// Disable warning: Missing XML comment on public members.
+// Required to successfully build this generated test project.
+#pragma warning disable 1591
+
+namespace Testing.PublishingSettings;
+
+public static class PublishingSettingsReflection
+{
+    public static FileDescriptor Descriptor => null;
+}
+
+public class OriginalServiceName
+{
+    public static ServiceDescriptor Descriptor => null;
+
+    // Fake gRPC client
+    public class OriginalServiceNameClient
+    {
+        public OriginalServiceNameClient() { }
+        public OriginalServiceNameClient(CallInvoker callInvoker) { }
+        public virtual AsyncUnaryCall<Response> AMethodAsync(Request request, CallOptions options) => throw new NotImplementedException();
+        public virtual Response AMethod(Request request, CallOptions options) => throw new NotImplementedException();
+        public virtual AsyncUnaryCall<Empty> VoidMethodAsync(Request request, CallOptions options) => throw new NotImplementedException();
+        public virtual Empty VoidMethod(Request request, CallOptions options) => throw new NotImplementedException();
+    }
+}
+
+public class ServiceWithHandwrittenSignatures
+{
+    public static ServiceDescriptor Descriptor => null;
+
+    // Fake gRPC client
+    public class ServiceWithHandwrittenSignaturesClient
+    {
+        public ServiceWithHandwrittenSignaturesClient() { }
+        public ServiceWithHandwrittenSignaturesClient(CallInvoker callInvoker) { }
+        public virtual AsyncUnaryCall<Response> AMethodAsync(Request request, CallOptions options) => throw new NotImplementedException();
+        public virtual Response AMethod(Request request, CallOptions options) => throw new NotImplementedException();
+        public virtual AsyncUnaryCall<Empty> VoidMethodAsync(Request request, CallOptions options) => throw new NotImplementedException();
+        public virtual Empty VoidMethod(Request request, CallOptions options) => throw new NotImplementedException();
+    }
+}
+
+public class ServiceWithResources
+{
+    public static ServiceDescriptor Descriptor => null;
+
+    // Fake gRPC client
+    public class ServiceWithResourcesClient
+    {
+        public ServiceWithResourcesClient() { }
+        public ServiceWithResourcesClient(CallInvoker callInvoker) { }
+        public virtual AsyncUnaryCall<Resource> AMethodAsync(ResourceRequest request, CallOptions options) => throw new NotImplementedException();
+        public virtual Resource AMethod(ResourceRequest request, CallOptions options) => throw new NotImplementedException();
+    }
+}
+
+public partial class ServiceWithHandwrittenSignaturesClient
+{
+    // This is the hand-written method we're deliberately not generating
+    public Response AMethod(string string1) => throw new NotImplementedException();
+    public Task<Response> AMethodAsync(string string1, CallSettings callSettings = null) => throw new NotImplementedException();
+    public Task<Response> AMethodAsync(string string1, CancellationToken cancellationToken) => throw new NotImplementedException();
+}
+
+public class Request : ProtoMsgFake<Request>
+{
+    public string String1 { get; set; }
+    public string String2 { get; set; }
+}
+
+public class Response : ProtoMsgFake<Response> { }
+
+public partial class ResourceRequest : ProtoMsgFake<ResourceRequest>
+{
+    public string Parent { get; set; }
+    public string Database { get; set; }
+}
+
+public partial class Resource : ProtoMsgFake<Resource>
+{
+    public string Name { get; set; }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/ServiceConfig.yaml
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/ServiceConfig.yaml
@@ -1,0 +1,22 @@
+﻿type: google.api.Service
+config_version: 3
+name: test.googleapis.com
+title: Client Libraries Showcase API
+
+apis:
+- name: testing.publishingsettings.OriginalServiceName
+- name: testing.publishingsettings.ServiceWithHandwrittenSignatures
+- name: testing.publishingsettings.ServiceWithResources
+
+publishing:
+  librarySettings:
+  - version: testing.publishingsettings
+    dotnetSettings:
+      ignored_resources:
+      - test.googleapis.com/Location
+      renamed_resources:
+        test.googleapis.com/OriginalDatabase: RenamedDatabase
+      handwritten_signatures:
+      - "ServiceWithHandwrittenSignatures.AMethod(string_1)"
+      renamed_services:
+        OriginalServiceName: RenamedServiceName

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/RenamedServiceNameClient.AMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/RenamedServiceNameClient.AMethodRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,48 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.PublishingSettings.Snippets
+{
+    // [START unknown_generated_OriginalServiceName_AMethod_async]
+    using System.Threading.Tasks;
+    using Testing.PublishingSettings;
+
+    public sealed partial class GeneratedRenamedServiceNameClientSnippets
+    {
+        /// <summary>Snippet for AMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated and should be regarded as a code template only.
+        /// It will require modifications to work:
+        /// - It may require correct/in-range values for request initialization.
+        /// - It may require specifying regional endpoints when creating the service client as shown in
+        ///   https://cloud.google.com/dotnet/docs/reference/help/client-configuration#endpoint.
+        /// </remarks>
+        public async Task AMethodRequestObjectAsync()
+        {
+            // Create client
+            RenamedServiceNameClient renamedServiceNameClient = await RenamedServiceNameClient.CreateAsync();
+            // Initialize request argument(s)
+            Request request = new Request
+            {
+                String1 = "",
+                String2 = "",
+            };
+            // Make the request
+            Response response = await renamedServiceNameClient.AMethodAsync(request);
+        }
+    }
+    // [END unknown_generated_OriginalServiceName_AMethod_async]
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/RenamedServiceNameClient.AMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/RenamedServiceNameClient.AMethodRequestObjectSnippet.g.cs
@@ -1,0 +1,47 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.PublishingSettings.Snippets
+{
+    // [START unknown_generated_OriginalServiceName_AMethod_sync]
+    using Testing.PublishingSettings;
+
+    public sealed partial class GeneratedRenamedServiceNameClientSnippets
+    {
+        /// <summary>Snippet for AMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated and should be regarded as a code template only.
+        /// It will require modifications to work:
+        /// - It may require correct/in-range values for request initialization.
+        /// - It may require specifying regional endpoints when creating the service client as shown in
+        ///   https://cloud.google.com/dotnet/docs/reference/help/client-configuration#endpoint.
+        /// </remarks>
+        public void AMethodRequestObject()
+        {
+            // Create client
+            RenamedServiceNameClient renamedServiceNameClient = RenamedServiceNameClient.Create();
+            // Initialize request argument(s)
+            Request request = new Request
+            {
+                String1 = "",
+                String2 = "",
+            };
+            // Make the request
+            Response response = renamedServiceNameClient.AMethod(request);
+        }
+    }
+    // [END unknown_generated_OriginalServiceName_AMethod_sync]
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithHandwrittenSignaturesClient.AMethod1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithHandwrittenSignaturesClient.AMethod1AsyncSnippet.g.cs
@@ -1,0 +1,44 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.PublishingSettings.Snippets
+{
+    // [START unknown_generated_ServiceWithHandwrittenSignatures_AMethod_async_flattened1]
+    using System.Threading.Tasks;
+    using Testing.PublishingSettings;
+
+    public sealed partial class GeneratedServiceWithHandwrittenSignaturesClientSnippets
+    {
+        /// <summary>Snippet for AMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated and should be regarded as a code template only.
+        /// It will require modifications to work:
+        /// - It may require correct/in-range values for request initialization.
+        /// - It may require specifying regional endpoints when creating the service client as shown in
+        ///   https://cloud.google.com/dotnet/docs/reference/help/client-configuration#endpoint.
+        /// </remarks>
+        public async Task AMethod1Async()
+        {
+            // Create client
+            ServiceWithHandwrittenSignaturesClient serviceWithHandwrittenSignaturesClient = await ServiceWithHandwrittenSignaturesClient.CreateAsync();
+            // Initialize request argument(s)
+            string string1 = "";
+            // Make the request
+            Response response = await serviceWithHandwrittenSignaturesClient.AMethodAsync(string1);
+        }
+    }
+    // [END unknown_generated_ServiceWithHandwrittenSignatures_AMethod_async_flattened1]
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithHandwrittenSignaturesClient.AMethod1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithHandwrittenSignaturesClient.AMethod1Snippet.g.cs
@@ -1,0 +1,43 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.PublishingSettings.Snippets
+{
+    // [START unknown_generated_ServiceWithHandwrittenSignatures_AMethod_sync_flattened1]
+    using Testing.PublishingSettings;
+
+    public sealed partial class GeneratedServiceWithHandwrittenSignaturesClientSnippets
+    {
+        /// <summary>Snippet for AMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated and should be regarded as a code template only.
+        /// It will require modifications to work:
+        /// - It may require correct/in-range values for request initialization.
+        /// - It may require specifying regional endpoints when creating the service client as shown in
+        ///   https://cloud.google.com/dotnet/docs/reference/help/client-configuration#endpoint.
+        /// </remarks>
+        public void AMethod1()
+        {
+            // Create client
+            ServiceWithHandwrittenSignaturesClient serviceWithHandwrittenSignaturesClient = ServiceWithHandwrittenSignaturesClient.Create();
+            // Initialize request argument(s)
+            string string1 = "";
+            // Make the request
+            Response response = serviceWithHandwrittenSignaturesClient.AMethod(string1);
+        }
+    }
+    // [END unknown_generated_ServiceWithHandwrittenSignatures_AMethod_sync_flattened1]
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithHandwrittenSignaturesClient.AMethod2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithHandwrittenSignaturesClient.AMethod2AsyncSnippet.g.cs
@@ -1,0 +1,45 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.PublishingSettings.Snippets
+{
+    // [START unknown_generated_ServiceWithHandwrittenSignatures_AMethod_async_flattened2]
+    using System.Threading.Tasks;
+    using Testing.PublishingSettings;
+
+    public sealed partial class GeneratedServiceWithHandwrittenSignaturesClientSnippets
+    {
+        /// <summary>Snippet for AMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated and should be regarded as a code template only.
+        /// It will require modifications to work:
+        /// - It may require correct/in-range values for request initialization.
+        /// - It may require specifying regional endpoints when creating the service client as shown in
+        ///   https://cloud.google.com/dotnet/docs/reference/help/client-configuration#endpoint.
+        /// </remarks>
+        public async Task AMethod2Async()
+        {
+            // Create client
+            ServiceWithHandwrittenSignaturesClient serviceWithHandwrittenSignaturesClient = await ServiceWithHandwrittenSignaturesClient.CreateAsync();
+            // Initialize request argument(s)
+            string string1 = "";
+            string string2 = "";
+            // Make the request
+            Response response = await serviceWithHandwrittenSignaturesClient.AMethodAsync(string1, string2);
+        }
+    }
+    // [END unknown_generated_ServiceWithHandwrittenSignatures_AMethod_async_flattened2]
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithHandwrittenSignaturesClient.AMethod2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithHandwrittenSignaturesClient.AMethod2Snippet.g.cs
@@ -1,0 +1,44 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.PublishingSettings.Snippets
+{
+    // [START unknown_generated_ServiceWithHandwrittenSignatures_AMethod_sync_flattened2]
+    using Testing.PublishingSettings;
+
+    public sealed partial class GeneratedServiceWithHandwrittenSignaturesClientSnippets
+    {
+        /// <summary>Snippet for AMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated and should be regarded as a code template only.
+        /// It will require modifications to work:
+        /// - It may require correct/in-range values for request initialization.
+        /// - It may require specifying regional endpoints when creating the service client as shown in
+        ///   https://cloud.google.com/dotnet/docs/reference/help/client-configuration#endpoint.
+        /// </remarks>
+        public void AMethod2()
+        {
+            // Create client
+            ServiceWithHandwrittenSignaturesClient serviceWithHandwrittenSignaturesClient = ServiceWithHandwrittenSignaturesClient.Create();
+            // Initialize request argument(s)
+            string string1 = "";
+            string string2 = "";
+            // Make the request
+            Response response = serviceWithHandwrittenSignaturesClient.AMethod(string1, string2);
+        }
+    }
+    // [END unknown_generated_ServiceWithHandwrittenSignatures_AMethod_sync_flattened2]
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithHandwrittenSignaturesClient.AMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithHandwrittenSignaturesClient.AMethodRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,48 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.PublishingSettings.Snippets
+{
+    // [START unknown_generated_ServiceWithHandwrittenSignatures_AMethod_async]
+    using System.Threading.Tasks;
+    using Testing.PublishingSettings;
+
+    public sealed partial class GeneratedServiceWithHandwrittenSignaturesClientSnippets
+    {
+        /// <summary>Snippet for AMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated and should be regarded as a code template only.
+        /// It will require modifications to work:
+        /// - It may require correct/in-range values for request initialization.
+        /// - It may require specifying regional endpoints when creating the service client as shown in
+        ///   https://cloud.google.com/dotnet/docs/reference/help/client-configuration#endpoint.
+        /// </remarks>
+        public async Task AMethodRequestObjectAsync()
+        {
+            // Create client
+            ServiceWithHandwrittenSignaturesClient serviceWithHandwrittenSignaturesClient = await ServiceWithHandwrittenSignaturesClient.CreateAsync();
+            // Initialize request argument(s)
+            Request request = new Request
+            {
+                String1 = "",
+                String2 = "",
+            };
+            // Make the request
+            Response response = await serviceWithHandwrittenSignaturesClient.AMethodAsync(request);
+        }
+    }
+    // [END unknown_generated_ServiceWithHandwrittenSignatures_AMethod_async]
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithHandwrittenSignaturesClient.AMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithHandwrittenSignaturesClient.AMethodRequestObjectSnippet.g.cs
@@ -1,0 +1,47 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.PublishingSettings.Snippets
+{
+    // [START unknown_generated_ServiceWithHandwrittenSignatures_AMethod_sync]
+    using Testing.PublishingSettings;
+
+    public sealed partial class GeneratedServiceWithHandwrittenSignaturesClientSnippets
+    {
+        /// <summary>Snippet for AMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated and should be regarded as a code template only.
+        /// It will require modifications to work:
+        /// - It may require correct/in-range values for request initialization.
+        /// - It may require specifying regional endpoints when creating the service client as shown in
+        ///   https://cloud.google.com/dotnet/docs/reference/help/client-configuration#endpoint.
+        /// </remarks>
+        public void AMethodRequestObject()
+        {
+            // Create client
+            ServiceWithHandwrittenSignaturesClient serviceWithHandwrittenSignaturesClient = ServiceWithHandwrittenSignaturesClient.Create();
+            // Initialize request argument(s)
+            Request request = new Request
+            {
+                String1 = "",
+                String2 = "",
+            };
+            // Make the request
+            Response response = serviceWithHandwrittenSignaturesClient.AMethod(request);
+        }
+    }
+    // [END unknown_generated_ServiceWithHandwrittenSignatures_AMethod_sync]
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithResourcesClient.AMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithResourcesClient.AMethodRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,49 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.PublishingSettings.Snippets
+{
+    // [START unknown_generated_ServiceWithResources_AMethod_async]
+    using PublishingSettingsCommon.Namespace;
+    using System.Threading.Tasks;
+    using Testing.PublishingSettings;
+
+    public sealed partial class GeneratedServiceWithResourcesClientSnippets
+    {
+        /// <summary>Snippet for AMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated and should be regarded as a code template only.
+        /// It will require modifications to work:
+        /// - It may require correct/in-range values for request initialization.
+        /// - It may require specifying regional endpoints when creating the service client as shown in
+        ///   https://cloud.google.com/dotnet/docs/reference/help/client-configuration#endpoint.
+        /// </remarks>
+        public async Task AMethodRequestObjectAsync()
+        {
+            // Create client
+            ServiceWithResourcesClient serviceWithResourcesClient = await ServiceWithResourcesClient.CreateAsync();
+            // Initialize request argument(s)
+            ResourceRequest request = new ResourceRequest
+            {
+                ParentAsCommonLocationName = CommonLocationName.FromProjectLocation("[PROJECT]", "[LOCATION]"),
+                DatabaseAsRenamedDatabaseName = RenamedDatabaseName.FromDatabase("[DATABASE]"),
+            };
+            // Make the request
+            Resource response = await serviceWithResourcesClient.AMethodAsync(request);
+        }
+    }
+    // [END unknown_generated_ServiceWithResources_AMethod_async]
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithResourcesClient.AMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithResourcesClient.AMethodRequestObjectSnippet.g.cs
@@ -1,0 +1,48 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.PublishingSettings.Snippets
+{
+    // [START unknown_generated_ServiceWithResources_AMethod_sync]
+    using PublishingSettingsCommon.Namespace;
+    using Testing.PublishingSettings;
+
+    public sealed partial class GeneratedServiceWithResourcesClientSnippets
+    {
+        /// <summary>Snippet for AMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated and should be regarded as a code template only.
+        /// It will require modifications to work:
+        /// - It may require correct/in-range values for request initialization.
+        /// - It may require specifying regional endpoints when creating the service client as shown in
+        ///   https://cloud.google.com/dotnet/docs/reference/help/client-configuration#endpoint.
+        /// </remarks>
+        public void AMethodRequestObject()
+        {
+            // Create client
+            ServiceWithResourcesClient serviceWithResourcesClient = ServiceWithResourcesClient.Create();
+            // Initialize request argument(s)
+            ResourceRequest request = new ResourceRequest
+            {
+                ParentAsCommonLocationName = CommonLocationName.FromProjectLocation("[PROJECT]", "[LOCATION]"),
+                DatabaseAsRenamedDatabaseName = RenamedDatabaseName.FromDatabase("[DATABASE]"),
+            };
+            // Make the request
+            Resource response = serviceWithResourcesClient.AMethod(request);
+        }
+    }
+    // [END unknown_generated_ServiceWithResources_AMethod_sync]
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/Testing.PublishingSettings.GeneratedSnippets.csproj
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/Testing.PublishingSettings.GeneratedSnippets.csproj
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net462</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Testing.PublishingSettings/Testing.PublishingSettings.csproj" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
+  </ItemGroup>
+
+</Project>

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/snippet_metadata_testing.publishingsettings.json
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/snippet_metadata_testing.publishingsettings.json
@@ -1,0 +1,502 @@
+{
+  "clientLibrary": {
+    "name": "Testing.PublishingSettings",
+    "language": "C_SHARP",
+    "apis": [
+      {
+        "id": "testing.publishingsettings"
+      }
+    ]
+  },
+  "snippets": [
+    {
+      "regionTag": "unknown_generated_OriginalServiceName_AMethod_sync",
+      "title": "AMethodRequestObject",
+      "description": "Snippet for AMethod",
+      "file": "RenamedServiceNameClient.AMethodRequestObjectSnippet.g.cs",
+      "language": "C_SHARP",
+      "clientMethod": {
+        "shortName": "AMethod",
+        "fullName": "Testing.PublishingSettings.RenamedServiceNameClient.AMethod",
+        "parameters": [
+          {
+            "type": "Testing.PublishingSettings.Request",
+            "name": "request"
+          },
+          {
+            "type": "Google.Api.Gax.Grpc.CallSettings",
+            "name": "callSettings"
+          }
+        ],
+        "resultType": "Testing.PublishingSettings.Response",
+        "client": {
+          "shortName": "RenamedServiceNameClient",
+          "fullName": "Testing.PublishingSettings.RenamedServiceNameClient"
+        },
+        "method": {
+          "shortName": "AMethod",
+          "fullName": "testing.publishingsettings.OriginalServiceName.AMethod",
+          "service": {
+            "shortName": "OriginalServiceName",
+            "fullName": "testing.publishingsettings.OriginalServiceName"
+          }
+        }
+      },
+      "canonical": true,
+      "origin": "API_DEFINITION",
+      "segments": [
+        {
+          "start": 20,
+          "end": 45,
+          "type": "FULL"
+        },
+        {
+          "start": 34,
+          "end": 43,
+          "type": "SHORT"
+        }
+      ]
+    },
+    {
+      "regionTag": "unknown_generated_OriginalServiceName_AMethod_async",
+      "title": "AMethodRequestObjectAsync",
+      "description": "Snippet for AMethodAsync",
+      "file": "RenamedServiceNameClient.AMethodRequestObjectAsyncSnippet.g.cs",
+      "language": "C_SHARP",
+      "clientMethod": {
+        "shortName": "AMethodAsync",
+        "fullName": "Testing.PublishingSettings.RenamedServiceNameClient.AMethodAsync",
+        "async": true,
+        "parameters": [
+          {
+            "type": "Testing.PublishingSettings.Request",
+            "name": "request"
+          },
+          {
+            "type": "Google.Api.Gax.Grpc.CallSettings",
+            "name": "callSettings"
+          }
+        ],
+        "resultType": "System.Threading.Tasks.Task<Testing.PublishingSettings.Response>",
+        "client": {
+          "shortName": "RenamedServiceNameClient",
+          "fullName": "Testing.PublishingSettings.RenamedServiceNameClient"
+        },
+        "method": {
+          "shortName": "AMethod",
+          "fullName": "testing.publishingsettings.OriginalServiceName.AMethod",
+          "service": {
+            "shortName": "OriginalServiceName",
+            "fullName": "testing.publishingsettings.OriginalServiceName"
+          }
+        }
+      },
+      "canonical": true,
+      "origin": "API_DEFINITION",
+      "segments": [
+        {
+          "start": 20,
+          "end": 46,
+          "type": "FULL"
+        },
+        {
+          "start": 35,
+          "end": 44,
+          "type": "SHORT"
+        }
+      ]
+    },
+    {
+      "regionTag": "unknown_generated_ServiceWithHandwrittenSignatures_AMethod_sync",
+      "title": "AMethodRequestObject",
+      "description": "Snippet for AMethod",
+      "file": "ServiceWithHandwrittenSignaturesClient.AMethodRequestObjectSnippet.g.cs",
+      "language": "C_SHARP",
+      "clientMethod": {
+        "shortName": "AMethod",
+        "fullName": "Testing.PublishingSettings.ServiceWithHandwrittenSignaturesClient.AMethod",
+        "parameters": [
+          {
+            "type": "Testing.PublishingSettings.Request",
+            "name": "request"
+          },
+          {
+            "type": "Google.Api.Gax.Grpc.CallSettings",
+            "name": "callSettings"
+          }
+        ],
+        "resultType": "Testing.PublishingSettings.Response",
+        "client": {
+          "shortName": "ServiceWithHandwrittenSignaturesClient",
+          "fullName": "Testing.PublishingSettings.ServiceWithHandwrittenSignaturesClient"
+        },
+        "method": {
+          "shortName": "AMethod",
+          "fullName": "testing.publishingsettings.ServiceWithHandwrittenSignatures.AMethod",
+          "service": {
+            "shortName": "ServiceWithHandwrittenSignatures",
+            "fullName": "testing.publishingsettings.ServiceWithHandwrittenSignatures"
+          }
+        }
+      },
+      "canonical": true,
+      "origin": "API_DEFINITION",
+      "segments": [
+        {
+          "start": 20,
+          "end": 45,
+          "type": "FULL"
+        },
+        {
+          "start": 34,
+          "end": 43,
+          "type": "SHORT"
+        }
+      ]
+    },
+    {
+      "regionTag": "unknown_generated_ServiceWithHandwrittenSignatures_AMethod_async",
+      "title": "AMethodRequestObjectAsync",
+      "description": "Snippet for AMethodAsync",
+      "file": "ServiceWithHandwrittenSignaturesClient.AMethodRequestObjectAsyncSnippet.g.cs",
+      "language": "C_SHARP",
+      "clientMethod": {
+        "shortName": "AMethodAsync",
+        "fullName": "Testing.PublishingSettings.ServiceWithHandwrittenSignaturesClient.AMethodAsync",
+        "async": true,
+        "parameters": [
+          {
+            "type": "Testing.PublishingSettings.Request",
+            "name": "request"
+          },
+          {
+            "type": "Google.Api.Gax.Grpc.CallSettings",
+            "name": "callSettings"
+          }
+        ],
+        "resultType": "System.Threading.Tasks.Task<Testing.PublishingSettings.Response>",
+        "client": {
+          "shortName": "ServiceWithHandwrittenSignaturesClient",
+          "fullName": "Testing.PublishingSettings.ServiceWithHandwrittenSignaturesClient"
+        },
+        "method": {
+          "shortName": "AMethod",
+          "fullName": "testing.publishingsettings.ServiceWithHandwrittenSignatures.AMethod",
+          "service": {
+            "shortName": "ServiceWithHandwrittenSignatures",
+            "fullName": "testing.publishingsettings.ServiceWithHandwrittenSignatures"
+          }
+        }
+      },
+      "canonical": true,
+      "origin": "API_DEFINITION",
+      "segments": [
+        {
+          "start": 20,
+          "end": 46,
+          "type": "FULL"
+        },
+        {
+          "start": 35,
+          "end": 44,
+          "type": "SHORT"
+        }
+      ]
+    },
+    {
+      "regionTag": "unknown_generated_ServiceWithHandwrittenSignatures_AMethod_sync_flattened1",
+      "title": "AMethod1",
+      "description": "Snippet for AMethod",
+      "file": "ServiceWithHandwrittenSignaturesClient.AMethod1Snippet.g.cs",
+      "language": "C_SHARP",
+      "clientMethod": {
+        "shortName": "AMethod",
+        "fullName": "Testing.PublishingSettings.ServiceWithHandwrittenSignaturesClient.AMethod",
+        "parameters": [
+          {
+            "type": "System.String",
+            "name": "string1"
+          },
+          {
+            "type": "Google.Api.Gax.Grpc.CallSettings",
+            "name": "callSettings"
+          }
+        ],
+        "resultType": "Testing.PublishingSettings.Response",
+        "client": {
+          "shortName": "ServiceWithHandwrittenSignaturesClient",
+          "fullName": "Testing.PublishingSettings.ServiceWithHandwrittenSignaturesClient"
+        },
+        "method": {
+          "shortName": "AMethod",
+          "fullName": "testing.publishingsettings.ServiceWithHandwrittenSignatures.AMethod",
+          "service": {
+            "shortName": "ServiceWithHandwrittenSignatures",
+            "fullName": "testing.publishingsettings.ServiceWithHandwrittenSignatures"
+          }
+        }
+      },
+      "origin": "API_DEFINITION",
+      "segments": [
+        {
+          "start": 20,
+          "end": 41,
+          "type": "FULL"
+        },
+        {
+          "start": 34,
+          "end": 39,
+          "type": "SHORT"
+        }
+      ]
+    },
+    {
+      "regionTag": "unknown_generated_ServiceWithHandwrittenSignatures_AMethod_async_flattened1",
+      "title": "AMethod1Async",
+      "description": "Snippet for AMethodAsync",
+      "file": "ServiceWithHandwrittenSignaturesClient.AMethod1AsyncSnippet.g.cs",
+      "language": "C_SHARP",
+      "clientMethod": {
+        "shortName": "AMethodAsync",
+        "fullName": "Testing.PublishingSettings.ServiceWithHandwrittenSignaturesClient.AMethodAsync",
+        "async": true,
+        "parameters": [
+          {
+            "type": "System.String",
+            "name": "string1"
+          },
+          {
+            "type": "Google.Api.Gax.Grpc.CallSettings",
+            "name": "callSettings"
+          }
+        ],
+        "resultType": "System.Threading.Tasks.Task<Testing.PublishingSettings.Response>",
+        "client": {
+          "shortName": "ServiceWithHandwrittenSignaturesClient",
+          "fullName": "Testing.PublishingSettings.ServiceWithHandwrittenSignaturesClient"
+        },
+        "method": {
+          "shortName": "AMethod",
+          "fullName": "testing.publishingsettings.ServiceWithHandwrittenSignatures.AMethod",
+          "service": {
+            "shortName": "ServiceWithHandwrittenSignatures",
+            "fullName": "testing.publishingsettings.ServiceWithHandwrittenSignatures"
+          }
+        }
+      },
+      "origin": "API_DEFINITION",
+      "segments": [
+        {
+          "start": 20,
+          "end": 42,
+          "type": "FULL"
+        },
+        {
+          "start": 35,
+          "end": 40,
+          "type": "SHORT"
+        }
+      ]
+    },
+    {
+      "regionTag": "unknown_generated_ServiceWithHandwrittenSignatures_AMethod_sync_flattened2",
+      "title": "AMethod2",
+      "description": "Snippet for AMethod",
+      "file": "ServiceWithHandwrittenSignaturesClient.AMethod2Snippet.g.cs",
+      "language": "C_SHARP",
+      "clientMethod": {
+        "shortName": "AMethod",
+        "fullName": "Testing.PublishingSettings.ServiceWithHandwrittenSignaturesClient.AMethod",
+        "parameters": [
+          {
+            "type": "System.String",
+            "name": "string1"
+          },
+          {
+            "type": "System.String",
+            "name": "string2"
+          },
+          {
+            "type": "Google.Api.Gax.Grpc.CallSettings",
+            "name": "callSettings"
+          }
+        ],
+        "resultType": "Testing.PublishingSettings.Response",
+        "client": {
+          "shortName": "ServiceWithHandwrittenSignaturesClient",
+          "fullName": "Testing.PublishingSettings.ServiceWithHandwrittenSignaturesClient"
+        },
+        "method": {
+          "shortName": "AMethod",
+          "fullName": "testing.publishingsettings.ServiceWithHandwrittenSignatures.AMethod",
+          "service": {
+            "shortName": "ServiceWithHandwrittenSignatures",
+            "fullName": "testing.publishingsettings.ServiceWithHandwrittenSignatures"
+          }
+        }
+      },
+      "origin": "API_DEFINITION",
+      "segments": [
+        {
+          "start": 20,
+          "end": 42,
+          "type": "FULL"
+        },
+        {
+          "start": 34,
+          "end": 40,
+          "type": "SHORT"
+        }
+      ]
+    },
+    {
+      "regionTag": "unknown_generated_ServiceWithHandwrittenSignatures_AMethod_async_flattened2",
+      "title": "AMethod2Async",
+      "description": "Snippet for AMethodAsync",
+      "file": "ServiceWithHandwrittenSignaturesClient.AMethod2AsyncSnippet.g.cs",
+      "language": "C_SHARP",
+      "clientMethod": {
+        "shortName": "AMethodAsync",
+        "fullName": "Testing.PublishingSettings.ServiceWithHandwrittenSignaturesClient.AMethodAsync",
+        "async": true,
+        "parameters": [
+          {
+            "type": "System.String",
+            "name": "string1"
+          },
+          {
+            "type": "System.String",
+            "name": "string2"
+          },
+          {
+            "type": "Google.Api.Gax.Grpc.CallSettings",
+            "name": "callSettings"
+          }
+        ],
+        "resultType": "System.Threading.Tasks.Task<Testing.PublishingSettings.Response>",
+        "client": {
+          "shortName": "ServiceWithHandwrittenSignaturesClient",
+          "fullName": "Testing.PublishingSettings.ServiceWithHandwrittenSignaturesClient"
+        },
+        "method": {
+          "shortName": "AMethod",
+          "fullName": "testing.publishingsettings.ServiceWithHandwrittenSignatures.AMethod",
+          "service": {
+            "shortName": "ServiceWithHandwrittenSignatures",
+            "fullName": "testing.publishingsettings.ServiceWithHandwrittenSignatures"
+          }
+        }
+      },
+      "origin": "API_DEFINITION",
+      "segments": [
+        {
+          "start": 20,
+          "end": 43,
+          "type": "FULL"
+        },
+        {
+          "start": 35,
+          "end": 41,
+          "type": "SHORT"
+        }
+      ]
+    },
+    {
+      "regionTag": "unknown_generated_ServiceWithResources_AMethod_sync",
+      "title": "AMethodRequestObject",
+      "description": "Snippet for AMethod",
+      "file": "ServiceWithResourcesClient.AMethodRequestObjectSnippet.g.cs",
+      "language": "C_SHARP",
+      "clientMethod": {
+        "shortName": "AMethod",
+        "fullName": "Testing.PublishingSettings.ServiceWithResourcesClient.AMethod",
+        "parameters": [
+          {
+            "type": "Testing.PublishingSettings.ResourceRequest",
+            "name": "request"
+          },
+          {
+            "type": "Google.Api.Gax.Grpc.CallSettings",
+            "name": "callSettings"
+          }
+        ],
+        "resultType": "Testing.PublishingSettings.Resource",
+        "client": {
+          "shortName": "ServiceWithResourcesClient",
+          "fullName": "Testing.PublishingSettings.ServiceWithResourcesClient"
+        },
+        "method": {
+          "shortName": "AMethod",
+          "fullName": "testing.publishingsettings.ServiceWithResources.AMethod",
+          "service": {
+            "shortName": "ServiceWithResources",
+            "fullName": "testing.publishingsettings.ServiceWithResources"
+          }
+        }
+      },
+      "canonical": true,
+      "origin": "API_DEFINITION",
+      "segments": [
+        {
+          "start": 20,
+          "end": 46,
+          "type": "FULL"
+        },
+        {
+          "start": 35,
+          "end": 44,
+          "type": "SHORT"
+        }
+      ]
+    },
+    {
+      "regionTag": "unknown_generated_ServiceWithResources_AMethod_async",
+      "title": "AMethodRequestObjectAsync",
+      "description": "Snippet for AMethodAsync",
+      "file": "ServiceWithResourcesClient.AMethodRequestObjectAsyncSnippet.g.cs",
+      "language": "C_SHARP",
+      "clientMethod": {
+        "shortName": "AMethodAsync",
+        "fullName": "Testing.PublishingSettings.ServiceWithResourcesClient.AMethodAsync",
+        "async": true,
+        "parameters": [
+          {
+            "type": "Testing.PublishingSettings.ResourceRequest",
+            "name": "request"
+          },
+          {
+            "type": "Google.Api.Gax.Grpc.CallSettings",
+            "name": "callSettings"
+          }
+        ],
+        "resultType": "System.Threading.Tasks.Task<Testing.PublishingSettings.Resource>",
+        "client": {
+          "shortName": "ServiceWithResourcesClient",
+          "fullName": "Testing.PublishingSettings.ServiceWithResourcesClient"
+        },
+        "method": {
+          "shortName": "AMethod",
+          "fullName": "testing.publishingsettings.ServiceWithResources.AMethod",
+          "service": {
+            "shortName": "ServiceWithResources",
+            "fullName": "testing.publishingsettings.ServiceWithResources"
+          }
+        }
+      },
+      "canonical": true,
+      "origin": "API_DEFINITION",
+      "segments": [
+        {
+          "start": 20,
+          "end": 47,
+          "type": "FULL"
+        },
+        {
+          "start": 36,
+          "end": 45,
+          "type": "SHORT"
+        }
+      ]
+    }
+  ]
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.Snippets/RenamedServiceNameClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.Snippets/RenamedServiceNameClientSnippets.g.cs
@@ -1,0 +1,59 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.PublishingSettings.Snippets
+{
+    using System.Threading.Tasks;
+
+    /// <summary>Generated snippets.</summary>
+    public sealed class AllGeneratedRenamedServiceNameClientSnippets
+    {
+        /// <summary>Snippet for AMethod</summary>
+        public void AMethodRequestObject()
+        {
+            // Snippet: AMethod(Request, CallSettings)
+            // Create client
+            RenamedServiceNameClient renamedServiceNameClient = RenamedServiceNameClient.Create();
+            // Initialize request argument(s)
+            Request request = new Request
+            {
+                String1 = "",
+                String2 = "",
+            };
+            // Make the request
+            Response response = renamedServiceNameClient.AMethod(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for AMethodAsync</summary>
+        public async Task AMethodRequestObjectAsync()
+        {
+            // Snippet: AMethodAsync(Request, CallSettings)
+            // Additional: AMethodAsync(Request, CancellationToken)
+            // Create client
+            RenamedServiceNameClient renamedServiceNameClient = await RenamedServiceNameClient.CreateAsync();
+            // Initialize request argument(s)
+            Request request = new Request
+            {
+                String1 = "",
+                String2 = "",
+            };
+            // Make the request
+            Response response = await renamedServiceNameClient.AMethodAsync(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.Snippets/ServiceWithHandwrittenSignaturesClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.Snippets/ServiceWithHandwrittenSignaturesClientSnippets.g.cs
@@ -1,0 +1,115 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.PublishingSettings.Snippets
+{
+    using System.Threading.Tasks;
+
+    /// <summary>Generated snippets.</summary>
+    public sealed class AllGeneratedServiceWithHandwrittenSignaturesClientSnippets
+    {
+        /// <summary>Snippet for AMethod</summary>
+        public void AMethodRequestObject()
+        {
+            // Snippet: AMethod(Request, CallSettings)
+            // Create client
+            ServiceWithHandwrittenSignaturesClient serviceWithHandwrittenSignaturesClient = ServiceWithHandwrittenSignaturesClient.Create();
+            // Initialize request argument(s)
+            Request request = new Request
+            {
+                String1 = "",
+                String2 = "",
+            };
+            // Make the request
+            Response response = serviceWithHandwrittenSignaturesClient.AMethod(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for AMethodAsync</summary>
+        public async Task AMethodRequestObjectAsync()
+        {
+            // Snippet: AMethodAsync(Request, CallSettings)
+            // Additional: AMethodAsync(Request, CancellationToken)
+            // Create client
+            ServiceWithHandwrittenSignaturesClient serviceWithHandwrittenSignaturesClient = await ServiceWithHandwrittenSignaturesClient.CreateAsync();
+            // Initialize request argument(s)
+            Request request = new Request
+            {
+                String1 = "",
+                String2 = "",
+            };
+            // Make the request
+            Response response = await serviceWithHandwrittenSignaturesClient.AMethodAsync(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for AMethod</summary>
+        public void AMethod1()
+        {
+            // Snippet: AMethod(string, CallSettings)
+            // Create client
+            ServiceWithHandwrittenSignaturesClient serviceWithHandwrittenSignaturesClient = ServiceWithHandwrittenSignaturesClient.Create();
+            // Initialize request argument(s)
+            string string1 = "";
+            // Make the request
+            Response response = serviceWithHandwrittenSignaturesClient.AMethod(string1);
+            // End snippet
+        }
+
+        /// <summary>Snippet for AMethodAsync</summary>
+        public async Task AMethod1Async()
+        {
+            // Snippet: AMethodAsync(string, CallSettings)
+            // Additional: AMethodAsync(string, CancellationToken)
+            // Create client
+            ServiceWithHandwrittenSignaturesClient serviceWithHandwrittenSignaturesClient = await ServiceWithHandwrittenSignaturesClient.CreateAsync();
+            // Initialize request argument(s)
+            string string1 = "";
+            // Make the request
+            Response response = await serviceWithHandwrittenSignaturesClient.AMethodAsync(string1);
+            // End snippet
+        }
+
+        /// <summary>Snippet for AMethod</summary>
+        public void AMethod2()
+        {
+            // Snippet: AMethod(string, string, CallSettings)
+            // Create client
+            ServiceWithHandwrittenSignaturesClient serviceWithHandwrittenSignaturesClient = ServiceWithHandwrittenSignaturesClient.Create();
+            // Initialize request argument(s)
+            string string1 = "";
+            string string2 = "";
+            // Make the request
+            Response response = serviceWithHandwrittenSignaturesClient.AMethod(string1, string2);
+            // End snippet
+        }
+
+        /// <summary>Snippet for AMethodAsync</summary>
+        public async Task AMethod2Async()
+        {
+            // Snippet: AMethodAsync(string, string, CallSettings)
+            // Additional: AMethodAsync(string, string, CancellationToken)
+            // Create client
+            ServiceWithHandwrittenSignaturesClient serviceWithHandwrittenSignaturesClient = await ServiceWithHandwrittenSignaturesClient.CreateAsync();
+            // Initialize request argument(s)
+            string string1 = "";
+            string string2 = "";
+            // Make the request
+            Response response = await serviceWithHandwrittenSignaturesClient.AMethodAsync(string1, string2);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.Snippets/ServiceWithResourcesClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.Snippets/ServiceWithResourcesClientSnippets.g.cs
@@ -1,0 +1,60 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace Testing.PublishingSettings.Snippets
+{
+    using PublishingSettingsCommon.Namespace;
+    using System.Threading.Tasks;
+
+    /// <summary>Generated snippets.</summary>
+    public sealed class AllGeneratedServiceWithResourcesClientSnippets
+    {
+        /// <summary>Snippet for AMethod</summary>
+        public void AMethodRequestObject()
+        {
+            // Snippet: AMethod(ResourceRequest, CallSettings)
+            // Create client
+            ServiceWithResourcesClient serviceWithResourcesClient = ServiceWithResourcesClient.Create();
+            // Initialize request argument(s)
+            ResourceRequest request = new ResourceRequest
+            {
+                ParentAsCommonLocationName = CommonLocationName.FromProjectLocation("[PROJECT]", "[LOCATION]"),
+                DatabaseAsRenamedDatabaseName = RenamedDatabaseName.FromDatabase("[DATABASE]"),
+            };
+            // Make the request
+            Resource response = serviceWithResourcesClient.AMethod(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for AMethodAsync</summary>
+        public async Task AMethodRequestObjectAsync()
+        {
+            // Snippet: AMethodAsync(ResourceRequest, CallSettings)
+            // Additional: AMethodAsync(ResourceRequest, CancellationToken)
+            // Create client
+            ServiceWithResourcesClient serviceWithResourcesClient = await ServiceWithResourcesClient.CreateAsync();
+            // Initialize request argument(s)
+            ResourceRequest request = new ResourceRequest
+            {
+                ParentAsCommonLocationName = CommonLocationName.FromProjectLocation("[PROJECT]", "[LOCATION]"),
+                DatabaseAsRenamedDatabaseName = RenamedDatabaseName.FromDatabase("[DATABASE]"),
+            };
+            // Make the request
+            Resource response = await serviceWithResourcesClient.AMethodAsync(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.Snippets/Testing.PublishingSettings.Snippets.csproj
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.Snippets/Testing.PublishingSettings.Snippets.csproj
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net462</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Testing.PublishingSettings/Testing.PublishingSettings.csproj" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
+  </ItemGroup>
+
+</Project>

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/PackageApiMetadata.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/PackageApiMetadata.g.cs
@@ -1,0 +1,35 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+#pragma warning disable CS8981
+using gaxgrpc = Google.Api.Gax.Grpc;
+using gpr = Google.Protobuf.Reflection;
+using scg = System.Collections.Generic;
+
+namespace Testing.PublishingSettings
+{
+    /// <summary>Static class to provide common access to package-wide API metadata.</summary>
+    internal static class PackageApiMetadata
+    {
+        /// <summary>The <see cref="gaxgrpc::ApiMetadata"/> for services in this package.</summary>
+        internal static gaxgrpc::ApiMetadata ApiMetadata { get; } = new gaxgrpc::ApiMetadata("Testing.PublishingSettings", GetFileDescriptors);
+
+        private static scg::IEnumerable<gpr::FileDescriptor> GetFileDescriptors()
+        {
+            yield return PublishingSettingsReflection.Descriptor;
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/PublishingSettingsResourceNames.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/PublishingSettingsResourceNames.g.cs
@@ -1,0 +1,486 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+#pragma warning disable CS8981
+using gax = Google.Api.Gax;
+using pn = PublishingSettingsCommon.Namespace;
+using sys = System;
+using tp = Testing.PublishingSettings;
+
+namespace Testing.PublishingSettings
+{
+    /// <summary>Resource name for the <c>Resource</c> resource.</summary>
+    public sealed partial class ResourceName : gax::IResourceName, sys::IEquatable<ResourceName>
+    {
+        /// <summary>The possible contents of <see cref="ResourceName"/>.</summary>
+        public enum ResourceNameType
+        {
+            /// <summary>An unparsed resource name.</summary>
+            Unparsed = 0,
+
+            /// <summary>
+            /// A resource name with pattern <c>projects/{project}/locations/{location}/resources/{resource}</c>.
+            /// </summary>
+            ProjectLocationResource = 1,
+        }
+
+        private static gax::PathTemplate s_projectLocationResource = new gax::PathTemplate("projects/{project}/locations/{location}/resources/{resource}");
+
+        /// <summary>Creates a <see cref="ResourceName"/> containing an unparsed resource name.</summary>
+        /// <param name="unparsedResourceName">The unparsed resource name. Must not be <c>null</c>.</param>
+        /// <returns>
+        /// A new instance of <see cref="ResourceName"/> containing the provided <paramref name="unparsedResourceName"/>
+        /// .
+        /// </returns>
+        public static ResourceName FromUnparsed(gax::UnparsedResourceName unparsedResourceName) =>
+            new ResourceName(ResourceNameType.Unparsed, gax::GaxPreconditions.CheckNotNull(unparsedResourceName, nameof(unparsedResourceName)));
+
+        /// <summary>
+        /// Creates a <see cref="ResourceName"/> with the pattern
+        /// <c>projects/{project}/locations/{location}/resources/{resource}</c>.
+        /// </summary>
+        /// <param name="projectId">The <c>Project</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="locationId">The <c>Location</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="resourceId">The <c>Resource</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>A new instance of <see cref="ResourceName"/> constructed from the provided ids.</returns>
+        public static ResourceName FromProjectLocationResource(string projectId, string locationId, string resourceId) =>
+            new ResourceName(ResourceNameType.ProjectLocationResource, projectId: gax::GaxPreconditions.CheckNotNullOrEmpty(projectId, nameof(projectId)), locationId: gax::GaxPreconditions.CheckNotNullOrEmpty(locationId, nameof(locationId)), resourceId: gax::GaxPreconditions.CheckNotNullOrEmpty(resourceId, nameof(resourceId)));
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="ResourceName"/> with pattern
+        /// <c>projects/{project}/locations/{location}/resources/{resource}</c>.
+        /// </summary>
+        /// <param name="projectId">The <c>Project</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="locationId">The <c>Location</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="resourceId">The <c>Resource</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="ResourceName"/> with pattern
+        /// <c>projects/{project}/locations/{location}/resources/{resource}</c>.
+        /// </returns>
+        public static string Format(string projectId, string locationId, string resourceId) =>
+            FormatProjectLocationResource(projectId, locationId, resourceId);
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="ResourceName"/> with pattern
+        /// <c>projects/{project}/locations/{location}/resources/{resource}</c>.
+        /// </summary>
+        /// <param name="projectId">The <c>Project</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="locationId">The <c>Location</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="resourceId">The <c>Resource</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="ResourceName"/> with pattern
+        /// <c>projects/{project}/locations/{location}/resources/{resource}</c>.
+        /// </returns>
+        public static string FormatProjectLocationResource(string projectId, string locationId, string resourceId) =>
+            s_projectLocationResource.Expand(gax::GaxPreconditions.CheckNotNullOrEmpty(projectId, nameof(projectId)), gax::GaxPreconditions.CheckNotNullOrEmpty(locationId, nameof(locationId)), gax::GaxPreconditions.CheckNotNullOrEmpty(resourceId, nameof(resourceId)));
+
+        /// <summary>Parses the given resource name string into a new <see cref="ResourceName"/> instance.</summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet">
+        /// <item><description><c>projects/{project}/locations/{location}/resources/{resource}</c></description></item>
+        /// </list>
+        /// </remarks>
+        /// <param name="resourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="ResourceName"/> if successful.</returns>
+        public static ResourceName Parse(string resourceName) => Parse(resourceName, false);
+
+        /// <summary>
+        /// Parses the given resource name string into a new <see cref="ResourceName"/> instance; optionally allowing an
+        /// unparseable resource name.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet">
+        /// <item><description><c>projects/{project}/locations/{location}/resources/{resource}</c></description></item>
+        /// </list>
+        /// Or may be in any format if <paramref name="allowUnparsed"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="resourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnparsed">
+        /// If <c>true</c> will successfully store an unparseable resource name into the <see cref="UnparsedResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unparseable resource name is
+        /// specified.
+        /// </param>
+        /// <returns>The parsed <see cref="ResourceName"/> if successful.</returns>
+        public static ResourceName Parse(string resourceName, bool allowUnparsed) =>
+            TryParse(resourceName, allowUnparsed, out ResourceName result) ? result : throw new sys::ArgumentException("The given resource-name matches no pattern.");
+
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="ResourceName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet">
+        /// <item><description><c>projects/{project}/locations/{location}/resources/{resource}</c></description></item>
+        /// </list>
+        /// </remarks>
+        /// <param name="resourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="ResourceName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string resourceName, out ResourceName result) => TryParse(resourceName, false, out result);
+
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="ResourceName"/> instance; optionally
+        /// allowing an unparseable resource name.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet">
+        /// <item><description><c>projects/{project}/locations/{location}/resources/{resource}</c></description></item>
+        /// </list>
+        /// Or may be in any format if <paramref name="allowUnparsed"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="resourceName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnparsed">
+        /// If <c>true</c> will successfully store an unparseable resource name into the <see cref="UnparsedResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unparseable resource name is
+        /// specified.
+        /// </param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="ResourceName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string resourceName, bool allowUnparsed, out ResourceName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(resourceName, nameof(resourceName));
+            gax::TemplatedResourceName resourceName2;
+            if (s_projectLocationResource.TryParseName(resourceName, out resourceName2))
+            {
+                result = FromProjectLocationResource(resourceName2[0], resourceName2[1], resourceName2[2]);
+                return true;
+            }
+            if (allowUnparsed)
+            {
+                if (gax::UnparsedResourceName.TryParse(resourceName, out gax::UnparsedResourceName unparsedResourceName))
+                {
+                    result = FromUnparsed(unparsedResourceName);
+                    return true;
+                }
+            }
+            result = null;
+            return false;
+        }
+
+        private ResourceName(ResourceNameType type, gax::UnparsedResourceName unparsedResourceName = null, string locationId = null, string projectId = null, string resourceId = null)
+        {
+            Type = type;
+            UnparsedResource = unparsedResourceName;
+            LocationId = locationId;
+            ProjectId = projectId;
+            ResourceId = resourceId;
+        }
+
+        /// <summary>
+        /// Constructs a new instance of a <see cref="ResourceName"/> class from the component parts of pattern
+        /// <c>projects/{project}/locations/{location}/resources/{resource}</c>
+        /// </summary>
+        /// <param name="projectId">The <c>Project</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="locationId">The <c>Location</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <param name="resourceId">The <c>Resource</c> ID. Must not be <c>null</c> or empty.</param>
+        public ResourceName(string projectId, string locationId, string resourceId) : this(ResourceNameType.ProjectLocationResource, projectId: gax::GaxPreconditions.CheckNotNullOrEmpty(projectId, nameof(projectId)), locationId: gax::GaxPreconditions.CheckNotNullOrEmpty(locationId, nameof(locationId)), resourceId: gax::GaxPreconditions.CheckNotNullOrEmpty(resourceId, nameof(resourceId)))
+        {
+        }
+
+        /// <summary>The <see cref="ResourceNameType"/> of the contained resource name.</summary>
+        public ResourceNameType Type { get; }
+
+        /// <summary>
+        /// The contained <see cref="gax::UnparsedResourceName"/>. Only non-<c>null</c> if this instance contains an
+        /// unparsed resource name.
+        /// </summary>
+        public gax::UnparsedResourceName UnparsedResource { get; }
+
+        /// <summary>
+        /// The <c>Location</c> ID. Will not be <c>null</c>, unless this instance contains an unparsed resource name.
+        /// </summary>
+        public string LocationId { get; }
+
+        /// <summary>
+        /// The <c>Project</c> ID. Will not be <c>null</c>, unless this instance contains an unparsed resource name.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <summary>
+        /// The <c>Resource</c> ID. Will not be <c>null</c>, unless this instance contains an unparsed resource name.
+        /// </summary>
+        public string ResourceId { get; }
+
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
+        public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
+
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
+        public override string ToString()
+        {
+            switch (Type)
+            {
+                case ResourceNameType.Unparsed: return UnparsedResource.ToString();
+                case ResourceNameType.ProjectLocationResource: return s_projectLocationResource.Expand(ProjectId, LocationId, ResourceId);
+                default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
+            }
+        }
+
+        /// <summary>Returns a hash code for this resource name.</summary>
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj) => Equals(obj as ResourceName);
+
+        /// <inheritdoc/>
+        public bool Equals(ResourceName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc/>
+        public static bool operator ==(ResourceName a, ResourceName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc/>
+        public static bool operator !=(ResourceName a, ResourceName b) => !(a == b);
+    }
+
+    /// <summary>Resource name for the <c>RenamedDatabase</c> resource.</summary>
+    public sealed partial class RenamedDatabaseName : gax::IResourceName, sys::IEquatable<RenamedDatabaseName>
+    {
+        /// <summary>The possible contents of <see cref="RenamedDatabaseName"/>.</summary>
+        public enum ResourceNameType
+        {
+            /// <summary>An unparsed resource name.</summary>
+            Unparsed = 0,
+
+            /// <summary>A resource name with pattern <c>databases/{database}</c>.</summary>
+            Database = 1,
+        }
+
+        private static gax::PathTemplate s_database = new gax::PathTemplate("databases/{database}");
+
+        /// <summary>Creates a <see cref="RenamedDatabaseName"/> containing an unparsed resource name.</summary>
+        /// <param name="unparsedResourceName">The unparsed resource name. Must not be <c>null</c>.</param>
+        /// <returns>
+        /// A new instance of <see cref="RenamedDatabaseName"/> containing the provided
+        /// <paramref name="unparsedResourceName"/>.
+        /// </returns>
+        public static RenamedDatabaseName FromUnparsed(gax::UnparsedResourceName unparsedResourceName) =>
+            new RenamedDatabaseName(ResourceNameType.Unparsed, gax::GaxPreconditions.CheckNotNull(unparsedResourceName, nameof(unparsedResourceName)));
+
+        /// <summary>Creates a <see cref="RenamedDatabaseName"/> with the pattern <c>databases/{database}</c>.</summary>
+        /// <param name="databaseId">The <c>Database</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>A new instance of <see cref="RenamedDatabaseName"/> constructed from the provided ids.</returns>
+        public static RenamedDatabaseName FromDatabase(string databaseId) =>
+            new RenamedDatabaseName(ResourceNameType.Database, databaseId: gax::GaxPreconditions.CheckNotNullOrEmpty(databaseId, nameof(databaseId)));
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="RenamedDatabaseName"/> with pattern
+        /// <c>databases/{database}</c>.
+        /// </summary>
+        /// <param name="databaseId">The <c>Database</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="RenamedDatabaseName"/> with pattern <c>databases/{database}</c>
+        /// .
+        /// </returns>
+        public static string Format(string databaseId) => FormatDatabase(databaseId);
+
+        /// <summary>
+        /// Formats the IDs into the string representation of this <see cref="RenamedDatabaseName"/> with pattern
+        /// <c>databases/{database}</c>.
+        /// </summary>
+        /// <param name="databaseId">The <c>Database</c> ID. Must not be <c>null</c> or empty.</param>
+        /// <returns>
+        /// The string representation of this <see cref="RenamedDatabaseName"/> with pattern <c>databases/{database}</c>
+        /// .
+        /// </returns>
+        public static string FormatDatabase(string databaseId) =>
+            s_database.Expand(gax::GaxPreconditions.CheckNotNullOrEmpty(databaseId, nameof(databaseId)));
+
+        /// <summary>
+        /// Parses the given resource name string into a new <see cref="RenamedDatabaseName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>databases/{database}</c></description></item></list>
+        /// </remarks>
+        /// <param name="renamedDatabaseName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="RenamedDatabaseName"/> if successful.</returns>
+        public static RenamedDatabaseName Parse(string renamedDatabaseName) => Parse(renamedDatabaseName, false);
+
+        /// <summary>
+        /// Parses the given resource name string into a new <see cref="RenamedDatabaseName"/> instance; optionally
+        /// allowing an unparseable resource name.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>databases/{database}</c></description></item></list>
+        /// Or may be in any format if <paramref name="allowUnparsed"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="renamedDatabaseName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnparsed">
+        /// If <c>true</c> will successfully store an unparseable resource name into the <see cref="UnparsedResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unparseable resource name is
+        /// specified.
+        /// </param>
+        /// <returns>The parsed <see cref="RenamedDatabaseName"/> if successful.</returns>
+        public static RenamedDatabaseName Parse(string renamedDatabaseName, bool allowUnparsed) =>
+            TryParse(renamedDatabaseName, allowUnparsed, out RenamedDatabaseName result) ? result : throw new sys::ArgumentException("The given resource-name matches no pattern.");
+
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="RenamedDatabaseName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>databases/{database}</c></description></item></list>
+        /// </remarks>
+        /// <param name="renamedDatabaseName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="RenamedDatabaseName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string renamedDatabaseName, out RenamedDatabaseName result) =>
+            TryParse(renamedDatabaseName, false, out result);
+
+        /// <summary>
+        /// Tries to parse the given resource name string into a new <see cref="RenamedDatabaseName"/> instance;
+        /// optionally allowing an unparseable resource name.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully, the resource name must be formatted as one of the following:
+        /// <list type="bullet"><item><description><c>databases/{database}</c></description></item></list>
+        /// Or may be in any format if <paramref name="allowUnparsed"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="renamedDatabaseName">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnparsed">
+        /// If <c>true</c> will successfully store an unparseable resource name into the <see cref="UnparsedResource"/>
+        /// property; otherwise will throw an <see cref="sys::ArgumentException"/> if an unparseable resource name is
+        /// specified.
+        /// </param>
+        /// <param name="result">
+        /// When this method returns, the parsed <see cref="RenamedDatabaseName"/>, or <c>null</c> if parsing failed.
+        /// </param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string renamedDatabaseName, bool allowUnparsed, out RenamedDatabaseName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(renamedDatabaseName, nameof(renamedDatabaseName));
+            gax::TemplatedResourceName resourceName;
+            if (s_database.TryParseName(renamedDatabaseName, out resourceName))
+            {
+                result = FromDatabase(resourceName[0]);
+                return true;
+            }
+            if (allowUnparsed)
+            {
+                if (gax::UnparsedResourceName.TryParse(renamedDatabaseName, out gax::UnparsedResourceName unparsedResourceName))
+                {
+                    result = FromUnparsed(unparsedResourceName);
+                    return true;
+                }
+            }
+            result = null;
+            return false;
+        }
+
+        private RenamedDatabaseName(ResourceNameType type, gax::UnparsedResourceName unparsedResourceName = null, string databaseId = null)
+        {
+            Type = type;
+            UnparsedResource = unparsedResourceName;
+            DatabaseId = databaseId;
+        }
+
+        /// <summary>
+        /// Constructs a new instance of a <see cref="RenamedDatabaseName"/> class from the component parts of pattern
+        /// <c>databases/{database}</c>
+        /// </summary>
+        /// <param name="databaseId">The <c>Database</c> ID. Must not be <c>null</c> or empty.</param>
+        public RenamedDatabaseName(string databaseId) : this(ResourceNameType.Database, databaseId: gax::GaxPreconditions.CheckNotNullOrEmpty(databaseId, nameof(databaseId)))
+        {
+        }
+
+        /// <summary>The <see cref="ResourceNameType"/> of the contained resource name.</summary>
+        public ResourceNameType Type { get; }
+
+        /// <summary>
+        /// The contained <see cref="gax::UnparsedResourceName"/>. Only non-<c>null</c> if this instance contains an
+        /// unparsed resource name.
+        /// </summary>
+        public gax::UnparsedResourceName UnparsedResource { get; }
+
+        /// <summary>
+        /// The <c>Database</c> ID. Will not be <c>null</c>, unless this instance contains an unparsed resource name.
+        /// </summary>
+        public string DatabaseId { get; }
+
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
+        public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
+
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
+        public override string ToString()
+        {
+            switch (Type)
+            {
+                case ResourceNameType.Unparsed: return UnparsedResource.ToString();
+                case ResourceNameType.Database: return s_database.Expand(DatabaseId);
+                default: throw new sys::InvalidOperationException("Unrecognized resource-type.");
+            }
+        }
+
+        /// <summary>Returns a hash code for this resource name.</summary>
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj) => Equals(obj as RenamedDatabaseName);
+
+        /// <inheritdoc/>
+        public bool Equals(RenamedDatabaseName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc/>
+        public static bool operator ==(RenamedDatabaseName a, RenamedDatabaseName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc/>
+        public static bool operator !=(RenamedDatabaseName a, RenamedDatabaseName b) => !(a == b);
+    }
+
+    public partial class ResourceRequest
+    {
+        /// <summary>
+        /// <see cref="pn::CommonLocationName"/>-typed view over the <see cref="Parent"/> resource name property.
+        /// </summary>
+        public pn::CommonLocationName ParentAsCommonLocationName
+        {
+            get => string.IsNullOrEmpty(Parent) ? null : pn::CommonLocationName.Parse(Parent, allowUnparsed: true);
+            set => Parent = value?.ToString() ?? "";
+        }
+
+        /// <summary>
+        /// <see cref="RenamedDatabaseName"/>-typed view over the <see cref="Database"/> resource name property.
+        /// </summary>
+        public RenamedDatabaseName DatabaseAsRenamedDatabaseName
+        {
+            get => string.IsNullOrEmpty(Database) ? null : RenamedDatabaseName.Parse(Database, allowUnparsed: true);
+            set => Database = value?.ToString() ?? "";
+        }
+    }
+
+    public partial class Resource
+    {
+        /// <summary>
+        /// <see cref="tp::ResourceName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// </summary>
+        public tp::ResourceName ResourceName
+        {
+            get => string.IsNullOrEmpty(Name) ? null : tp::ResourceName.Parse(Name, allowUnparsed: true);
+            set => Name = value?.ToString() ?? "";
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/RenamedServiceNameClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/RenamedServiceNameClient.g.cs
@@ -1,0 +1,288 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+#pragma warning disable CS8981
+using gax = Google.Api.Gax;
+using gaxgrpc = Google.Api.Gax.Grpc;
+using proto = Google.Protobuf;
+using grpccore = Grpc.Core;
+using grpcinter = Grpc.Core.Interceptors;
+using mel = Microsoft.Extensions.Logging;
+using sys = System;
+using scg = System.Collections.Generic;
+using sco = System.Collections.ObjectModel;
+using st = System.Threading;
+using stt = System.Threading.Tasks;
+
+namespace Testing.PublishingSettings
+{
+    /// <summary>Settings for <see cref="RenamedServiceNameClient"/> instances.</summary>
+    public sealed partial class RenamedServiceNameSettings : gaxgrpc::ServiceSettingsBase
+    {
+        /// <summary>Get a new instance of the default <see cref="RenamedServiceNameSettings"/>.</summary>
+        /// <returns>A new instance of the default <see cref="RenamedServiceNameSettings"/>.</returns>
+        public static RenamedServiceNameSettings GetDefault() => new RenamedServiceNameSettings();
+
+        /// <summary>Constructs a new <see cref="RenamedServiceNameSettings"/> object with default settings.</summary>
+        public RenamedServiceNameSettings()
+        {
+        }
+
+        private RenamedServiceNameSettings(RenamedServiceNameSettings existing) : base(existing)
+        {
+            gax::GaxPreconditions.CheckNotNull(existing, nameof(existing));
+            AMethodSettings = existing.AMethodSettings;
+            OnCopy(existing);
+        }
+
+        partial void OnCopy(RenamedServiceNameSettings existing);
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>RenamedServiceNameClient.AMethod</c> and <c>RenamedServiceNameClient.AMethodAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// <list type="bullet">
+        /// <item><description>This call will not be retried.</description></item>
+        /// <item><description>No timeout is applied.</description></item>
+        /// </list>
+        /// </remarks>
+        public gaxgrpc::CallSettings AMethodSettings { get; set; } = gaxgrpc::CallSettings.FromExpiration(gax::Expiration.None);
+
+        /// <summary>Creates a deep clone of this object, with all the same property values.</summary>
+        /// <returns>A deep clone of this <see cref="RenamedServiceNameSettings"/> object.</returns>
+        public RenamedServiceNameSettings Clone() => new RenamedServiceNameSettings(this);
+    }
+
+    /// <summary>
+    /// Builder class for <see cref="RenamedServiceNameClient"/> to provide simple configuration of credentials,
+    /// endpoint etc.
+    /// </summary>
+    public sealed partial class RenamedServiceNameClientBuilder : gaxgrpc::ClientBuilderBase<RenamedServiceNameClient>
+    {
+        /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
+        public RenamedServiceNameSettings Settings { get; set; }
+
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RenamedServiceNameClientBuilder() : base(RenamedServiceNameClient.ServiceMetadata)
+        {
+        }
+
+        partial void InterceptBuild(ref RenamedServiceNameClient client);
+
+        partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RenamedServiceNameClient> task);
+
+        /// <summary>Builds the resulting client.</summary>
+        public override RenamedServiceNameClient Build()
+        {
+            RenamedServiceNameClient client = null;
+            InterceptBuild(ref client);
+            return client ?? BuildImpl();
+        }
+
+        /// <summary>Builds the resulting client asynchronously.</summary>
+        public override stt::Task<RenamedServiceNameClient> BuildAsync(st::CancellationToken cancellationToken = default)
+        {
+            stt::Task<RenamedServiceNameClient> task = null;
+            InterceptBuildAsync(cancellationToken, ref task);
+            return task ?? BuildAsyncImpl(cancellationToken);
+        }
+
+        private RenamedServiceNameClient BuildImpl()
+        {
+            Validate();
+            grpccore::CallInvoker callInvoker = CreateCallInvoker();
+            return RenamedServiceNameClient.Create(callInvoker, Settings, Logger);
+        }
+
+        private async stt::Task<RenamedServiceNameClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
+        {
+            Validate();
+            grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
+            return RenamedServiceNameClient.Create(callInvoker, Settings, Logger);
+        }
+
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
+        protected override gaxgrpc::ChannelPool GetChannelPool() => RenamedServiceNameClient.ChannelPool;
+    }
+
+    /// <summary>RenamedServiceName client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// This is a service we expect to be renamed.
+    /// </remarks>
+    public abstract partial class RenamedServiceNameClient
+    {
+        /// <summary>
+        /// The default endpoint for the RenamedServiceName service, which is a host of "" and a port of 443.
+        /// </summary>
+        public static string DefaultEndpoint { get; } = ":443";
+
+        /// <summary>The default RenamedServiceName scopes.</summary>
+        /// <remarks>The default RenamedServiceName scopes are:<list type="bullet"></list></remarks>
+        public static scg::IReadOnlyList<string> DefaultScopes { get; } = new sco::ReadOnlyCollection<string>(new string[] { });
+
+        /// <summary>The service metadata associated with this client type.</summary>
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(OriginalServiceName.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
+
+        /// <summary>
+        /// Asynchronously creates a <see cref="RenamedServiceNameClient"/> using the default credentials, endpoint and
+        /// settings. To specify custom credentials or other settings, use <see cref="RenamedServiceNameClientBuilder"/>
+        /// .
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// The <see cref="st::CancellationToken"/> to use while creating the client.
+        /// </param>
+        /// <returns>The task representing the created <see cref="RenamedServiceNameClient"/>.</returns>
+        public static stt::Task<RenamedServiceNameClient> CreateAsync(st::CancellationToken cancellationToken = default) =>
+            new RenamedServiceNameClientBuilder().BuildAsync(cancellationToken);
+
+        /// <summary>
+        /// Synchronously creates a <see cref="RenamedServiceNameClient"/> using the default credentials, endpoint and
+        /// settings. To specify custom credentials or other settings, use <see cref="RenamedServiceNameClientBuilder"/>
+        /// .
+        /// </summary>
+        /// <returns>The created <see cref="RenamedServiceNameClient"/>.</returns>
+        public static RenamedServiceNameClient Create() => new RenamedServiceNameClientBuilder().Build();
+
+        /// <summary>
+        /// Creates a <see cref="RenamedServiceNameClient"/> which uses the specified call invoker for remote
+        /// operations.
+        /// </summary>
+        /// <param name="callInvoker">
+        /// The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.
+        /// </param>
+        /// <param name="settings">Optional <see cref="RenamedServiceNameSettings"/>.</param>
+        /// <param name="logger">Optional <see cref="mel::ILogger"/>.</param>
+        /// <returns>The created <see cref="RenamedServiceNameClient"/>.</returns>
+        internal static RenamedServiceNameClient Create(grpccore::CallInvoker callInvoker, RenamedServiceNameSettings settings = null, mel::ILogger logger = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            grpcinter::Interceptor interceptor = settings?.Interceptor;
+            if (interceptor != null)
+            {
+                callInvoker = grpcinter::CallInvokerExtensions.Intercept(callInvoker, interceptor);
+            }
+            OriginalServiceName.OriginalServiceNameClient grpcClient = new OriginalServiceName.OriginalServiceNameClient(callInvoker);
+            return new RenamedServiceNameClientImpl(grpcClient, settings, logger);
+        }
+
+        /// <summary>
+        /// Shuts down any channels automatically created by <see cref="Create()"/> and
+        /// <see cref="CreateAsync(st::CancellationToken)"/>. Channels which weren't automatically created are not
+        /// affected.
+        /// </summary>
+        /// <remarks>
+        /// After calling this method, further calls to <see cref="Create()"/> and
+        /// <see cref="CreateAsync(st::CancellationToken)"/> will create new channels, which could in turn be shut down
+        /// by another call to this method.
+        /// </remarks>
+        /// <returns>A task representing the asynchronous shutdown operation.</returns>
+        public static stt::Task ShutdownDefaultChannelsAsync() => ChannelPool.ShutdownChannelsAsync();
+
+        /// <summary>The underlying gRPC RenamedServiceName client</summary>
+        public virtual OriginalServiceName.OriginalServiceNameClient GrpcClient => throw new sys::NotImplementedException();
+
+        /// <summary>
+        /// Test summary text for AMethod
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The RPC response.</returns>
+        public virtual Response AMethod(Request request, gaxgrpc::CallSettings callSettings = null) =>
+            throw new sys::NotImplementedException();
+
+        /// <summary>
+        /// Test summary text for AMethod
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual stt::Task<Response> AMethodAsync(Request request, gaxgrpc::CallSettings callSettings = null) =>
+            throw new sys::NotImplementedException();
+
+        /// <summary>
+        /// Test summary text for AMethod
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="cancellationToken">A <see cref="st::CancellationToken"/> to use for this RPC.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual stt::Task<Response> AMethodAsync(Request request, st::CancellationToken cancellationToken) =>
+            AMethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+    }
+
+    /// <summary>RenamedServiceName client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// This is a service we expect to be renamed.
+    /// </remarks>
+    public sealed partial class RenamedServiceNameClientImpl : RenamedServiceNameClient
+    {
+        private readonly gaxgrpc::ApiCall<Request, Response> _callAMethod;
+
+        /// <summary>
+        /// Constructs a client wrapper for the RenamedServiceName service, with the specified gRPC client and settings.
+        /// </summary>
+        /// <param name="grpcClient">The underlying gRPC client.</param>
+        /// <param name="settings">The base <see cref="RenamedServiceNameSettings"/> used within this client.</param>
+        /// <param name="logger">Optional <see cref="mel::ILogger"/> to use within this client.</param>
+        public RenamedServiceNameClientImpl(OriginalServiceName.OriginalServiceNameClient grpcClient, RenamedServiceNameSettings settings, mel::ILogger logger)
+        {
+            GrpcClient = grpcClient;
+            RenamedServiceNameSettings effectiveSettings = settings ?? RenamedServiceNameSettings.GetDefault();
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            _callAMethod = clientHelper.BuildApiCall<Request, Response>("AMethod", grpcClient.AMethodAsync, grpcClient.AMethod, effectiveSettings.AMethodSettings);
+            Modify_ApiCall(ref _callAMethod);
+            Modify_AMethodApiCall(ref _callAMethod);
+            OnConstruction(grpcClient, effectiveSettings, clientHelper);
+        }
+
+        partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call) where TRequest : class, proto::IMessage<TRequest> where TResponse : class, proto::IMessage<TResponse>;
+
+        partial void Modify_AMethodApiCall(ref gaxgrpc::ApiCall<Request, Response> call);
+
+        partial void OnConstruction(OriginalServiceName.OriginalServiceNameClient grpcClient, RenamedServiceNameSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);
+
+        /// <summary>The underlying gRPC RenamedServiceName client</summary>
+        public override OriginalServiceName.OriginalServiceNameClient GrpcClient { get; }
+
+        partial void Modify_Request(ref Request request, ref gaxgrpc::CallSettings settings);
+
+        /// <summary>
+        /// Test summary text for AMethod
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The RPC response.</returns>
+        public override Response AMethod(Request request, gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_Request(ref request, ref callSettings);
+            return _callAMethod.Sync(request, callSettings);
+        }
+
+        /// <summary>
+        /// Test summary text for AMethod
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public override stt::Task<Response> AMethodAsync(Request request, gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_Request(ref request, ref callSettings);
+            return _callAMethod.Async(request, callSettings);
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceCollectionExtensions.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceCollectionExtensions.g.cs
@@ -1,0 +1,83 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+#pragma warning disable CS8981
+using gaxgrpc = Google.Api.Gax.Grpc;
+using gpr = Google.Protobuf.Reflection;
+using sys = System;
+using scg = System.Collections.Generic;
+using tp = Testing.PublishingSettings;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>Static class to provide extension methods to configure API clients.</summary>
+    public static partial class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds a singleton <see cref="tp::RenamedServiceNameClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRenamedServiceNameClient(this IServiceCollection services, sys::Action<tp::RenamedServiceNameClientBuilder> action = null) =>
+            services.AddSingleton(provider =>
+            {
+                tp::RenamedServiceNameClientBuilder builder = new tp::RenamedServiceNameClientBuilder();
+                action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="tp::ServiceWithHandwrittenSignaturesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddServiceWithHandwrittenSignaturesClient(this IServiceCollection services, sys::Action<tp::ServiceWithHandwrittenSignaturesClientBuilder> action = null) =>
+            services.AddSingleton(provider =>
+            {
+                tp::ServiceWithHandwrittenSignaturesClientBuilder builder = new tp::ServiceWithHandwrittenSignaturesClientBuilder();
+                action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="tp::ServiceWithResourcesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddServiceWithResourcesClient(this IServiceCollection services, sys::Action<tp::ServiceWithResourcesClientBuilder> action = null) =>
+            services.AddSingleton(provider =>
+            {
+                tp::ServiceWithResourcesClientBuilder builder = new tp::ServiceWithResourcesClientBuilder();
+                action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithHandwrittenSignaturesClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithHandwrittenSignaturesClient.g.cs
@@ -1,0 +1,340 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+#pragma warning disable CS8981
+using gax = Google.Api.Gax;
+using gaxgrpc = Google.Api.Gax.Grpc;
+using proto = Google.Protobuf;
+using grpccore = Grpc.Core;
+using grpcinter = Grpc.Core.Interceptors;
+using mel = Microsoft.Extensions.Logging;
+using sys = System;
+using scg = System.Collections.Generic;
+using sco = System.Collections.ObjectModel;
+using st = System.Threading;
+using stt = System.Threading.Tasks;
+
+namespace Testing.PublishingSettings
+{
+    /// <summary>Settings for <see cref="ServiceWithHandwrittenSignaturesClient"/> instances.</summary>
+    public sealed partial class ServiceWithHandwrittenSignaturesSettings : gaxgrpc::ServiceSettingsBase
+    {
+        /// <summary>Get a new instance of the default <see cref="ServiceWithHandwrittenSignaturesSettings"/>.</summary>
+        /// <returns>A new instance of the default <see cref="ServiceWithHandwrittenSignaturesSettings"/>.</returns>
+        public static ServiceWithHandwrittenSignaturesSettings GetDefault() => new ServiceWithHandwrittenSignaturesSettings();
+
+        /// <summary>
+        /// Constructs a new <see cref="ServiceWithHandwrittenSignaturesSettings"/> object with default settings.
+        /// </summary>
+        public ServiceWithHandwrittenSignaturesSettings()
+        {
+        }
+
+        private ServiceWithHandwrittenSignaturesSettings(ServiceWithHandwrittenSignaturesSettings existing) : base(existing)
+        {
+            gax::GaxPreconditions.CheckNotNull(existing, nameof(existing));
+            AMethodSettings = existing.AMethodSettings;
+            OnCopy(existing);
+        }
+
+        partial void OnCopy(ServiceWithHandwrittenSignaturesSettings existing);
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>ServiceWithHandwrittenSignaturesClient.AMethod</c> and
+        /// <c>ServiceWithHandwrittenSignaturesClient.AMethodAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// <list type="bullet">
+        /// <item><description>This call will not be retried.</description></item>
+        /// <item><description>No timeout is applied.</description></item>
+        /// </list>
+        /// </remarks>
+        public gaxgrpc::CallSettings AMethodSettings { get; set; } = gaxgrpc::CallSettings.FromExpiration(gax::Expiration.None);
+
+        /// <summary>Creates a deep clone of this object, with all the same property values.</summary>
+        /// <returns>A deep clone of this <see cref="ServiceWithHandwrittenSignaturesSettings"/> object.</returns>
+        public ServiceWithHandwrittenSignaturesSettings Clone() => new ServiceWithHandwrittenSignaturesSettings(this);
+    }
+
+    /// <summary>
+    /// Builder class for <see cref="ServiceWithHandwrittenSignaturesClient"/> to provide simple configuration of
+    /// credentials, endpoint etc.
+    /// </summary>
+    public sealed partial class ServiceWithHandwrittenSignaturesClientBuilder : gaxgrpc::ClientBuilderBase<ServiceWithHandwrittenSignaturesClient>
+    {
+        /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
+        public ServiceWithHandwrittenSignaturesSettings Settings { get; set; }
+
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ServiceWithHandwrittenSignaturesClientBuilder() : base(ServiceWithHandwrittenSignaturesClient.ServiceMetadata)
+        {
+        }
+
+        partial void InterceptBuild(ref ServiceWithHandwrittenSignaturesClient client);
+
+        partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ServiceWithHandwrittenSignaturesClient> task);
+
+        /// <summary>Builds the resulting client.</summary>
+        public override ServiceWithHandwrittenSignaturesClient Build()
+        {
+            ServiceWithHandwrittenSignaturesClient client = null;
+            InterceptBuild(ref client);
+            return client ?? BuildImpl();
+        }
+
+        /// <summary>Builds the resulting client asynchronously.</summary>
+        public override stt::Task<ServiceWithHandwrittenSignaturesClient> BuildAsync(st::CancellationToken cancellationToken = default)
+        {
+            stt::Task<ServiceWithHandwrittenSignaturesClient> task = null;
+            InterceptBuildAsync(cancellationToken, ref task);
+            return task ?? BuildAsyncImpl(cancellationToken);
+        }
+
+        private ServiceWithHandwrittenSignaturesClient BuildImpl()
+        {
+            Validate();
+            grpccore::CallInvoker callInvoker = CreateCallInvoker();
+            return ServiceWithHandwrittenSignaturesClient.Create(callInvoker, Settings, Logger);
+        }
+
+        private async stt::Task<ServiceWithHandwrittenSignaturesClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
+        {
+            Validate();
+            grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
+            return ServiceWithHandwrittenSignaturesClient.Create(callInvoker, Settings, Logger);
+        }
+
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
+        protected override gaxgrpc::ChannelPool GetChannelPool() => ServiceWithHandwrittenSignaturesClient.ChannelPool;
+    }
+
+    /// <summary>ServiceWithHandwrittenSignatures client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// This is a service with a handwritten signature.
+    /// </remarks>
+    public abstract partial class ServiceWithHandwrittenSignaturesClient
+    {
+        /// <summary>
+        /// The default endpoint for the ServiceWithHandwrittenSignatures service, which is a host of "" and a port of
+        /// 443.
+        /// </summary>
+        public static string DefaultEndpoint { get; } = ":443";
+
+        /// <summary>The default ServiceWithHandwrittenSignatures scopes.</summary>
+        /// <remarks>The default ServiceWithHandwrittenSignatures scopes are:<list type="bullet"></list></remarks>
+        public static scg::IReadOnlyList<string> DefaultScopes { get; } = new sco::ReadOnlyCollection<string>(new string[] { });
+
+        /// <summary>The service metadata associated with this client type.</summary>
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(ServiceWithHandwrittenSignatures.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
+
+        /// <summary>
+        /// Asynchronously creates a <see cref="ServiceWithHandwrittenSignaturesClient"/> using the default credentials,
+        /// endpoint and settings. To specify custom credentials or other settings, use
+        /// <see cref="ServiceWithHandwrittenSignaturesClientBuilder"/>.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// The <see cref="st::CancellationToken"/> to use while creating the client.
+        /// </param>
+        /// <returns>The task representing the created <see cref="ServiceWithHandwrittenSignaturesClient"/>.</returns>
+        public static stt::Task<ServiceWithHandwrittenSignaturesClient> CreateAsync(st::CancellationToken cancellationToken = default) =>
+            new ServiceWithHandwrittenSignaturesClientBuilder().BuildAsync(cancellationToken);
+
+        /// <summary>
+        /// Synchronously creates a <see cref="ServiceWithHandwrittenSignaturesClient"/> using the default credentials,
+        /// endpoint and settings. To specify custom credentials or other settings, use
+        /// <see cref="ServiceWithHandwrittenSignaturesClientBuilder"/>.
+        /// </summary>
+        /// <returns>The created <see cref="ServiceWithHandwrittenSignaturesClient"/>.</returns>
+        public static ServiceWithHandwrittenSignaturesClient Create() =>
+            new ServiceWithHandwrittenSignaturesClientBuilder().Build();
+
+        /// <summary>
+        /// Creates a <see cref="ServiceWithHandwrittenSignaturesClient"/> which uses the specified call invoker for
+        /// remote operations.
+        /// </summary>
+        /// <param name="callInvoker">
+        /// The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.
+        /// </param>
+        /// <param name="settings">Optional <see cref="ServiceWithHandwrittenSignaturesSettings"/>.</param>
+        /// <param name="logger">Optional <see cref="mel::ILogger"/>.</param>
+        /// <returns>The created <see cref="ServiceWithHandwrittenSignaturesClient"/>.</returns>
+        internal static ServiceWithHandwrittenSignaturesClient Create(grpccore::CallInvoker callInvoker, ServiceWithHandwrittenSignaturesSettings settings = null, mel::ILogger logger = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            grpcinter::Interceptor interceptor = settings?.Interceptor;
+            if (interceptor != null)
+            {
+                callInvoker = grpcinter::CallInvokerExtensions.Intercept(callInvoker, interceptor);
+            }
+            ServiceWithHandwrittenSignatures.ServiceWithHandwrittenSignaturesClient grpcClient = new ServiceWithHandwrittenSignatures.ServiceWithHandwrittenSignaturesClient(callInvoker);
+            return new ServiceWithHandwrittenSignaturesClientImpl(grpcClient, settings, logger);
+        }
+
+        /// <summary>
+        /// Shuts down any channels automatically created by <see cref="Create()"/> and
+        /// <see cref="CreateAsync(st::CancellationToken)"/>. Channels which weren't automatically created are not
+        /// affected.
+        /// </summary>
+        /// <remarks>
+        /// After calling this method, further calls to <see cref="Create()"/> and
+        /// <see cref="CreateAsync(st::CancellationToken)"/> will create new channels, which could in turn be shut down
+        /// by another call to this method.
+        /// </remarks>
+        /// <returns>A task representing the asynchronous shutdown operation.</returns>
+        public static stt::Task ShutdownDefaultChannelsAsync() => ChannelPool.ShutdownChannelsAsync();
+
+        /// <summary>The underlying gRPC ServiceWithHandwrittenSignatures client</summary>
+        public virtual ServiceWithHandwrittenSignatures.ServiceWithHandwrittenSignaturesClient GrpcClient => throw new sys::NotImplementedException();
+
+        /// <summary>
+        /// Test summary text for AMethod
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The RPC response.</returns>
+        public virtual Response AMethod(Request request, gaxgrpc::CallSettings callSettings = null) =>
+            throw new sys::NotImplementedException();
+
+        /// <summary>
+        /// Test summary text for AMethod
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual stt::Task<Response> AMethodAsync(Request request, gaxgrpc::CallSettings callSettings = null) =>
+            throw new sys::NotImplementedException();
+
+        /// <summary>
+        /// Test summary text for AMethod
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="cancellationToken">A <see cref="st::CancellationToken"/> to use for this RPC.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual stt::Task<Response> AMethodAsync(Request request, st::CancellationToken cancellationToken) =>
+            AMethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Test summary text for AMethod
+        /// </summary>
+        /// <param name="string1">
+        /// </param>
+        /// <param name="string2">
+        /// </param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The RPC response.</returns>
+        public virtual Response AMethod(string string1, string string2, gaxgrpc::CallSettings callSettings = null) =>
+            AMethod(new Request
+            {
+                String1 = string1 ?? "",
+                String2 = string2 ?? "",
+            }, callSettings);
+
+        /// <summary>
+        /// Test summary text for AMethod
+        /// </summary>
+        /// <param name="string1">
+        /// </param>
+        /// <param name="string2">
+        /// </param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual stt::Task<Response> AMethodAsync(string string1, string string2, gaxgrpc::CallSettings callSettings = null) =>
+            AMethodAsync(new Request
+            {
+                String1 = string1 ?? "",
+                String2 = string2 ?? "",
+            }, callSettings);
+
+        /// <summary>
+        /// Test summary text for AMethod
+        /// </summary>
+        /// <param name="string1">
+        /// </param>
+        /// <param name="string2">
+        /// </param>
+        /// <param name="cancellationToken">A <see cref="st::CancellationToken"/> to use for this RPC.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual stt::Task<Response> AMethodAsync(string string1, string string2, st::CancellationToken cancellationToken) =>
+            AMethodAsync(string1, string2, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+    }
+
+    /// <summary>ServiceWithHandwrittenSignatures client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// This is a service with a handwritten signature.
+    /// </remarks>
+    public sealed partial class ServiceWithHandwrittenSignaturesClientImpl : ServiceWithHandwrittenSignaturesClient
+    {
+        private readonly gaxgrpc::ApiCall<Request, Response> _callAMethod;
+
+        /// <summary>
+        /// Constructs a client wrapper for the ServiceWithHandwrittenSignatures service, with the specified gRPC client
+        /// and settings.
+        /// </summary>
+        /// <param name="grpcClient">The underlying gRPC client.</param>
+        /// <param name="settings">
+        /// The base <see cref="ServiceWithHandwrittenSignaturesSettings"/> used within this client.
+        /// </param>
+        /// <param name="logger">Optional <see cref="mel::ILogger"/> to use within this client.</param>
+        public ServiceWithHandwrittenSignaturesClientImpl(ServiceWithHandwrittenSignatures.ServiceWithHandwrittenSignaturesClient grpcClient, ServiceWithHandwrittenSignaturesSettings settings, mel::ILogger logger)
+        {
+            GrpcClient = grpcClient;
+            ServiceWithHandwrittenSignaturesSettings effectiveSettings = settings ?? ServiceWithHandwrittenSignaturesSettings.GetDefault();
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            _callAMethod = clientHelper.BuildApiCall<Request, Response>("AMethod", grpcClient.AMethodAsync, grpcClient.AMethod, effectiveSettings.AMethodSettings);
+            Modify_ApiCall(ref _callAMethod);
+            Modify_AMethodApiCall(ref _callAMethod);
+            OnConstruction(grpcClient, effectiveSettings, clientHelper);
+        }
+
+        partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call) where TRequest : class, proto::IMessage<TRequest> where TResponse : class, proto::IMessage<TResponse>;
+
+        partial void Modify_AMethodApiCall(ref gaxgrpc::ApiCall<Request, Response> call);
+
+        partial void OnConstruction(ServiceWithHandwrittenSignatures.ServiceWithHandwrittenSignaturesClient grpcClient, ServiceWithHandwrittenSignaturesSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);
+
+        /// <summary>The underlying gRPC ServiceWithHandwrittenSignatures client</summary>
+        public override ServiceWithHandwrittenSignatures.ServiceWithHandwrittenSignaturesClient GrpcClient { get; }
+
+        partial void Modify_Request(ref Request request, ref gaxgrpc::CallSettings settings);
+
+        /// <summary>
+        /// Test summary text for AMethod
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The RPC response.</returns>
+        public override Response AMethod(Request request, gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_Request(ref request, ref callSettings);
+            return _callAMethod.Sync(request, callSettings);
+        }
+
+        /// <summary>
+        /// Test summary text for AMethod
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public override stt::Task<Response> AMethodAsync(Request request, gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_Request(ref request, ref callSettings);
+            return _callAMethod.Async(request, callSettings);
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithResourcesClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithResourcesClient.g.cs
@@ -1,0 +1,289 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+#pragma warning disable CS8981
+using gax = Google.Api.Gax;
+using gaxgrpc = Google.Api.Gax.Grpc;
+using proto = Google.Protobuf;
+using grpccore = Grpc.Core;
+using grpcinter = Grpc.Core.Interceptors;
+using mel = Microsoft.Extensions.Logging;
+using sys = System;
+using scg = System.Collections.Generic;
+using sco = System.Collections.ObjectModel;
+using st = System.Threading;
+using stt = System.Threading.Tasks;
+
+namespace Testing.PublishingSettings
+{
+    /// <summary>Settings for <see cref="ServiceWithResourcesClient"/> instances.</summary>
+    public sealed partial class ServiceWithResourcesSettings : gaxgrpc::ServiceSettingsBase
+    {
+        /// <summary>Get a new instance of the default <see cref="ServiceWithResourcesSettings"/>.</summary>
+        /// <returns>A new instance of the default <see cref="ServiceWithResourcesSettings"/>.</returns>
+        public static ServiceWithResourcesSettings GetDefault() => new ServiceWithResourcesSettings();
+
+        /// <summary>Constructs a new <see cref="ServiceWithResourcesSettings"/> object with default settings.</summary>
+        public ServiceWithResourcesSettings()
+        {
+        }
+
+        private ServiceWithResourcesSettings(ServiceWithResourcesSettings existing) : base(existing)
+        {
+            gax::GaxPreconditions.CheckNotNull(existing, nameof(existing));
+            AMethodSettings = existing.AMethodSettings;
+            OnCopy(existing);
+        }
+
+        partial void OnCopy(ServiceWithResourcesSettings existing);
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>ServiceWithResourcesClient.AMethod</c> and <c>ServiceWithResourcesClient.AMethodAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// <list type="bullet">
+        /// <item><description>This call will not be retried.</description></item>
+        /// <item><description>No timeout is applied.</description></item>
+        /// </list>
+        /// </remarks>
+        public gaxgrpc::CallSettings AMethodSettings { get; set; } = gaxgrpc::CallSettings.FromExpiration(gax::Expiration.None);
+
+        /// <summary>Creates a deep clone of this object, with all the same property values.</summary>
+        /// <returns>A deep clone of this <see cref="ServiceWithResourcesSettings"/> object.</returns>
+        public ServiceWithResourcesSettings Clone() => new ServiceWithResourcesSettings(this);
+    }
+
+    /// <summary>
+    /// Builder class for <see cref="ServiceWithResourcesClient"/> to provide simple configuration of credentials,
+    /// endpoint etc.
+    /// </summary>
+    public sealed partial class ServiceWithResourcesClientBuilder : gaxgrpc::ClientBuilderBase<ServiceWithResourcesClient>
+    {
+        /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
+        public ServiceWithResourcesSettings Settings { get; set; }
+
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ServiceWithResourcesClientBuilder() : base(ServiceWithResourcesClient.ServiceMetadata)
+        {
+        }
+
+        partial void InterceptBuild(ref ServiceWithResourcesClient client);
+
+        partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ServiceWithResourcesClient> task);
+
+        /// <summary>Builds the resulting client.</summary>
+        public override ServiceWithResourcesClient Build()
+        {
+            ServiceWithResourcesClient client = null;
+            InterceptBuild(ref client);
+            return client ?? BuildImpl();
+        }
+
+        /// <summary>Builds the resulting client asynchronously.</summary>
+        public override stt::Task<ServiceWithResourcesClient> BuildAsync(st::CancellationToken cancellationToken = default)
+        {
+            stt::Task<ServiceWithResourcesClient> task = null;
+            InterceptBuildAsync(cancellationToken, ref task);
+            return task ?? BuildAsyncImpl(cancellationToken);
+        }
+
+        private ServiceWithResourcesClient BuildImpl()
+        {
+            Validate();
+            grpccore::CallInvoker callInvoker = CreateCallInvoker();
+            return ServiceWithResourcesClient.Create(callInvoker, Settings, Logger);
+        }
+
+        private async stt::Task<ServiceWithResourcesClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
+        {
+            Validate();
+            grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
+            return ServiceWithResourcesClient.Create(callInvoker, Settings, Logger);
+        }
+
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
+        protected override gaxgrpc::ChannelPool GetChannelPool() => ServiceWithResourcesClient.ChannelPool;
+    }
+
+    /// <summary>ServiceWithResources client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// This is a service using resources.
+    /// </remarks>
+    public abstract partial class ServiceWithResourcesClient
+    {
+        /// <summary>
+        /// The default endpoint for the ServiceWithResources service, which is a host of "" and a port of 443.
+        /// </summary>
+        public static string DefaultEndpoint { get; } = ":443";
+
+        /// <summary>The default ServiceWithResources scopes.</summary>
+        /// <remarks>The default ServiceWithResources scopes are:<list type="bullet"></list></remarks>
+        public static scg::IReadOnlyList<string> DefaultScopes { get; } = new sco::ReadOnlyCollection<string>(new string[] { });
+
+        /// <summary>The service metadata associated with this client type.</summary>
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(ServiceWithResources.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
+
+        /// <summary>
+        /// Asynchronously creates a <see cref="ServiceWithResourcesClient"/> using the default credentials, endpoint
+        /// and settings. To specify custom credentials or other settings, use
+        /// <see cref="ServiceWithResourcesClientBuilder"/>.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// The <see cref="st::CancellationToken"/> to use while creating the client.
+        /// </param>
+        /// <returns>The task representing the created <see cref="ServiceWithResourcesClient"/>.</returns>
+        public static stt::Task<ServiceWithResourcesClient> CreateAsync(st::CancellationToken cancellationToken = default) =>
+            new ServiceWithResourcesClientBuilder().BuildAsync(cancellationToken);
+
+        /// <summary>
+        /// Synchronously creates a <see cref="ServiceWithResourcesClient"/> using the default credentials, endpoint and
+        /// settings. To specify custom credentials or other settings, use
+        /// <see cref="ServiceWithResourcesClientBuilder"/>.
+        /// </summary>
+        /// <returns>The created <see cref="ServiceWithResourcesClient"/>.</returns>
+        public static ServiceWithResourcesClient Create() => new ServiceWithResourcesClientBuilder().Build();
+
+        /// <summary>
+        /// Creates a <see cref="ServiceWithResourcesClient"/> which uses the specified call invoker for remote
+        /// operations.
+        /// </summary>
+        /// <param name="callInvoker">
+        /// The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.
+        /// </param>
+        /// <param name="settings">Optional <see cref="ServiceWithResourcesSettings"/>.</param>
+        /// <param name="logger">Optional <see cref="mel::ILogger"/>.</param>
+        /// <returns>The created <see cref="ServiceWithResourcesClient"/>.</returns>
+        internal static ServiceWithResourcesClient Create(grpccore::CallInvoker callInvoker, ServiceWithResourcesSettings settings = null, mel::ILogger logger = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            grpcinter::Interceptor interceptor = settings?.Interceptor;
+            if (interceptor != null)
+            {
+                callInvoker = grpcinter::CallInvokerExtensions.Intercept(callInvoker, interceptor);
+            }
+            ServiceWithResources.ServiceWithResourcesClient grpcClient = new ServiceWithResources.ServiceWithResourcesClient(callInvoker);
+            return new ServiceWithResourcesClientImpl(grpcClient, settings, logger);
+        }
+
+        /// <summary>
+        /// Shuts down any channels automatically created by <see cref="Create()"/> and
+        /// <see cref="CreateAsync(st::CancellationToken)"/>. Channels which weren't automatically created are not
+        /// affected.
+        /// </summary>
+        /// <remarks>
+        /// After calling this method, further calls to <see cref="Create()"/> and
+        /// <see cref="CreateAsync(st::CancellationToken)"/> will create new channels, which could in turn be shut down
+        /// by another call to this method.
+        /// </remarks>
+        /// <returns>A task representing the asynchronous shutdown operation.</returns>
+        public static stt::Task ShutdownDefaultChannelsAsync() => ChannelPool.ShutdownChannelsAsync();
+
+        /// <summary>The underlying gRPC ServiceWithResources client</summary>
+        public virtual ServiceWithResources.ServiceWithResourcesClient GrpcClient => throw new sys::NotImplementedException();
+
+        /// <summary>
+        /// Test summary text for AMethod
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The RPC response.</returns>
+        public virtual Resource AMethod(ResourceRequest request, gaxgrpc::CallSettings callSettings = null) =>
+            throw new sys::NotImplementedException();
+
+        /// <summary>
+        /// Test summary text for AMethod
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual stt::Task<Resource> AMethodAsync(ResourceRequest request, gaxgrpc::CallSettings callSettings = null) =>
+            throw new sys::NotImplementedException();
+
+        /// <summary>
+        /// Test summary text for AMethod
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="cancellationToken">A <see cref="st::CancellationToken"/> to use for this RPC.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual stt::Task<Resource> AMethodAsync(ResourceRequest request, st::CancellationToken cancellationToken) =>
+            AMethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+    }
+
+    /// <summary>ServiceWithResources client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// This is a service using resources.
+    /// </remarks>
+    public sealed partial class ServiceWithResourcesClientImpl : ServiceWithResourcesClient
+    {
+        private readonly gaxgrpc::ApiCall<ResourceRequest, Resource> _callAMethod;
+
+        /// <summary>
+        /// Constructs a client wrapper for the ServiceWithResources service, with the specified gRPC client and
+        /// settings.
+        /// </summary>
+        /// <param name="grpcClient">The underlying gRPC client.</param>
+        /// <param name="settings">The base <see cref="ServiceWithResourcesSettings"/> used within this client.</param>
+        /// <param name="logger">Optional <see cref="mel::ILogger"/> to use within this client.</param>
+        public ServiceWithResourcesClientImpl(ServiceWithResources.ServiceWithResourcesClient grpcClient, ServiceWithResourcesSettings settings, mel::ILogger logger)
+        {
+            GrpcClient = grpcClient;
+            ServiceWithResourcesSettings effectiveSettings = settings ?? ServiceWithResourcesSettings.GetDefault();
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            _callAMethod = clientHelper.BuildApiCall<ResourceRequest, Resource>("AMethod", grpcClient.AMethodAsync, grpcClient.AMethod, effectiveSettings.AMethodSettings);
+            Modify_ApiCall(ref _callAMethod);
+            Modify_AMethodApiCall(ref _callAMethod);
+            OnConstruction(grpcClient, effectiveSettings, clientHelper);
+        }
+
+        partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call) where TRequest : class, proto::IMessage<TRequest> where TResponse : class, proto::IMessage<TResponse>;
+
+        partial void Modify_AMethodApiCall(ref gaxgrpc::ApiCall<ResourceRequest, Resource> call);
+
+        partial void OnConstruction(ServiceWithResources.ServiceWithResourcesClient grpcClient, ServiceWithResourcesSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);
+
+        /// <summary>The underlying gRPC ServiceWithResources client</summary>
+        public override ServiceWithResources.ServiceWithResourcesClient GrpcClient { get; }
+
+        partial void Modify_ResourceRequest(ref ResourceRequest request, ref gaxgrpc::CallSettings settings);
+
+        /// <summary>
+        /// Test summary text for AMethod
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The RPC response.</returns>
+        public override Resource AMethod(ResourceRequest request, gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_ResourceRequest(ref request, ref callSettings);
+            return _callAMethod.Sync(request, callSettings);
+        }
+
+        /// <summary>
+        /// Test summary text for AMethod
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public override stt::Task<Resource> AMethodAsync(ResourceRequest request, gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_ResourceRequest(ref request, ref callSettings);
+            return _callAMethod.Async(request, callSettings);
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/Testing.PublishingSettings.csproj
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/Testing.PublishingSettings.csproj
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+
+    <!-- TODO: Version defaults to 1.0.0-alpha01, edit as required -->
+    <Version>1.0.0-alpha01</Version>
+
+    <!-- TODO: NuGet packaging options -->
+    <!--
+      <Description>
+        TODO: Description of this library.
+      </Description>
+      <PackageTags>TODO;Library;Tags</PackageTags>
+      <Copyright>TODO: Copyright Statement</Copyright>
+      <Authors>TODO:Authors</Authors>
+      *** TODO: These Icon, License, Project, and repo settings *MUST* be checked and edited ***
+      *** The values given are just examples ***
+      <PackageIconUrl>TODO: https://cloud.google.com/images/gcp-icon-64x64.png</PackageIconUrl>
+      <PackageLicenseUrl>TODO: https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+      <PackageProjectUrl>TODO: https://github.com/googleapis/google-cloud-dotnet</PackageProjectUrl>
+      <RepositoryType>TODO: git</RepositoryType>
+      <RepositoryUrl>TODO: https://github.com/googleapis/google-cloud-dotnet</RepositoryUrl>
+    -->
+
+    <!-- TODO: Configure package signing -->
+    <!--
+      <AssemblyOriginatorKeyFile>...</AssemblyOriginatorKeyFile>
+      <SignAssembly>true</SignAssembly>
+      <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
+    -->
+
+    <!-- These items should not require editing -->
+    <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Deterministic>true</Deterministic>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
+  </ItemGroup>
+
+</Project>

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/gapic_metadata.json
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/gapic_metadata.json
@@ -1,0 +1,54 @@
+{
+  "schema": "1.0",
+  "comment": "This file maps proto services/RPCs to the corresponding library clients/methods",
+  "language": "csharp",
+  "protoPackage": "testing.publishingsettings",
+  "libraryPackage": "Testing.PublishingSettings",
+  "services": {
+    "OriginalServiceName": {
+      "clients": {
+        "grpc": {
+          "libraryClient": "RenamedServiceNameClient",
+          "rpcs": {
+            "AMethod": {
+              "methods": [
+                "AMethod",
+                "AMethodAsync"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "ServiceWithHandwrittenSignatures": {
+      "clients": {
+        "grpc": {
+          "libraryClient": "ServiceWithHandwrittenSignaturesClient",
+          "rpcs": {
+            "AMethod": {
+              "methods": [
+                "AMethod",
+                "AMethodAsync"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "ServiceWithResources": {
+      "clients": {
+        "grpc": {
+          "libraryClient": "ServiceWithResourcesClient",
+          "rpcs": {
+            "AMethod": {
+              "methods": [
+                "AMethod",
+                "AMethodAsync"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/Google.Api.Generator/Generation/LroAdaptationGenerator.cs
+++ b/Google.Api.Generator/Generation/LroAdaptationGenerator.cs
@@ -75,7 +75,7 @@ namespace Google.Api.Generator.Generation
         {
             foreach (var service in _fileDesc.Services)
             {
-                var serviceDetails = new ServiceDetails(_catalog, _ctx.Namespace, service, grpcServiceConfig: null, serviceConfig: null, transports: ApiTransports.None);
+                var serviceDetails = new ServiceDetails(_catalog, _ctx.Namespace, service, grpcServiceConfig: null, serviceConfig: null, transports: ApiTransports.None, librarySettings: null);
                 // Assumption: each method has its own request type.
                 foreach (var method in serviceDetails.Methods.OfType<MethodDetails.NonStandardLro>())
                 {
@@ -119,7 +119,7 @@ namespace Google.Api.Generator.Generation
         {
             foreach (var service in _fileDesc.Services)
             {
-                var serviceDetails = new ServiceDetails(_catalog, _ctx.Namespace, service, grpcServiceConfig: null, serviceConfig: null, transports: ApiTransports.None);
+                var serviceDetails = new ServiceDetails(_catalog, _ctx.Namespace, service, grpcServiceConfig: null, serviceConfig: null, transports: ApiTransports.None, librarySettings: null);
                 // TODO: Use "is not" and continue when we can guarantee a recent enough version of C#.
                 if (serviceDetails.NonStandardLro is ServiceDetails.NonStandardLroDetails lroDetails)
                 {

--- a/Google.Api.Generator/Generation/MetadataGenerator.cs
+++ b/Google.Api.Generator/Generation/MetadataGenerator.cs
@@ -34,7 +34,7 @@ namespace Google.Api.Generator.Generation
             var protoPackage = primaryLibraryServices.First().ProtoPackage;
             var libraryNamespace = primaryLibraryServices.First().Namespace;
             var servicesByName = new SortedDictionary<string, ServiceForTransport>(
-                primaryLibraryServices.ToDictionary(serviceDetails => serviceDetails.ServiceName, ServiceForTransportMetadata),
+                primaryLibraryServices.ToDictionary(serviceDetails => serviceDetails.OriginalServiceName, ServiceForTransportMetadata),
                 StringComparer.Ordinal);
 
             return new GapicMetadata

--- a/Google.Api.Generator/Generation/ServiceMethodGenerator.Signatures.cs
+++ b/Google.Api.Generator/Generation/ServiceMethodGenerator.Signatures.cs
@@ -207,6 +207,7 @@ namespace Google.Api.Generator.Generation
                     }
                 }
 
+                public bool HasHandWrittenEquivalent => _sig.HasHandwrittenEquivalent;
                 public MethodDeclarationSyntax AbstractSyncRequestMethod => AbstractRequestMethod(true, true, Parameters);
                 public MethodDeclarationSyntax AbstractAsyncCallSettingsRequestMethod => AbstractRequestMethod(false, true, Parameters);
                 public MethodDeclarationSyntax AbstractAsyncCancellationTokenRequestMethod => AbstractRequestMethod(false, false, Parameters);
@@ -275,6 +276,11 @@ namespace Google.Api.Generator.Generation
 
                 public IEnumerable<ResourceName> ResourceNames => ResourceName.Create(this);
             }
+
+            /// <summary>
+            /// Where hand-written equivalents are provided, we don't generate overloads in the client.
+            /// </summary>
+            public IEnumerable<Signature> SignaturesToGenerate => Signatures.Where(sig => !sig.HasHandWrittenEquivalent);
 
             public IEnumerable<Signature> Signatures => MethodDetails.Signatures.Select(sig => new Signature(this, sig));
         }

--- a/Google.Api.Generator/Generation/ServiceMethodGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceMethodGenerator.cs
@@ -58,7 +58,7 @@ namespace Google.Api.Generator.Generation
                         yield return method.AbstractSyncRequestMethod;
                         yield return method.AbstractAsyncCallSettingsRequestMethod;
                         yield return method.AbstractAsyncCancellationTokenRequestMethod;
-                        foreach (var signature in method.Signatures)
+                        foreach (var signature in method.SignaturesToGenerate)
                         {
                             yield return signature.AbstractSyncRequestMethod;
                             yield return signature.AbstractAsyncCallSettingsRequestMethod;
@@ -74,7 +74,7 @@ namespace Google.Api.Generator.Generation
                     case MethodDetails.Paginated _:
                         yield return method.AbstractSyncRequestMethod;
                         yield return method.AbstractAsyncCallSettingsRequestMethod;
-                        foreach (var signature in method.Signatures)
+                        foreach (var signature in method.SignaturesToGenerate)
                         {
                             yield return signature.AbstractSyncPaginatedRequestMethod;
                             yield return signature.AbstractAsyncPaginatedCallSettingsRequestMethod;
@@ -92,7 +92,7 @@ namespace Google.Api.Generator.Generation
                         yield return method.AbstractLroOperationsClientProperty;
                         yield return method.AbstractLroSyncPollMethod;
                         yield return method.AbstractLroAsyncPollMethod;
-                        foreach (var signature in method.Signatures)
+                        foreach (var signature in method.SignaturesToGenerate)
                         {
                             yield return signature.AbstractSyncRequestMethod;
                             yield return signature.AbstractAsyncCallSettingsRequestMethod;
@@ -116,7 +116,7 @@ namespace Google.Api.Generator.Generation
                     case MethodDetails.ServerStreaming _:
                         yield return method.AbstractServerStreamClass;
                         yield return method.AbstractServerStreamSyncRequestMethod;
-                        foreach (var signature in method.Signatures)
+                        foreach (var signature in method.SignaturesToGenerate)
                         {
                             yield return signature.AbstractServerStreamSyncRequestMethod;
                             foreach (var resourceName in signature.ResourceNames)

--- a/Google.Api.Generator/Generation/SnippetCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/SnippetCodeGenerator.cs
@@ -225,7 +225,7 @@ namespace Google.Api.Generator.Generation
                             FullName = $"{TargetMethod.Svc.ServiceFullName}.{TargetMethod.ProtoRpcName}",
                             Service = new ServiceMetadata
                             {
-                                ShortName = TargetMethod.Svc.ServiceName,
+                                ShortName = TargetMethod.Svc.OriginalServiceName,
                                 FullName = TargetMethod.Svc.ServiceFullName
                             }
                         }
@@ -262,7 +262,7 @@ namespace Google.Api.Generator.Generation
 
                 string regionTagName =
                     // {apishortname}_{apiVersion}_generated_{serviceName}_{rpcName}_{sync|async}_{disambiguation}
-                    $"{effectiveShortName}{effectiveVersion}_generated_{TargetMethod.Svc.ServiceName}_{TargetMethod.ProtoRpcName}_{syncText}{effectiveDisambiguation}";
+                    $"{effectiveShortName}{effectiveVersion}_generated_{TargetMethod.Svc.OriginalServiceName}_{TargetMethod.ProtoRpcName}_{syncText}{effectiveDisambiguation}";
 
                 metadata.RegionTag = regionTagName;
 

--- a/Google.Api.Generator/Google.Api.Generator.csproj
+++ b/Google.Api.Generator/Google.Api.Generator.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Google.Api.CommonProtos" Version="2.8.0" />
+    <PackageReference Include="Google.Api.CommonProtos" Version="2.9.0" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="4.3.1" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="3.0.0" />
     <PackageReference Include="Google.Cloud.Location" Version="2.0.0" />

--- a/Google.Api.Generator/ProtoUtils/ProtoCatalog.cs
+++ b/Google.Api.Generator/ProtoUtils/ProtoCatalog.cs
@@ -31,15 +31,16 @@ namespace Google.Api.Generator.ProtoUtils
         /// <param name="allDescriptors">All the file descriptors that have been loaded.</param>
         /// <param name="requiredFileDescriptors">The file descriptors which *must* have their resource name fields resolved.</param>
         /// <param name="commonResourcesConfigs">The common resource name definitions.</param>
+        /// <param name="serviceConfig">The service configuration, used for additional settings.</param>
         public ProtoCatalog(
             string defaultPackage, IEnumerable<FileDescriptor> allDescriptors,
-            IEnumerable<FileDescriptor> requiredFileDescriptors, IEnumerable<CommonResources> commonResourcesConfigs)
+            IEnumerable<FileDescriptor> requiredFileDescriptors, IEnumerable<CommonResources> commonResourcesConfigs, ClientLibrarySettings librarySettings)
         {
             _defaultPackage = defaultPackage;
             allDescriptors = allDescriptors.ToList();
             _msgs = allDescriptors.SelectMany(desc => desc.MessageTypes).SelectMany(MsgPlusNested).ToDictionary(x => x.FullName);
             _services = allDescriptors.SelectMany(desc => desc.Services).ToDictionary(x => x.FullName);
-            _resourcesByFileName = ResourceDetails.LoadResourceDefinitionsByFileName(allDescriptors, commonResourcesConfigs).GroupBy(x => x.FileName)
+            _resourcesByFileName = ResourceDetails.LoadResourceDefinitionsByFileName(allDescriptors, commonResourcesConfigs, librarySettings).GroupBy(x => x.FileName)
                 .ToImmutableDictionary(x => x.Key, x => (IReadOnlyList<ResourceDetails.Definition>)x.ToImmutableList());
             var resourcesByUrt = _resourcesByFileName.Values.SelectMany(x => x).ToDictionary(x => x.UnifiedResourceTypeName);
             var resourcesByPatternComparison = _resourcesByFileName.Values.SelectMany(x => x)


### PR DESCRIPTION
This significantly reduces the amount of customization needed in google-cloud-dotnet.

Note: it's expected that this won't build yet, as the options aren't available yet...