### PR TITLE
feat: Generate dependencies for known packages

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/Google.Showcase.V1Beta1.csproj
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/Google.Showcase.V1Beta1.csproj
@@ -42,9 +42,9 @@
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" Condition="'$(TargetFramework)'=='net462'" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
-    <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
   </ItemGroup>
 
 </Project>

--- a/Google.Api.Generator/Generation/ServiceDetails.cs
+++ b/Google.Api.Generator/Generation/ServiceDetails.cs
@@ -38,9 +38,9 @@ namespace Google.Api.Generator.Generation
 
         private static readonly Dictionary<string, MixinDetails> AvailableMixins = new[]
         {
-            new MixinDetails(IAMPolicy.Descriptor.FullName, typeof(IAMPolicyClient), typeof(IAMPolicyClientImpl), typeof(IAMPolicy.IAMPolicyClient), typeof(IAMPolicySettings)),
-            new MixinDetails(Locations.Descriptor.FullName, typeof(LocationsClient), typeof(LocationsClientImpl), typeof(Locations.LocationsClient), typeof(LocationsSettings)),
-        }.ToDictionary(details => details.GrpcServiceName);
+            new MixinDetails(IAMPolicy.Descriptor, typeof(IAMPolicyClient), typeof(IAMPolicyClientImpl), typeof(IAMPolicy.IAMPolicyClient), typeof(IAMPolicySettings)),
+            new MixinDetails(Locations.Descriptor, typeof(LocationsClient), typeof(LocationsClientImpl), typeof(Locations.LocationsClient), typeof(LocationsSettings)),
+        }.ToDictionary(details => details.ProtobufServiceDescriptor.FullName);
 
         public ServiceDetails(ProtoCatalog catalog, string ns, ServiceDescriptor desc, ServiceConfig grpcServiceConfig, Service serviceConfig, ApiTransports transports, ClientLibrarySettings librarySettings)
         {
@@ -252,9 +252,10 @@ namespace Google.Api.Generator.Generation
         public class MixinDetails
         {
             /// <summary>
-            /// The fully-qualified gRPC service name, as specified in service config files.
+            /// The original protobuf service descriptor, which we expect
+            /// to have a gRPC client.
             /// </summary>
-            public string GrpcServiceName { get; }
+            public ServiceDescriptor ProtobufServiceDescriptor { get; }
 
             /// <summary>
             /// The type of the generated GAPIC client.
@@ -276,9 +277,9 @@ namespace Google.Api.Generator.Generation
             /// </summary>
             public Typ GapicSettingsType { get; }
 
-            public MixinDetails(string grpcServiceName, System.Type gapicClientType, System.Type gapicClientImplType, System.Type grpcClientType, System.Type gapicSettingsType)
+            public MixinDetails(ServiceDescriptor serviceDescriptor, System.Type gapicClientType, System.Type gapicClientImplType, System.Type grpcClientType, System.Type gapicSettingsType)
             {
-                GrpcServiceName = grpcServiceName;
+                ProtobufServiceDescriptor = serviceDescriptor;
                 GapicClientType = Typ.Of(gapicClientType);
                 GapicClientImplType = Typ.Of(gapicClientImplType);
                 GrpcClientType = Typ.Of(grpcClientType);


### PR DESCRIPTION
If we see that the NuGet package containing a mixin is required, even if we're not generating it as as mixin, include the package reference.