### PR TITLE
chore: Update packaging to use PackageLicenseExpression

### DIFF
--- a/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.ManufacturerCenter.v1/Google.Apis.ManufacturerCenter.v1.csproj
+++ b/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.ManufacturerCenter.v1/Google.Apis.ManufacturerCenter.v1.csproj
@@ -8,7 +8,7 @@
     <Copyright>Copyright 2022 Google LLC</Copyright>
     <PackageTags>Google</PackageTags>
     <PackageProjectUrl>https://github.com/google/google-api-dotnet-client</PackageProjectUrl>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/google/google-api-dotnet-client</RepositoryUrl>
     <PackageIconUrl>https://www.gstatic.com/images/branding/product/1x/google_developers_64dp.png</PackageIconUrl>

--- a/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.Storage.v1/Google.Apis.Storage.v1.csproj
+++ b/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.Storage.v1/Google.Apis.Storage.v1.csproj
@@ -8,7 +8,7 @@
     <Copyright>Copyright 2022 Google LLC</Copyright>
     <PackageTags>Google</PackageTags>
     <PackageProjectUrl>https://github.com/google/google-api-dotnet-client</PackageProjectUrl>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/google/google-api-dotnet-client</RepositoryUrl>
     <PackageIconUrl>https://www.gstatic.com/images/branding/product/1x/google_developers_64dp.png</PackageIconUrl>

--- a/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.Translate.v2/Google.Apis.Translate.v2.csproj
+++ b/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.Translate.v2/Google.Apis.Translate.v2.csproj
@@ -8,7 +8,7 @@
     <Copyright>Copyright 2022 Google LLC</Copyright>
     <PackageTags>Google</PackageTags>
     <PackageProjectUrl>https://github.com/google/google-api-dotnet-client</PackageProjectUrl>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/google/google-api-dotnet-client</RepositoryUrl>
     <PackageIconUrl>https://www.gstatic.com/images/branding/product/1x/google_developers_64dp.png</PackageIconUrl>

--- a/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.Webfonts.v1/Google.Apis.Webfonts.v1.csproj
+++ b/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.Webfonts.v1/Google.Apis.Webfonts.v1.csproj
@@ -8,7 +8,7 @@
     <Copyright>Copyright 2022 Google LLC</Copyright>
     <PackageTags>Google</PackageTags>
     <PackageProjectUrl>https://github.com/google/google-api-dotnet-client</PackageProjectUrl>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/google/google-api-dotnet-client</RepositoryUrl>
     <PackageIconUrl>https://www.gstatic.com/images/branding/product/1x/google_developers_64dp.png</PackageIconUrl>

--- a/Google.Api.Generator.Rest/Models/PackageModel.cs
+++ b/Google.Api.Generator.Rest/Models/PackageModel.cs
@@ -323,7 +323,7 @@ namespace Google.Api.Generator.Rest.Models
                     new XElement("Copyright", $"Copyright {clock.GetCurrentDateTimeUtc().Year} {(_discoveryDoc.OwnerName == "Google" ? "Google LLC" : _discoveryDoc.OwnerName)}"),
                     new XElement("PackageTags", "Google"),
                     new XElement("PackageProjectUrl", "https://github.com/google/google-api-dotnet-client"),
-                    new XElement("PackageLicenseFile", "LICENSE"),
+                    new XElement("PackageLicenseExpression", "Apache-2.0"),
                     new XElement("RepositoryType", "git"),
                     new XElement("RepositoryUrl", "https://github.com/google/google-api-dotnet-client"),
                     new XElement("PackageIconUrl", "https://www.gstatic.com/images/branding/product/1x/google_developers_64dp.png"),


### PR DESCRIPTION
We still include the license file within the package, so we continue to meet all obligations, but this is easier for customers to validate.

(Non-urgent to review.)