### PR TITLE
fix: Filter which publication.library_settings we use by version

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/ServiceConfig.yaml
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/ServiceConfig.yaml
@@ -10,6 +10,7 @@ apis:
 
 publishing:
   librarySettings:
+  - version: testing.publishingsettings.wrong1
   - version: testing.publishingsettings
     dotnetSettings:
       ignored_resources:
@@ -20,3 +21,4 @@ publishing:
       - "ServiceWithHandwrittenSignatures.AMethod(string_1)"
       renamed_services:
         OriginalServiceName: RenamedServiceName
+  - version: testing.publishingsettings.wrong2

--- a/Google.Api.Generator/CodeGenerator.cs
+++ b/Google.Api.Generator/CodeGenerator.cs
@@ -123,9 +123,8 @@ namespace Google.Api.Generator
             var allServiceDetails = new List<ServiceDetails>();
             foreach (var singlePackageFileDescs in byPackage)
             {
-                // TODO: Actually make sure we use the right settings by version.
-                // Alternatively, ensure that each *published* service config only contains a single LibrarySettings entry.
-                var librarySettings = serviceConfig?.Publishing?.LibrarySettings?.FirstOrDefault();
+                // Find the right library settings by matching the proto package we're publishing.
+                var librarySettings = serviceConfig?.Publishing?.LibrarySettings?.FirstOrDefault(ls => ls.Version == singlePackageFileDescs.Key);
 
                 var namespaces = singlePackageFileDescs.Select(x => x.CSharpNamespace()).Distinct().ToList();
                 if (namespaces.Count > 1)


### PR DESCRIPTION
The "version" is actually the fully-qualified proto package... which we happen to already have to hand.

(This isn't urgent - please wait until you're back!)