### PR TITLE
feat: Pin generated snippets namespace to GoogleCSharpSnippets.

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1.GeneratedSnippets/BasicClient.AMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1.GeneratedSnippets/BasicClient.AMethodRequestObjectAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Basic.V1.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START basic_v1_generated_Basic_AMethod_async]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1.GeneratedSnippets/BasicClient.AMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1.GeneratedSnippets/BasicClient.AMethodRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Basic.V1.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START basic_v1_generated_Basic_AMethod_sync]
     using Testing.Basic.V1;

--- a/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1.Snippets/BasicClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1.Snippets/BasicClientSnippets.g.cs
@@ -14,9 +14,10 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Basic.V1.Snippets
+namespace GoogleCSharpSnippets
 {
     using System.Threading.Tasks;
+    using Testing.Basic.V1;
 
     /// <summary>Generated snippets.</summary>
     public sealed class AllGeneratedBasicClientSnippets

--- a/Google.Api.Generator.Tests/ProtoTests/BasicLro/Testing.BasicLro.GeneratedSnippets/BasicLroClient.Method1RequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/BasicLro/Testing.BasicLro.GeneratedSnippets/BasicLroClient.Method1RequestObjectAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.BasicLro.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START lro_generated_BasicLro_Method1_async]
     using Google.LongRunning;

--- a/Google.Api.Generator.Tests/ProtoTests/BasicLro/Testing.BasicLro.GeneratedSnippets/BasicLroClient.Method1RequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/BasicLro/Testing.BasicLro.GeneratedSnippets/BasicLroClient.Method1RequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.BasicLro.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START lro_generated_BasicLro_Method1_sync]
     using Google.LongRunning;

--- a/Google.Api.Generator.Tests/ProtoTests/BasicLro/Testing.BasicLro.Snippets/BasicLroClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/BasicLro/Testing.BasicLro.Snippets/BasicLroClientSnippets.g.cs
@@ -14,10 +14,11 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.BasicLro.Snippets
+namespace GoogleCSharpSnippets
 {
     using Google.LongRunning;
     using System.Threading.Tasks;
+    using Testing.BasicLro;
 
     /// <summary>Generated snippets.</summary>
     public sealed class AllGeneratedBasicLroClientSnippets

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.GeneratedSnippets/DeprecatedClient.DeprecatedFieldMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.GeneratedSnippets/DeprecatedClient.DeprecatedFieldMethodAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Deprecated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START deprecated_generated_Deprecated_DeprecatedFieldMethod_async_flattened]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.GeneratedSnippets/DeprecatedClient.DeprecatedFieldMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.GeneratedSnippets/DeprecatedClient.DeprecatedFieldMethodRequestObjectAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Deprecated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START deprecated_generated_Deprecated_DeprecatedFieldMethod_async]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.GeneratedSnippets/DeprecatedClient.DeprecatedFieldMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.GeneratedSnippets/DeprecatedClient.DeprecatedFieldMethodRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Deprecated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START deprecated_generated_Deprecated_DeprecatedFieldMethod_sync]
     using Testing.Deprecated;

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.GeneratedSnippets/DeprecatedClient.DeprecatedFieldMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.GeneratedSnippets/DeprecatedClient.DeprecatedFieldMethodSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Deprecated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START deprecated_generated_Deprecated_DeprecatedFieldMethod_sync_flattened]
     using Testing.Deprecated;

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.GeneratedSnippets/DeprecatedClient.DeprecatedMessageMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.GeneratedSnippets/DeprecatedClient.DeprecatedMessageMethodRequestObjectAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Deprecated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START deprecated_generated_Deprecated_DeprecatedMessageMethod_async]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.GeneratedSnippets/DeprecatedClient.DeprecatedMessageMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.GeneratedSnippets/DeprecatedClient.DeprecatedMessageMethodRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Deprecated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START deprecated_generated_Deprecated_DeprecatedMessageMethod_sync]
     using Testing.Deprecated;

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.GeneratedSnippets/DeprecatedClient.DeprecatedMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.GeneratedSnippets/DeprecatedClient.DeprecatedMethodRequestObjectAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Deprecated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START deprecated_generated_Deprecated_DeprecatedMethod_async]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.GeneratedSnippets/DeprecatedClient.DeprecatedMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.GeneratedSnippets/DeprecatedClient.DeprecatedMethodRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Deprecated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START deprecated_generated_Deprecated_DeprecatedMethod_sync]
     using Testing.Deprecated;

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.GeneratedSnippets/DeprecatedClient.DeprecatedResponseMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.GeneratedSnippets/DeprecatedClient.DeprecatedResponseMethodRequestObjectAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Deprecated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START deprecated_generated_Deprecated_DeprecatedResponseMethod_async]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.GeneratedSnippets/DeprecatedClient.DeprecatedResponseMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.GeneratedSnippets/DeprecatedClient.DeprecatedResponseMethodRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Deprecated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START deprecated_generated_Deprecated_DeprecatedResponseMethod_sync]
     using Testing.Deprecated;

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.Snippets/DeprecatedClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated.Snippets/DeprecatedClientSnippets.g.cs
@@ -14,9 +14,10 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Deprecated.Snippets
+namespace GoogleCSharpSnippets
 {
     using System.Threading.Tasks;
+    using Testing.Deprecated;
 
     /// <summary>Generated snippets.</summary>
     public sealed class AllGeneratedDeprecatedClientSnippets

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.GeneratedSnippets/KeywordsClient.Method1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.GeneratedSnippets/KeywordsClient.Method1AsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Keywords.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_Keywords_Method1_async_flattened]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.GeneratedSnippets/KeywordsClient.Method1RequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.GeneratedSnippets/KeywordsClient.Method1RequestObjectAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Keywords.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_Keywords_Method1_async]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.GeneratedSnippets/KeywordsClient.Method1RequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.GeneratedSnippets/KeywordsClient.Method1RequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Keywords.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_Keywords_Method1_sync]
     using Testing.Keywords;

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.GeneratedSnippets/KeywordsClient.Method1ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.GeneratedSnippets/KeywordsClient.Method1ResourceNamesAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Keywords.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_Keywords_Method1_async_flattened_resourceNames]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.GeneratedSnippets/KeywordsClient.Method1ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.GeneratedSnippets/KeywordsClient.Method1ResourceNamesSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Keywords.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_Keywords_Method1_sync_flattened_resourceNames]
     using Testing.Keywords;

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.GeneratedSnippets/KeywordsClient.Method1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.GeneratedSnippets/KeywordsClient.Method1Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Keywords.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_Keywords_Method1_sync_flattened]
     using Testing.Keywords;

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.GeneratedSnippets/KeywordsClient.Method2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.GeneratedSnippets/KeywordsClient.Method2AsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Keywords.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_Keywords_Method2_async_flattened]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.GeneratedSnippets/KeywordsClient.Method2RequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.GeneratedSnippets/KeywordsClient.Method2RequestObjectAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Keywords.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_Keywords_Method2_async]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.GeneratedSnippets/KeywordsClient.Method2RequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.GeneratedSnippets/KeywordsClient.Method2RequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Keywords.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_Keywords_Method2_sync]
     using Testing.Keywords;

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.GeneratedSnippets/KeywordsClient.Method2ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.GeneratedSnippets/KeywordsClient.Method2ResourceNamesAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Keywords.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_Keywords_Method2_async_flattened_resourceNames]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.GeneratedSnippets/KeywordsClient.Method2ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.GeneratedSnippets/KeywordsClient.Method2ResourceNamesSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Keywords.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_Keywords_Method2_sync_flattened_resourceNames]
     using Testing.Keywords;

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.GeneratedSnippets/KeywordsClient.Method2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.GeneratedSnippets/KeywordsClient.Method2Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Keywords.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_Keywords_Method2_sync_flattened]
     using Testing.Keywords;

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.Snippets/KeywordsClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords.Snippets/KeywordsClientSnippets.g.cs
@@ -14,9 +14,10 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Keywords.Snippets
+namespace GoogleCSharpSnippets
 {
     using System.Threading.Tasks;
+    using Testing.Keywords;
 
     /// <summary>Generated snippets.</summary>
     public sealed class AllGeneratedKeywordsClientSnippets

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.ResourcedMethod1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.ResourcedMethod1AsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Paginated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START paginated_generated_Paginated_ResourcedMethod_async_flattened1]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.ResourcedMethod1ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.ResourcedMethod1ResourceNamesAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Paginated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START paginated_generated_Paginated_ResourcedMethod_async_flattened1_resourceNames]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.ResourcedMethod1ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.ResourcedMethod1ResourceNamesSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Paginated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START paginated_generated_Paginated_ResourcedMethod_sync_flattened1_resourceNames]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.ResourcedMethod1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.ResourcedMethod1Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Paginated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START paginated_generated_Paginated_ResourcedMethod_sync_flattened1]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.ResourcedMethod2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.ResourcedMethod2AsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Paginated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START paginated_generated_Paginated_ResourcedMethod_async_flattened2]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.ResourcedMethod2ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.ResourcedMethod2ResourceNamesAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Paginated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START paginated_generated_Paginated_ResourcedMethod_async_flattened2_resourceNames]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.ResourcedMethod2ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.ResourcedMethod2ResourceNamesSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Paginated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START paginated_generated_Paginated_ResourcedMethod_sync_flattened2_resourceNames]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.ResourcedMethod2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.ResourcedMethod2Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Paginated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START paginated_generated_Paginated_ResourcedMethod_sync_flattened2]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.ResourcedMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.ResourcedMethodRequestObjectAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Paginated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START paginated_generated_Paginated_ResourcedMethod_async]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.ResourcedMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.ResourcedMethodRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Paginated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START paginated_generated_Paginated_ResourcedMethod_sync]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.SignatureMethod1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.SignatureMethod1AsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Paginated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START paginated_generated_Paginated_SignatureMethod_async_flattened1]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.SignatureMethod1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.SignatureMethod1Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Paginated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START paginated_generated_Paginated_SignatureMethod_sync_flattened1]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.SignatureMethod2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.SignatureMethod2AsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Paginated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START paginated_generated_Paginated_SignatureMethod_async_flattened2]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.SignatureMethod2RequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.SignatureMethod2RequestObjectAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Paginated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START paginated_generated_Paginated_SignatureMethod2_async]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.SignatureMethod2RequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.SignatureMethod2RequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Paginated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START paginated_generated_Paginated_SignatureMethod2_sync]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.SignatureMethod2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.SignatureMethod2Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Paginated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START paginated_generated_Paginated_SignatureMethod_sync_flattened2]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.SignatureMethod3AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.SignatureMethod3AsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Paginated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START paginated_generated_Paginated_SignatureMethod_async_flattened3]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.SignatureMethod3Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.SignatureMethod3Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Paginated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START paginated_generated_Paginated_SignatureMethod_sync_flattened3]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.SignatureMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.SignatureMethodRequestObjectAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Paginated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START paginated_generated_Paginated_SignatureMethod_async]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.SignatureMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.GeneratedSnippets/PaginatedClient.SignatureMethodRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Paginated.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START paginated_generated_Paginated_SignatureMethod_sync]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.Snippets/PaginatedClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Testing.Paginated.Snippets/PaginatedClientSnippets.g.cs
@@ -14,12 +14,13 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Paginated.Snippets
+namespace GoogleCSharpSnippets
 {
     using Google.Api.Gax;
     using System;
     using System.Linq;
     using System.Threading.Tasks;
+    using Testing.Paginated;
 
     /// <summary>Generated snippets.</summary>
     public sealed class AllGeneratedPaginatedClientSnippets

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/RenamedServiceNameClient.AMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/RenamedServiceNameClient.AMethodRequestObjectAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.PublishingSettings.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_OriginalServiceName_AMethod_async]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/RenamedServiceNameClient.AMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/RenamedServiceNameClient.AMethodRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.PublishingSettings.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_OriginalServiceName_AMethod_sync]
     using Testing.PublishingSettings;

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithHandwrittenSignaturesClient.AMethod1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithHandwrittenSignaturesClient.AMethod1AsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.PublishingSettings.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ServiceWithHandwrittenSignatures_AMethod_async_flattened1]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithHandwrittenSignaturesClient.AMethod1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithHandwrittenSignaturesClient.AMethod1Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.PublishingSettings.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ServiceWithHandwrittenSignatures_AMethod_sync_flattened1]
     using Testing.PublishingSettings;

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithHandwrittenSignaturesClient.AMethod2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithHandwrittenSignaturesClient.AMethod2AsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.PublishingSettings.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ServiceWithHandwrittenSignatures_AMethod_async_flattened2]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithHandwrittenSignaturesClient.AMethod2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithHandwrittenSignaturesClient.AMethod2Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.PublishingSettings.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ServiceWithHandwrittenSignatures_AMethod_sync_flattened2]
     using Testing.PublishingSettings;

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithHandwrittenSignaturesClient.AMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithHandwrittenSignaturesClient.AMethodRequestObjectAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.PublishingSettings.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ServiceWithHandwrittenSignatures_AMethod_async]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithHandwrittenSignaturesClient.AMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithHandwrittenSignaturesClient.AMethodRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.PublishingSettings.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ServiceWithHandwrittenSignatures_AMethod_sync]
     using Testing.PublishingSettings;

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithResourcesClient.AMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithResourcesClient.AMethodRequestObjectAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.PublishingSettings.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ServiceWithResources_AMethod_async]
     using PublishingSettingsCommon.Namespace;

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithResourcesClient.AMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithResourcesClient.AMethodRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.PublishingSettings.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ServiceWithResources_AMethod_sync]
     using PublishingSettingsCommon.Namespace;

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.Snippets/RenamedServiceNameClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.Snippets/RenamedServiceNameClientSnippets.g.cs
@@ -14,9 +14,10 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.PublishingSettings.Snippets
+namespace GoogleCSharpSnippets
 {
     using System.Threading.Tasks;
+    using Testing.PublishingSettings;
 
     /// <summary>Generated snippets.</summary>
     public sealed class AllGeneratedRenamedServiceNameClientSnippets

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.Snippets/ServiceWithHandwrittenSignaturesClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.Snippets/ServiceWithHandwrittenSignaturesClientSnippets.g.cs
@@ -14,9 +14,10 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.PublishingSettings.Snippets
+namespace GoogleCSharpSnippets
 {
     using System.Threading.Tasks;
+    using Testing.PublishingSettings;
 
     /// <summary>Generated snippets.</summary>
     public sealed class AllGeneratedServiceWithHandwrittenSignaturesClientSnippets

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.Snippets/ServiceWithResourcesClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.Snippets/ServiceWithResourcesClientSnippets.g.cs
@@ -14,10 +14,11 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.PublishingSettings.Snippets
+namespace GoogleCSharpSnippets
 {
     using PublishingSettingsCommon.Namespace;
     using System.Threading.Tasks;
+    using Testing.PublishingSettings;
 
     /// <summary>Generated snippets.</summary>
     public sealed class AllGeneratedServiceWithResourcesClientSnippets

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.GeneratedSnippets/ResourceNameSeparatorClient.Method1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.GeneratedSnippets/ResourceNameSeparatorClient.Method1AsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNameSeparator.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNameSeparator_Method1_async_flattened]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.GeneratedSnippets/ResourceNameSeparatorClient.Method1RequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.GeneratedSnippets/ResourceNameSeparatorClient.Method1RequestObjectAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNameSeparator.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNameSeparator_Method1_async]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.GeneratedSnippets/ResourceNameSeparatorClient.Method1RequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.GeneratedSnippets/ResourceNameSeparatorClient.Method1RequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNameSeparator.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNameSeparator_Method1_sync]
     using Testing.ResourceNameSeparator;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.GeneratedSnippets/ResourceNameSeparatorClient.Method1ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.GeneratedSnippets/ResourceNameSeparatorClient.Method1ResourceNamesAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNameSeparator.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNameSeparator_Method1_async_flattened_resourceNames]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.GeneratedSnippets/ResourceNameSeparatorClient.Method1ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.GeneratedSnippets/ResourceNameSeparatorClient.Method1ResourceNamesSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNameSeparator.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNameSeparator_Method1_sync_flattened_resourceNames]
     using Testing.ResourceNameSeparator;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.GeneratedSnippets/ResourceNameSeparatorClient.Method1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.GeneratedSnippets/ResourceNameSeparatorClient.Method1Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNameSeparator.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNameSeparator_Method1_sync_flattened]
     using Testing.ResourceNameSeparator;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.Snippets/ResourceNameSeparatorClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNameSeparator/Testing.ResourceNameSeparator.Snippets/ResourceNameSeparatorClientSnippets.g.cs
@@ -14,9 +14,10 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNameSeparator.Snippets
+namespace GoogleCSharpSnippets
 {
     using System.Threading.Tasks;
+    using Testing.ResourceNameSeparator;
 
     /// <summary>Generated snippets.</summary>
     public sealed class AllGeneratedResourceNameSeparatorClientSnippets

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.DeprecatedPatternMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.DeprecatedPatternMethodAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_DeprecatedPatternMethod_async_flattened]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.DeprecatedPatternMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.DeprecatedPatternMethodRequestObjectAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_DeprecatedPatternMethod_async]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.DeprecatedPatternMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.DeprecatedPatternMethodRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_DeprecatedPatternMethod_sync]
     using Testing.ResourceNames;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.DeprecatedPatternMethodResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.DeprecatedPatternMethodResourceNamesAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_DeprecatedPatternMethod_async_flattened_resourceNames]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.DeprecatedPatternMethodResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.DeprecatedPatternMethodResourceNamesSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_DeprecatedPatternMethod_sync_flattened_resourceNames]
     using Testing.ResourceNames;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.DeprecatedPatternMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.DeprecatedPatternMethodSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_DeprecatedPatternMethod_sync_flattened]
     using Testing.ResourceNames;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.LooseValidationPatternMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.LooseValidationPatternMethodAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_LooseValidationPatternMethod_async_flattened]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.LooseValidationPatternMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.LooseValidationPatternMethodRequestObjectAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_LooseValidationPatternMethod_async]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.LooseValidationPatternMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.LooseValidationPatternMethodRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_LooseValidationPatternMethod_sync]
     using Testing.ResourceNames;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.LooseValidationPatternMethodResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.LooseValidationPatternMethodResourceNamesAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_LooseValidationPatternMethod_async_flattened_resourceNames]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.LooseValidationPatternMethodResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.LooseValidationPatternMethodResourceNamesSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_LooseValidationPatternMethod_sync_flattened_resourceNames]
     using Testing.ResourceNames;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.LooseValidationPatternMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.LooseValidationPatternMethodSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_LooseValidationPatternMethod_sync_flattened]
     using Testing.ResourceNames;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.SinglePatternMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.SinglePatternMethodAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_SinglePatternMethod_async_flattened]
     using System.Collections.Generic;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.SinglePatternMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.SinglePatternMethodRequestObjectAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_SinglePatternMethod_async]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.SinglePatternMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.SinglePatternMethodRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_SinglePatternMethod_sync]
     using Testing.ResourceNames;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.SinglePatternMethodResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.SinglePatternMethodResourceNamesAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_SinglePatternMethod_async_flattened_resourceNames]
     using System.Collections.Generic;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.SinglePatternMethodResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.SinglePatternMethodResourceNamesSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_SinglePatternMethod_sync_flattened_resourceNames]
     using System.Collections.Generic;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.SinglePatternMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.SinglePatternMethodSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_SinglePatternMethod_sync_flattened]
     using System.Collections.Generic;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMethod_async_flattened]
     using System.Collections.Generic;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodRequestObjectAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMethod_async]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMethod_sync]
     using Testing.ResourceNames;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames1AsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMethod_async_flattened_resourceNames1]
     using System.Collections.Generic;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames1Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMethod_sync_flattened_resourceNames1]
     using System.Collections.Generic;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames2AsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMethod_async_flattened_resourceNames2]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames2Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMethod_sync_flattened_resourceNames2]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames3AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames3AsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMethod_async_flattened_resourceNames3]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames3Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames3Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMethod_sync_flattened_resourceNames3]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames4AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames4AsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMethod_async_flattened_resourceNames4]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames4Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames4Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMethod_sync_flattened_resourceNames4]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames5AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames5AsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMethod_async_flattened_resourceNames5]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames5Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames5Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMethod_sync_flattened_resourceNames5]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames6AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames6AsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMethod_async_flattened_resourceNames6]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames6Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames6Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMethod_sync_flattened_resourceNames6]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames7AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames7AsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMethod_async_flattened_resourceNames7]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames7Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames7Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMethod_sync_flattened_resourceNames7]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames8AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames8AsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMethod_async_flattened_resourceNames8]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames8Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodResourceNames8Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMethod_sync_flattened_resourceNames8]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMethodSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMethod_sync_flattened]
     using System.Collections.Generic;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMultipleMethod_async_flattened]
     using System.Collections.Generic;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodRequestObjectAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMultipleMethod_async]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMultipleMethod_sync]
     using Testing.ResourceNames;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames1AsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMultipleMethod_async_flattened_resourceNames1]
     using System.Collections.Generic;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames1Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMultipleMethod_sync_flattened_resourceNames1]
     using System.Collections.Generic;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames2AsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMultipleMethod_async_flattened_resourceNames2]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames2Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMultipleMethod_sync_flattened_resourceNames2]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames3AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames3AsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMultipleMethod_async_flattened_resourceNames3]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames3Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames3Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMultipleMethod_sync_flattened_resourceNames3]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames4AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames4AsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMultipleMethod_async_flattened_resourceNames4]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames4Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodResourceNames4Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMultipleMethod_sync_flattened_resourceNames4]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardMultiPatternMultipleMethodSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardMultiPatternMultipleMethod_sync_flattened]
     using System.Collections.Generic;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardOnlyPatternMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardOnlyPatternMethodAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardOnlyPatternMethod_async_flattened]
     using System.Collections.Generic;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardOnlyPatternMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardOnlyPatternMethodRequestObjectAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardOnlyPatternMethod_async]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardOnlyPatternMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardOnlyPatternMethodRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardOnlyPatternMethod_sync]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardOnlyPatternMethodResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardOnlyPatternMethodResourceNamesAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardOnlyPatternMethod_async_flattened_resourceNames]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardOnlyPatternMethodResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardOnlyPatternMethodResourceNamesSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardOnlyPatternMethod_sync_flattened_resourceNames]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardOnlyPatternMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.GeneratedSnippets/ResourceNamesClient.WildcardOnlyPatternMethodSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_ResourceNames_WildcardOnlyPatternMethod_sync_flattened]
     using System.Collections.Generic;

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.Snippets/ResourceNamesClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames.Snippets/ResourceNamesClientSnippets.g.cs
@@ -14,11 +14,12 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.ResourceNames.Snippets
+namespace GoogleCSharpSnippets
 {
     using Google.Api.Gax;
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using Testing.ResourceNames;
 
     /// <summary>Generated snippets.</summary>
     public sealed class AllGeneratedResourceNamesClientSnippets

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodBidiStreamingSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodBidiStreamingSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodBidiStreaming_sync]
     using Google.Api.Gax.Grpc;
@@ -36,9 +36,9 @@ namespace Testing.Snippets.Snippets
         public async Task MethodBidiStreaming()
         {
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize streaming call, retrieving the stream object
-            SnippetsClient.MethodBidiStreamingStream response = snippetsClient.MethodBidiStreaming();
+            ts::SnippetsClient.MethodBidiStreamingStream response = snippetsClient.MethodBidiStreaming();
 
             // Sending requests and retrieving responses can be arbitrarily interleaved
             // Exact sequence will depend on client/server behavior
@@ -47,10 +47,10 @@ namespace Testing.Snippets.Snippets
             Task responseHandlerTask = Task.Run(async () =>
             {
                 // Note that C# 8 code can use await foreach
-                AsyncResponseStream<Response> responseStream = response.GetResponseStream();
+                AsyncResponseStream<ts::Response> responseStream = response.GetResponseStream();
                 while (await responseStream.MoveNextAsync())
                 {
-                    Response responseItem = responseStream.Current;
+                    ts::Response responseItem = responseStream.Current;
                     // Do something with streamed response
                 }
                 // The response stream has completed
@@ -61,7 +61,7 @@ namespace Testing.Snippets.Snippets
             while (!done)
             {
                 // Initialize a request
-                SignatureRequest request = new SignatureRequest
+                ts::SignatureRequest request = new ts::SignatureRequest
                 {
                     AString = "",
                     AnInt = 0,

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodDefaultValuesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodDefaultValuesAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodDefaultValues_async_flattened]
     using System.Collections.Generic;
@@ -36,19 +36,19 @@ namespace Testing.Snippets.Snippets
         public async Task MethodDefaultValuesAsync()
         {
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             IEnumerable<double> repeatedDouble = new double[] { 0, };
-            IEnumerable<DefaultValuesRequest.Types.NestedMessage> repeatedNestedMessage = new DefaultValuesRequest.Types.NestedMessage[]
+            IEnumerable<ts::DefaultValuesRequest.Types.NestedMessage> repeatedNestedMessage = new ts::DefaultValuesRequest.Types.NestedMessage[]
             {
-                new DefaultValuesRequest.Types.NestedMessage(),
+                new ts::DefaultValuesRequest.Types.NestedMessage(),
             };
             IEnumerable<string> repeatedResourceName = new string[]
             {
                 "items/[ITEM_ID]/parts/[PART_ID]",
             };
             // Make the request
-            Response response = await snippetsClient.MethodDefaultValuesAsync(repeatedDouble, repeatedNestedMessage, repeatedResourceName);
+            ts::Response response = await snippetsClient.MethodDefaultValuesAsync(repeatedDouble, repeatedNestedMessage, repeatedResourceName);
         }
     }
     // [END snippets_generated_Snippets_MethodDefaultValues_async_flattened]

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodDefaultValuesRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodDefaultValuesRequestObjectAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodDefaultValues_async]
     using Google.Api.Gax;
@@ -37,9 +37,9 @@ namespace Testing.Snippets.Snippets
         public async Task MethodDefaultValuesRequestObjectAsync()
         {
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            DefaultValuesRequest request = new DefaultValuesRequest
+            ts::DefaultValuesRequest request = new ts::DefaultValuesRequest
             {
                 SingleDouble = 0,
                 SingleFloat = 0F,
@@ -56,10 +56,10 @@ namespace Testing.Snippets.Snippets
                 SingleBool = false,
                 SingleString = "",
                 SingleBytes = ByteString.Empty,
-                SingleMessage = new AnotherMessage(),
-                SingleNestedMessage = new DefaultValuesRequest.Types.NestedMessage(),
-                SingleEnum = Enum.Default,
-                SingleNestedEnum = DefaultValuesRequest.Types.NestedEnum.DefaultValue,
+                SingleMessage = new ts::AnotherMessage(),
+                SingleNestedMessage = new ts::DefaultValuesRequest.Types.NestedMessage(),
+                SingleEnum = ts::Enum.Default,
+                SingleNestedEnum = ts::DefaultValuesRequest.Types.NestedEnum.DefaultValue,
                 RepeatedDouble = { 0, },
                 RepeatedFloat = { 0F, },
                 RepeatedInt32 = { 0, },
@@ -77,31 +77,31 @@ namespace Testing.Snippets.Snippets
                 RepeatedBytes = { ByteString.Empty, },
                 RepeatedMessage =
                 {
-                    new AnotherMessage(),
+                    new ts::AnotherMessage(),
                 },
                 RepeatedNestedMessage =
                 {
-                    new DefaultValuesRequest.Types.NestedMessage(),
+                    new ts::DefaultValuesRequest.Types.NestedMessage(),
                 },
-                RepeatedEnum = { Enum.Default, },
+                RepeatedEnum = { ts::Enum.Default, },
                 RepeatedNestedEnum =
                 {
-                    DefaultValuesRequest.Types.NestedEnum.DefaultValue,
+                    ts::DefaultValuesRequest.Types.NestedEnum.DefaultValue,
                 },
-                SingleResourceNameAsAResourceName = AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
+                SingleResourceNameAsAResourceName = ts::AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
                 RepeatedResourceNameAsAResourceNames =
                 {
-                    AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
+                    ts::AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
                 },
                 SingleWildcardResourceAsResourceName = new UnparsedResourceName("a/wildcard/resource"),
                 RepeatedWildcardResourceAsResourceNames =
                 {
                     new UnparsedResourceName("a/wildcard/resource"),
                 },
-                MultiPatternResourceNameAsMultiPatternResourceName = MultiPatternResourceName.FromRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
+                MultiPatternResourceNameAsMultiPatternResourceName = ts::MultiPatternResourceName.FromRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
                 RepeatedMultiPatternResourceNameAsMultiPatternResourceNames =
                 {
-                    MultiPatternResourceName.FromRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
+                    ts::MultiPatternResourceName.FromRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
                 },
                 MapIntString = { { 0, "" }, },
                 SingleWrappedDouble = 0,
@@ -124,7 +124,7 @@ namespace Testing.Snippets.Snippets
                 RepeatedWrappedBytes = { ByteString.Empty, },
             };
             // Make the request
-            Response response = await snippetsClient.MethodDefaultValuesAsync(request);
+            ts::Response response = await snippetsClient.MethodDefaultValuesAsync(request);
         }
     }
     // [END snippets_generated_Snippets_MethodDefaultValues_async]

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodDefaultValuesRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodDefaultValuesRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodDefaultValues_sync]
     using Google.Api.Gax;

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodDefaultValuesResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodDefaultValuesResourceNamesAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodDefaultValues_async_flattened_resourceNames]
     using System.Collections.Generic;
@@ -36,19 +36,19 @@ namespace Testing.Snippets.Snippets
         public async Task MethodDefaultValuesResourceNamesAsync()
         {
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             IEnumerable<double> repeatedDouble = new double[] { 0, };
-            IEnumerable<DefaultValuesRequest.Types.NestedMessage> repeatedNestedMessage = new DefaultValuesRequest.Types.NestedMessage[]
+            IEnumerable<ts::DefaultValuesRequest.Types.NestedMessage> repeatedNestedMessage = new ts::DefaultValuesRequest.Types.NestedMessage[]
             {
-                new DefaultValuesRequest.Types.NestedMessage(),
+                new ts::DefaultValuesRequest.Types.NestedMessage(),
             };
-            IEnumerable<AResourceName> repeatedResourceName = new AResourceName[]
+            IEnumerable<ts::AResourceName> repeatedResourceName = new ts::AResourceName[]
             {
-                AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
+                ts::AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
             };
             // Make the request
-            Response response = await snippetsClient.MethodDefaultValuesAsync(repeatedDouble, repeatedNestedMessage, repeatedResourceName);
+            ts::Response response = await snippetsClient.MethodDefaultValuesAsync(repeatedDouble, repeatedNestedMessage, repeatedResourceName);
         }
     }
     // [END snippets_generated_Snippets_MethodDefaultValues_async_flattened_resourceNames]

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodDefaultValuesResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodDefaultValuesResourceNamesSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodDefaultValues_sync_flattened_resourceNames]
     using System.Collections.Generic;

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodDefaultValuesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodDefaultValuesSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodDefaultValues_sync_flattened]
     using System.Collections.Generic;

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodLroResourceSignatureAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodLroResourceSignatureAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodLroResourceSignature_async_flattened]
     using Google.LongRunning;
@@ -36,28 +36,28 @@ namespace Testing.Snippets.Snippets
         public async Task MethodLroResourceSignatureAsync()
         {
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             string firstName = "items/[ITEM_ID]";
             string secondName = "items/[ITEM_ID]";
             string thirdName = "items/[ITEM_ID]";
             // Make the request
-            Operation<LroResponse, LroMetadata> response = await snippetsClient.MethodLroResourceSignatureAsync(firstName, secondName, thirdName);
+            Operation<ts::LroResponse, ts::LroMetadata> response = await snippetsClient.MethodLroResourceSignatureAsync(firstName, secondName, thirdName);
 
             // Poll until the returned long-running operation is complete
-            Operation<LroResponse, LroMetadata> completedResponse = await response.PollUntilCompletedAsync();
+            Operation<ts::LroResponse, ts::LroMetadata> completedResponse = await response.PollUntilCompletedAsync();
             // Retrieve the operation result
-            LroResponse result = completedResponse.Result;
+            ts::LroResponse result = completedResponse.Result;
 
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<LroResponse, LroMetadata> retrievedResponse = await snippetsClient.PollOnceMethodLroResourceSignatureAsync(operationName);
+            Operation<ts::LroResponse, ts::LroMetadata> retrievedResponse = await snippetsClient.PollOnceMethodLroResourceSignatureAsync(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
             {
                 // If it has completed, then access the result
-                LroResponse retrievedResult = retrievedResponse.Result;
+                ts::LroResponse retrievedResult = retrievedResponse.Result;
             }
         }
     }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodLroResourceSignatureRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodLroResourceSignatureRequestObjectAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodLroResourceSignature_async]
     using Google.LongRunning;
@@ -36,31 +36,31 @@ namespace Testing.Snippets.Snippets
         public async Task MethodLroResourceSignatureRequestObjectAsync()
         {
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            ResourceSignatureRequest request = new ResourceSignatureRequest
+            ts::ResourceSignatureRequest request = new ts::ResourceSignatureRequest
             {
-                FirstNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
-                SecondNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
-                ThirdNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                FirstNameAsSimpleResourceName = ts::SimpleResourceName.FromItem("[ITEM_ID]"),
+                SecondNameAsSimpleResourceName = ts::SimpleResourceName.FromItem("[ITEM_ID]"),
+                ThirdNameAsSimpleResourceName = ts::SimpleResourceName.FromItem("[ITEM_ID]"),
             };
             // Make the request
-            Operation<LroResponse, LroMetadata> response = await snippetsClient.MethodLroResourceSignatureAsync(request);
+            Operation<ts::LroResponse, ts::LroMetadata> response = await snippetsClient.MethodLroResourceSignatureAsync(request);
 
             // Poll until the returned long-running operation is complete
-            Operation<LroResponse, LroMetadata> completedResponse = await response.PollUntilCompletedAsync();
+            Operation<ts::LroResponse, ts::LroMetadata> completedResponse = await response.PollUntilCompletedAsync();
             // Retrieve the operation result
-            LroResponse result = completedResponse.Result;
+            ts::LroResponse result = completedResponse.Result;
 
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<LroResponse, LroMetadata> retrievedResponse = await snippetsClient.PollOnceMethodLroResourceSignatureAsync(operationName);
+            Operation<ts::LroResponse, ts::LroMetadata> retrievedResponse = await snippetsClient.PollOnceMethodLroResourceSignatureAsync(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
             {
                 // If it has completed, then access the result
-                LroResponse retrievedResult = retrievedResponse.Result;
+                ts::LroResponse retrievedResult = retrievedResponse.Result;
             }
         }
     }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodLroResourceSignatureRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodLroResourceSignatureRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodLroResourceSignature_sync]
     using Google.LongRunning;

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodLroResourceSignatureResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodLroResourceSignatureResourceNamesAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodLroResourceSignature_async_flattened_resourceNames]
     using Google.LongRunning;
@@ -36,28 +36,28 @@ namespace Testing.Snippets.Snippets
         public async Task MethodLroResourceSignatureResourceNamesAsync()
         {
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
-            SimpleResourceName secondName = SimpleResourceName.FromItem("[ITEM_ID]");
-            SimpleResourceName thirdName = SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName firstName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName secondName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName thirdName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
             // Make the request
-            Operation<LroResponse, LroMetadata> response = await snippetsClient.MethodLroResourceSignatureAsync(firstName, secondName, thirdName);
+            Operation<ts::LroResponse, ts::LroMetadata> response = await snippetsClient.MethodLroResourceSignatureAsync(firstName, secondName, thirdName);
 
             // Poll until the returned long-running operation is complete
-            Operation<LroResponse, LroMetadata> completedResponse = await response.PollUntilCompletedAsync();
+            Operation<ts::LroResponse, ts::LroMetadata> completedResponse = await response.PollUntilCompletedAsync();
             // Retrieve the operation result
-            LroResponse result = completedResponse.Result;
+            ts::LroResponse result = completedResponse.Result;
 
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<LroResponse, LroMetadata> retrievedResponse = await snippetsClient.PollOnceMethodLroResourceSignatureAsync(operationName);
+            Operation<ts::LroResponse, ts::LroMetadata> retrievedResponse = await snippetsClient.PollOnceMethodLroResourceSignatureAsync(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
             {
                 // If it has completed, then access the result
-                LroResponse retrievedResult = retrievedResponse.Result;
+                ts::LroResponse retrievedResult = retrievedResponse.Result;
             }
         }
     }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodLroResourceSignatureResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodLroResourceSignatureResourceNamesSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodLroResourceSignature_sync_flattened_resourceNames]
     using Google.LongRunning;

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodLroResourceSignatureSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodLroResourceSignatureSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodLroResourceSignature_sync_flattened]
     using Google.LongRunning;

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodLroSignaturesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodLroSignaturesAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodLroSignatures_async_flattened]
     using Google.LongRunning;
@@ -36,28 +36,28 @@ namespace Testing.Snippets.Snippets
         public async Task MethodLroSignaturesAsync()
         {
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             string aString = "";
             int anInt = 0;
             bool aBool = false;
             // Make the request
-            Operation<LroResponse, LroMetadata> response = await snippetsClient.MethodLroSignaturesAsync(aString, anInt, aBool);
+            Operation<ts::LroResponse, ts::LroMetadata> response = await snippetsClient.MethodLroSignaturesAsync(aString, anInt, aBool);
 
             // Poll until the returned long-running operation is complete
-            Operation<LroResponse, LroMetadata> completedResponse = await response.PollUntilCompletedAsync();
+            Operation<ts::LroResponse, ts::LroMetadata> completedResponse = await response.PollUntilCompletedAsync();
             // Retrieve the operation result
-            LroResponse result = completedResponse.Result;
+            ts::LroResponse result = completedResponse.Result;
 
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<LroResponse, LroMetadata> retrievedResponse = await snippetsClient.PollOnceMethodLroSignaturesAsync(operationName);
+            Operation<ts::LroResponse, ts::LroMetadata> retrievedResponse = await snippetsClient.PollOnceMethodLroSignaturesAsync(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
             {
                 // If it has completed, then access the result
-                LroResponse retrievedResult = retrievedResponse.Result;
+                ts::LroResponse retrievedResult = retrievedResponse.Result;
             }
         }
     }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodLroSignaturesRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodLroSignaturesRequestObjectAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodLroSignatures_async]
     using Google.LongRunning;
@@ -36,9 +36,9 @@ namespace Testing.Snippets.Snippets
         public async Task MethodLroSignaturesRequestObjectAsync()
         {
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            SignatureRequest request = new SignatureRequest
+            ts::SignatureRequest request = new ts::SignatureRequest
             {
                 AString = "",
                 AnInt = 0,
@@ -46,22 +46,22 @@ namespace Testing.Snippets.Snippets
                 MapIntString = { { 0, "" }, },
             };
             // Make the request
-            Operation<LroResponse, LroMetadata> response = await snippetsClient.MethodLroSignaturesAsync(request);
+            Operation<ts::LroResponse, ts::LroMetadata> response = await snippetsClient.MethodLroSignaturesAsync(request);
 
             // Poll until the returned long-running operation is complete
-            Operation<LroResponse, LroMetadata> completedResponse = await response.PollUntilCompletedAsync();
+            Operation<ts::LroResponse, ts::LroMetadata> completedResponse = await response.PollUntilCompletedAsync();
             // Retrieve the operation result
-            LroResponse result = completedResponse.Result;
+            ts::LroResponse result = completedResponse.Result;
 
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<LroResponse, LroMetadata> retrievedResponse = await snippetsClient.PollOnceMethodLroSignaturesAsync(operationName);
+            Operation<ts::LroResponse, ts::LroMetadata> retrievedResponse = await snippetsClient.PollOnceMethodLroSignaturesAsync(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
             {
                 // If it has completed, then access the result
-                LroResponse retrievedResult = retrievedResponse.Result;
+                ts::LroResponse retrievedResult = retrievedResponse.Result;
             }
         }
     }

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodLroSignaturesRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodLroSignaturesRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodLroSignatures_sync]
     using Google.LongRunning;

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodLroSignaturesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodLroSignaturesSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodLroSignatures_sync_flattened]
     using Google.LongRunning;

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodMapSignatureAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodMapSignatureAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodMapSignature_async_flattened]
     using System.Collections.Generic;
@@ -36,11 +36,11 @@ namespace Testing.Snippets.Snippets
         public async Task MethodMapSignatureAsync()
         {
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             IDictionary<int, string> mapIntString = new Dictionary<int, string> { { 0, "" }, };
             // Make the request
-            Response response = await snippetsClient.MethodMapSignatureAsync(mapIntString);
+            ts::Response response = await snippetsClient.MethodMapSignatureAsync(mapIntString);
         }
     }
     // [END snippets_generated_Snippets_MethodMapSignature_async_flattened]

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodMapSignatureRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodMapSignatureRequestObjectAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodMapSignature_async]
     using System.Threading.Tasks;
@@ -35,9 +35,9 @@ namespace Testing.Snippets.Snippets
         public async Task MethodMapSignatureRequestObjectAsync()
         {
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            SignatureRequest request = new SignatureRequest
+            ts::SignatureRequest request = new ts::SignatureRequest
             {
                 AString = "",
                 AnInt = 0,
@@ -45,7 +45,7 @@ namespace Testing.Snippets.Snippets
                 MapIntString = { { 0, "" }, },
             };
             // Make the request
-            Response response = await snippetsClient.MethodMapSignatureAsync(request);
+            ts::Response response = await snippetsClient.MethodMapSignatureAsync(request);
         }
     }
     // [END snippets_generated_Snippets_MethodMapSignature_async]

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodMapSignatureRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodMapSignatureRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodMapSignature_sync]
     using Testing.Snippets;

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodMapSignatureSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodMapSignatureSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodMapSignature_sync_flattened]
     using System.Collections.Generic;

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodOneSignatureAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodOneSignatureAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodOneSignature_async_flattened]
     using System.Threading.Tasks;
@@ -35,13 +35,13 @@ namespace Testing.Snippets.Snippets
         public async Task MethodOneSignatureAsync()
         {
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             string aString = "";
             int anInt = 0;
             bool aBool = false;
             // Make the request
-            Response response = await snippetsClient.MethodOneSignatureAsync(aString, anInt, aBool);
+            ts::Response response = await snippetsClient.MethodOneSignatureAsync(aString, anInt, aBool);
         }
     }
     // [END snippets_generated_Snippets_MethodOneSignature_async_flattened]

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodOneSignatureRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodOneSignatureRequestObjectAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodOneSignature_async]
     using System.Threading.Tasks;
@@ -35,9 +35,9 @@ namespace Testing.Snippets.Snippets
         public async Task MethodOneSignatureRequestObjectAsync()
         {
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            SignatureRequest request = new SignatureRequest
+            ts::SignatureRequest request = new ts::SignatureRequest
             {
                 AString = "",
                 AnInt = 0,
@@ -45,7 +45,7 @@ namespace Testing.Snippets.Snippets
                 MapIntString = { { 0, "" }, },
             };
             // Make the request
-            Response response = await snippetsClient.MethodOneSignatureAsync(request);
+            ts::Response response = await snippetsClient.MethodOneSignatureAsync(request);
         }
     }
     // [END snippets_generated_Snippets_MethodOneSignature_async]

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodOneSignatureRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodOneSignatureRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodOneSignature_sync]
     using Testing.Snippets;

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodOneSignatureSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodOneSignatureSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodOneSignature_sync_flattened]
     using Testing.Snippets;

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodRepeatedResourceSignatureAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodRepeatedResourceSignatureAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodRepeatedResourceSignature_async_flattened]
     using System.Collections.Generic;
@@ -36,11 +36,11 @@ namespace Testing.Snippets.Snippets
         public async Task MethodRepeatedResourceSignatureAsync()
         {
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             IEnumerable<string> names = new string[] { "items/[ITEM_ID]", };
             // Make the request
-            Response response = await snippetsClient.MethodRepeatedResourceSignatureAsync(names);
+            ts::Response response = await snippetsClient.MethodRepeatedResourceSignatureAsync(names);
         }
     }
     // [END snippets_generated_Snippets_MethodRepeatedResourceSignature_async_flattened]

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodRepeatedResourceSignatureRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodRepeatedResourceSignatureRequestObjectAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodRepeatedResourceSignature_async]
     using System.Threading.Tasks;
@@ -35,17 +35,17 @@ namespace Testing.Snippets.Snippets
         public async Task MethodRepeatedResourceSignatureRequestObjectAsync()
         {
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            RepeatedResourceSignatureRequest request = new RepeatedResourceSignatureRequest
+            ts::RepeatedResourceSignatureRequest request = new ts::RepeatedResourceSignatureRequest
             {
                 SimpleResourceNames =
                 {
-                    SimpleResourceName.FromItem("[ITEM_ID]"),
+                    ts::SimpleResourceName.FromItem("[ITEM_ID]"),
                 },
             };
             // Make the request
-            Response response = await snippetsClient.MethodRepeatedResourceSignatureAsync(request);
+            ts::Response response = await snippetsClient.MethodRepeatedResourceSignatureAsync(request);
         }
     }
     // [END snippets_generated_Snippets_MethodRepeatedResourceSignature_async]

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodRepeatedResourceSignatureRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodRepeatedResourceSignatureRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodRepeatedResourceSignature_sync]
     using Testing.Snippets;

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodRepeatedResourceSignatureResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodRepeatedResourceSignatureResourceNamesAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodRepeatedResourceSignature_async_flattened_resourceNames]
     using System.Collections.Generic;
@@ -36,14 +36,14 @@ namespace Testing.Snippets.Snippets
         public async Task MethodRepeatedResourceSignatureResourceNamesAsync()
         {
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            IEnumerable<SimpleResourceName> names = new SimpleResourceName[]
+            IEnumerable<ts::SimpleResourceName> names = new ts::SimpleResourceName[]
             {
-                SimpleResourceName.FromItem("[ITEM_ID]"),
+                ts::SimpleResourceName.FromItem("[ITEM_ID]"),
             };
             // Make the request
-            Response response = await snippetsClient.MethodRepeatedResourceSignatureAsync(names);
+            ts::Response response = await snippetsClient.MethodRepeatedResourceSignatureAsync(names);
         }
     }
     // [END snippets_generated_Snippets_MethodRepeatedResourceSignature_async_flattened_resourceNames]

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodRepeatedResourceSignatureResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodRepeatedResourceSignatureResourceNamesSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodRepeatedResourceSignature_sync_flattened_resourceNames]
     using System.Collections.Generic;

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodRepeatedResourceSignatureSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodRepeatedResourceSignatureSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodRepeatedResourceSignature_sync_flattened]
     using System.Collections.Generic;

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodResourceSignature1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodResourceSignature1AsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodResourceSignature_async_flattened1]
     using System.Threading.Tasks;
@@ -35,13 +35,13 @@ namespace Testing.Snippets.Snippets
         public async Task MethodResourceSignature1Async()
         {
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             string firstName = "items/[ITEM_ID]";
             string secondName = "items/[ITEM_ID]";
             string thirdName = "items/[ITEM_ID]";
             // Make the request
-            Response response = await snippetsClient.MethodResourceSignatureAsync(firstName, secondName, thirdName);
+            ts::Response response = await snippetsClient.MethodResourceSignatureAsync(firstName, secondName, thirdName);
         }
     }
     // [END snippets_generated_Snippets_MethodResourceSignature_async_flattened1]

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodResourceSignature1ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodResourceSignature1ResourceNamesAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodResourceSignature_async_flattened1_resourceNames]
     using System.Threading.Tasks;
@@ -35,13 +35,13 @@ namespace Testing.Snippets.Snippets
         public async Task MethodResourceSignature1ResourceNamesAsync()
         {
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
-            SimpleResourceName secondName = SimpleResourceName.FromItem("[ITEM_ID]");
-            SimpleResourceName thirdName = SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName firstName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName secondName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName thirdName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
             // Make the request
-            Response response = await snippetsClient.MethodResourceSignatureAsync(firstName, secondName, thirdName);
+            ts::Response response = await snippetsClient.MethodResourceSignatureAsync(firstName, secondName, thirdName);
         }
     }
     // [END snippets_generated_Snippets_MethodResourceSignature_async_flattened1_resourceNames]

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodResourceSignature1ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodResourceSignature1ResourceNamesSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodResourceSignature_sync_flattened1_resourceNames]
     using Testing.Snippets;

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodResourceSignature1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodResourceSignature1Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodResourceSignature_sync_flattened1]
     using Testing.Snippets;

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodResourceSignature2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodResourceSignature2AsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodResourceSignature_async_flattened2]
     using System.Threading.Tasks;
@@ -35,11 +35,11 @@ namespace Testing.Snippets.Snippets
         public async Task MethodResourceSignature2Async()
         {
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             string firstName = "items/[ITEM_ID]";
             // Make the request
-            Response response = await snippetsClient.MethodResourceSignatureAsync(firstName);
+            ts::Response response = await snippetsClient.MethodResourceSignatureAsync(firstName);
         }
     }
     // [END snippets_generated_Snippets_MethodResourceSignature_async_flattened2]

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodResourceSignature2ResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodResourceSignature2ResourceNamesAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodResourceSignature_async_flattened2_resourceNames]
     using System.Threading.Tasks;
@@ -35,11 +35,11 @@ namespace Testing.Snippets.Snippets
         public async Task MethodResourceSignature2ResourceNamesAsync()
         {
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName firstName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
             // Make the request
-            Response response = await snippetsClient.MethodResourceSignatureAsync(firstName);
+            ts::Response response = await snippetsClient.MethodResourceSignatureAsync(firstName);
         }
     }
     // [END snippets_generated_Snippets_MethodResourceSignature_async_flattened2_resourceNames]

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodResourceSignature2ResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodResourceSignature2ResourceNamesSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodResourceSignature_sync_flattened2_resourceNames]
     using Testing.Snippets;

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodResourceSignature2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodResourceSignature2Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodResourceSignature_sync_flattened2]
     using Testing.Snippets;

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodResourceSignatureRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodResourceSignatureRequestObjectAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodResourceSignature_async]
     using System.Threading.Tasks;
@@ -35,16 +35,16 @@ namespace Testing.Snippets.Snippets
         public async Task MethodResourceSignatureRequestObjectAsync()
         {
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            ResourceSignatureRequest request = new ResourceSignatureRequest
+            ts::ResourceSignatureRequest request = new ts::ResourceSignatureRequest
             {
-                FirstNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
-                SecondNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
-                ThirdNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                FirstNameAsSimpleResourceName = ts::SimpleResourceName.FromItem("[ITEM_ID]"),
+                SecondNameAsSimpleResourceName = ts::SimpleResourceName.FromItem("[ITEM_ID]"),
+                ThirdNameAsSimpleResourceName = ts::SimpleResourceName.FromItem("[ITEM_ID]"),
             };
             // Make the request
-            Response response = await snippetsClient.MethodResourceSignatureAsync(request);
+            ts::Response response = await snippetsClient.MethodResourceSignatureAsync(request);
         }
     }
     // [END snippets_generated_Snippets_MethodResourceSignature_async]

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodResourceSignatureRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodResourceSignatureRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodResourceSignature_sync]
     using Testing.Snippets;

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodServerStreaming1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodServerStreaming1Snippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodServerStreaming_sync_flattened1]
     using Google.Api.Gax.Grpc;
@@ -36,19 +36,19 @@ namespace Testing.Snippets.Snippets
         public async Task MethodServerStreaming1()
         {
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
             string aString = "";
             bool aBool = false;
             // Make the request, returning a streaming response
-            SnippetsClient.MethodServerStreamingStream response = snippetsClient.MethodServerStreaming(aString, aBool);
+            ts::SnippetsClient.MethodServerStreamingStream response = snippetsClient.MethodServerStreaming(aString, aBool);
 
             // Read streaming responses from server until complete
             // Note that C# 8 code can use await foreach
-            AsyncResponseStream<Response> responseStream = response.GetResponseStream();
+            AsyncResponseStream<ts::Response> responseStream = response.GetResponseStream();
             while (await responseStream.MoveNextAsync())
             {
-                Response responseItem = responseStream.Current;
+                ts::Response responseItem = responseStream.Current;
                 // Do something with streamed response
             }
             // The response stream has completed

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodServerStreaming2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodServerStreaming2Snippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodServerStreaming_sync_flattened2]
     using Google.Api.Gax.Grpc;
@@ -36,16 +36,16 @@ namespace Testing.Snippets.Snippets
         public async Task MethodServerStreaming2()
         {
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Make the request, returning a streaming response
-            SnippetsClient.MethodServerStreamingStream response = snippetsClient.MethodServerStreaming();
+            ts::SnippetsClient.MethodServerStreamingStream response = snippetsClient.MethodServerStreaming();
 
             // Read streaming responses from server until complete
             // Note that C# 8 code can use await foreach
-            AsyncResponseStream<Response> responseStream = response.GetResponseStream();
+            AsyncResponseStream<ts::Response> responseStream = response.GetResponseStream();
             while (await responseStream.MoveNextAsync())
             {
-                Response responseItem = responseStream.Current;
+                ts::Response responseItem = responseStream.Current;
                 // Do something with streamed response
             }
             // The response stream has completed

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodServerStreamingRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodServerStreamingRequestObjectSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodServerStreaming_sync]
     using Google.Api.Gax.Grpc;
@@ -36,9 +36,9 @@ namespace Testing.Snippets.Snippets
         public async Task MethodServerStreamingRequestObject()
         {
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
-            SignatureRequest request = new SignatureRequest
+            ts::SignatureRequest request = new ts::SignatureRequest
             {
                 AString = "",
                 AnInt = 0,
@@ -46,14 +46,14 @@ namespace Testing.Snippets.Snippets
                 MapIntString = { { 0, "" }, },
             };
             // Make the request, returning a streaming response
-            SnippetsClient.MethodServerStreamingStream response = snippetsClient.MethodServerStreaming(request);
+            ts::SnippetsClient.MethodServerStreamingStream response = snippetsClient.MethodServerStreaming(request);
 
             // Read streaming responses from server until complete
             // Note that C# 8 code can use await foreach
-            AsyncResponseStream<Response> responseStream = response.GetResponseStream();
+            AsyncResponseStream<ts::Response> responseStream = response.GetResponseStream();
             while (await responseStream.MoveNextAsync())
             {
-                Response responseItem = responseStream.Current;
+                ts::Response responseItem = responseStream.Current;
                 // Do something with streamed response
             }
             // The response stream has completed

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodServerStreamingResourcesRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodServerStreamingResourcesRequestObjectSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodServerStreamingResources_sync]
     using Google.Api.Gax.Grpc;
@@ -36,23 +36,23 @@ namespace Testing.Snippets.Snippets
         public async Task MethodServerStreamingResourcesRequestObject()
         {
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
-            ResourceSignatureRequest request = new ResourceSignatureRequest
+            ts::ResourceSignatureRequest request = new ts::ResourceSignatureRequest
             {
-                FirstNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
-                SecondNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
-                ThirdNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                FirstNameAsSimpleResourceName = ts::SimpleResourceName.FromItem("[ITEM_ID]"),
+                SecondNameAsSimpleResourceName = ts::SimpleResourceName.FromItem("[ITEM_ID]"),
+                ThirdNameAsSimpleResourceName = ts::SimpleResourceName.FromItem("[ITEM_ID]"),
             };
             // Make the request, returning a streaming response
-            SnippetsClient.MethodServerStreamingResourcesStream response = snippetsClient.MethodServerStreamingResources(request);
+            ts::SnippetsClient.MethodServerStreamingResourcesStream response = snippetsClient.MethodServerStreamingResources(request);
 
             // Read streaming responses from server until complete
             // Note that C# 8 code can use await foreach
-            AsyncResponseStream<Response> responseStream = response.GetResponseStream();
+            AsyncResponseStream<ts::Response> responseStream = response.GetResponseStream();
             while (await responseStream.MoveNextAsync())
             {
-                Response responseItem = responseStream.Current;
+                ts::Response responseItem = responseStream.Current;
                 // Do something with streamed response
             }
             // The response stream has completed

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodServerStreamingResourcesResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodServerStreamingResourcesResourceNamesSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodServerStreamingResources_sync_flattened_resourceNames]
     using Google.Api.Gax.Grpc;
@@ -36,20 +36,20 @@ namespace Testing.Snippets.Snippets
         public async Task MethodServerStreamingResourcesResourceNames()
         {
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
-            SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
-            SimpleResourceName secondName = SimpleResourceName.FromItem("[ITEM_ID]");
-            SimpleResourceName thirdName = SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName firstName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName secondName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName thirdName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
             // Make the request, returning a streaming response
-            SnippetsClient.MethodServerStreamingResourcesStream response = snippetsClient.MethodServerStreamingResources(firstName, secondName, thirdName);
+            ts::SnippetsClient.MethodServerStreamingResourcesStream response = snippetsClient.MethodServerStreamingResources(firstName, secondName, thirdName);
 
             // Read streaming responses from server until complete
             // Note that C# 8 code can use await foreach
-            AsyncResponseStream<Response> responseStream = response.GetResponseStream();
+            AsyncResponseStream<ts::Response> responseStream = response.GetResponseStream();
             while (await responseStream.MoveNextAsync())
             {
-                Response responseItem = responseStream.Current;
+                ts::Response responseItem = responseStream.Current;
                 // Do something with streamed response
             }
             // The response stream has completed

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodServerStreamingResourcesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodServerStreamingResourcesSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodServerStreamingResources_sync_flattened]
     using Google.Api.Gax.Grpc;
@@ -36,20 +36,20 @@ namespace Testing.Snippets.Snippets
         public async Task MethodServerStreamingResources()
         {
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
             string firstName = "items/[ITEM_ID]";
             string secondName = "items/[ITEM_ID]";
             string thirdName = "items/[ITEM_ID]";
             // Make the request, returning a streaming response
-            SnippetsClient.MethodServerStreamingResourcesStream response = snippetsClient.MethodServerStreamingResources(firstName, secondName, thirdName);
+            ts::SnippetsClient.MethodServerStreamingResourcesStream response = snippetsClient.MethodServerStreamingResources(firstName, secondName, thirdName);
 
             // Read streaming responses from server until complete
             // Note that C# 8 code can use await foreach
-            AsyncResponseStream<Response> responseStream = response.GetResponseStream();
+            AsyncResponseStream<ts::Response> responseStream = response.GetResponseStream();
             while (await responseStream.MoveNextAsync())
             {
-                Response responseItem = responseStream.Current;
+                ts::Response responseItem = responseStream.Current;
                 // Do something with streamed response
             }
             // The response stream has completed

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodThreeSignatures1AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodThreeSignatures1AsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodThreeSignatures_async_flattened1]
     using System.Threading.Tasks;
@@ -35,13 +35,13 @@ namespace Testing.Snippets.Snippets
         public async Task MethodThreeSignatures1Async()
         {
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             string aString = "";
             int anInt = 0;
             bool aBool = false;
             // Make the request
-            Response response = await snippetsClient.MethodThreeSignaturesAsync(aString, anInt, aBool);
+            ts::Response response = await snippetsClient.MethodThreeSignaturesAsync(aString, anInt, aBool);
         }
     }
     // [END snippets_generated_Snippets_MethodThreeSignatures_async_flattened1]

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodThreeSignatures1Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodThreeSignatures1Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodThreeSignatures_sync_flattened1]
     using Testing.Snippets;

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodThreeSignatures2AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodThreeSignatures2AsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodThreeSignatures_async_flattened2]
     using System.Threading.Tasks;
@@ -35,12 +35,12 @@ namespace Testing.Snippets.Snippets
         public async Task MethodThreeSignatures2Async()
         {
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             string aString = "";
             bool aBool = false;
             // Make the request
-            Response response = await snippetsClient.MethodThreeSignaturesAsync(aString, aBool);
+            ts::Response response = await snippetsClient.MethodThreeSignaturesAsync(aString, aBool);
         }
     }
     // [END snippets_generated_Snippets_MethodThreeSignatures_async_flattened2]

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodThreeSignatures2Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodThreeSignatures2Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodThreeSignatures_sync_flattened2]
     using Testing.Snippets;

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodThreeSignatures3AsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodThreeSignatures3AsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodThreeSignatures_async_flattened3]
     using System.Threading.Tasks;
@@ -35,9 +35,9 @@ namespace Testing.Snippets.Snippets
         public async Task MethodThreeSignatures3Async()
         {
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Make the request
-            Response response = await snippetsClient.MethodThreeSignaturesAsync();
+            ts::Response response = await snippetsClient.MethodThreeSignaturesAsync();
         }
     }
     // [END snippets_generated_Snippets_MethodThreeSignatures_async_flattened3]

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodThreeSignatures3Snippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodThreeSignatures3Snippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodThreeSignatures_sync_flattened3]
     using Testing.Snippets;

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodThreeSignaturesRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodThreeSignaturesRequestObjectAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodThreeSignatures_async]
     using System.Threading.Tasks;
@@ -35,9 +35,9 @@ namespace Testing.Snippets.Snippets
         public async Task MethodThreeSignaturesRequestObjectAsync()
         {
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            SignatureRequest request = new SignatureRequest
+            ts::SignatureRequest request = new ts::SignatureRequest
             {
                 AString = "",
                 AnInt = 0,
@@ -45,7 +45,7 @@ namespace Testing.Snippets.Snippets
                 MapIntString = { { 0, "" }, },
             };
             // Make the request
-            Response response = await snippetsClient.MethodThreeSignaturesAsync(request);
+            ts::Response response = await snippetsClient.MethodThreeSignaturesAsync(request);
         }
     }
     // [END snippets_generated_Snippets_MethodThreeSignatures_async]

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodThreeSignaturesRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.MethodThreeSignaturesRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_MethodThreeSignatures_sync]
     using Testing.Snippets;

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.OneOfMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.OneOfMethodRequestObjectAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_OneOfMethod_async]
     using System.Threading.Tasks;
@@ -35,15 +35,15 @@ namespace Testing.Snippets.Snippets
         public async Task OneOfMethodRequestObjectAsync()
         {
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            OneOfRequest request = new OneOfRequest
+            ts::OneOfRequest request = new ts::OneOfRequest
             {
                 NonOneOfString = "",
                 AString = "",
             };
             // Make the request
-            Response response = await snippetsClient.OneOfMethodAsync(request);
+            ts::Response response = await snippetsClient.OneOfMethodAsync(request);
         }
     }
     // [END snippets_generated_Snippets_OneOfMethod_async]

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.OneOfMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.OneOfMethodRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_OneOfMethod_sync]
     using Testing.Snippets;

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.TaskMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.TaskMethodRequestObjectAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_TaskMethod_async]
     using System.Threading.Tasks;
@@ -35,7 +35,7 @@ namespace Testing.Snippets.Snippets
         public async Task TaskMethodRequestObjectAsync()
         {
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             ts::Task request = new ts::Task { };
             // Make the request

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.TaskMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.GeneratedSnippets/SnippetsClient.TaskMethodRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START snippets_generated_Snippets_TaskMethod_sync]
     using Testing.Snippets;

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.Snippets/SnippetsClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/Testing.Snippets.Snippets/SnippetsClientSnippets.g.cs
@@ -16,7 +16,7 @@
 
 #pragma warning disable CS8981
 
-namespace Testing.Snippets.Snippets
+namespace GoogleCSharpSnippets
 {
     using Google.Api.Gax;
     using Google.Api.Gax.Grpc;
@@ -34,9 +34,9 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodDefaultValues(DefaultValuesRequest, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
-            DefaultValuesRequest request = new DefaultValuesRequest
+            ts::DefaultValuesRequest request = new ts::DefaultValuesRequest
             {
                 SingleDouble = 0,
                 SingleFloat = 0F,
@@ -53,10 +53,10 @@ namespace Testing.Snippets.Snippets
                 SingleBool = false,
                 SingleString = "",
                 SingleBytes = ByteString.Empty,
-                SingleMessage = new AnotherMessage(),
-                SingleNestedMessage = new DefaultValuesRequest.Types.NestedMessage(),
-                SingleEnum = Enum.Default,
-                SingleNestedEnum = DefaultValuesRequest.Types.NestedEnum.DefaultValue,
+                SingleMessage = new ts::AnotherMessage(),
+                SingleNestedMessage = new ts::DefaultValuesRequest.Types.NestedMessage(),
+                SingleEnum = ts::Enum.Default,
+                SingleNestedEnum = ts::DefaultValuesRequest.Types.NestedEnum.DefaultValue,
                 RepeatedDouble = { 0, },
                 RepeatedFloat = { 0F, },
                 RepeatedInt32 = { 0, },
@@ -74,31 +74,31 @@ namespace Testing.Snippets.Snippets
                 RepeatedBytes = { ByteString.Empty, },
                 RepeatedMessage =
                 {
-                    new AnotherMessage(),
+                    new ts::AnotherMessage(),
                 },
                 RepeatedNestedMessage =
                 {
-                    new DefaultValuesRequest.Types.NestedMessage(),
+                    new ts::DefaultValuesRequest.Types.NestedMessage(),
                 },
-                RepeatedEnum = { Enum.Default, },
+                RepeatedEnum = { ts::Enum.Default, },
                 RepeatedNestedEnum =
                 {
-                    DefaultValuesRequest.Types.NestedEnum.DefaultValue,
+                    ts::DefaultValuesRequest.Types.NestedEnum.DefaultValue,
                 },
-                SingleResourceNameAsAResourceName = AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
+                SingleResourceNameAsAResourceName = ts::AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
                 RepeatedResourceNameAsAResourceNames =
                 {
-                    AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
+                    ts::AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
                 },
                 SingleWildcardResourceAsResourceName = new UnparsedResourceName("a/wildcard/resource"),
                 RepeatedWildcardResourceAsResourceNames =
                 {
                     new UnparsedResourceName("a/wildcard/resource"),
                 },
-                MultiPatternResourceNameAsMultiPatternResourceName = MultiPatternResourceName.FromRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
+                MultiPatternResourceNameAsMultiPatternResourceName = ts::MultiPatternResourceName.FromRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
                 RepeatedMultiPatternResourceNameAsMultiPatternResourceNames =
                 {
-                    MultiPatternResourceName.FromRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
+                    ts::MultiPatternResourceName.FromRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
                 },
                 MapIntString = { { 0, "" }, },
                 SingleWrappedDouble = 0,
@@ -121,7 +121,7 @@ namespace Testing.Snippets.Snippets
                 RepeatedWrappedBytes = { ByteString.Empty, },
             };
             // Make the request
-            Response response = snippetsClient.MethodDefaultValues(request);
+            ts::Response response = snippetsClient.MethodDefaultValues(request);
             // End snippet
         }
 
@@ -131,9 +131,9 @@ namespace Testing.Snippets.Snippets
             // Snippet: MethodDefaultValuesAsync(DefaultValuesRequest, CallSettings)
             // Additional: MethodDefaultValuesAsync(DefaultValuesRequest, CancellationToken)
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            DefaultValuesRequest request = new DefaultValuesRequest
+            ts::DefaultValuesRequest request = new ts::DefaultValuesRequest
             {
                 SingleDouble = 0,
                 SingleFloat = 0F,
@@ -150,10 +150,10 @@ namespace Testing.Snippets.Snippets
                 SingleBool = false,
                 SingleString = "",
                 SingleBytes = ByteString.Empty,
-                SingleMessage = new AnotherMessage(),
-                SingleNestedMessage = new DefaultValuesRequest.Types.NestedMessage(),
-                SingleEnum = Enum.Default,
-                SingleNestedEnum = DefaultValuesRequest.Types.NestedEnum.DefaultValue,
+                SingleMessage = new ts::AnotherMessage(),
+                SingleNestedMessage = new ts::DefaultValuesRequest.Types.NestedMessage(),
+                SingleEnum = ts::Enum.Default,
+                SingleNestedEnum = ts::DefaultValuesRequest.Types.NestedEnum.DefaultValue,
                 RepeatedDouble = { 0, },
                 RepeatedFloat = { 0F, },
                 RepeatedInt32 = { 0, },
@@ -171,31 +171,31 @@ namespace Testing.Snippets.Snippets
                 RepeatedBytes = { ByteString.Empty, },
                 RepeatedMessage =
                 {
-                    new AnotherMessage(),
+                    new ts::AnotherMessage(),
                 },
                 RepeatedNestedMessage =
                 {
-                    new DefaultValuesRequest.Types.NestedMessage(),
+                    new ts::DefaultValuesRequest.Types.NestedMessage(),
                 },
-                RepeatedEnum = { Enum.Default, },
+                RepeatedEnum = { ts::Enum.Default, },
                 RepeatedNestedEnum =
                 {
-                    DefaultValuesRequest.Types.NestedEnum.DefaultValue,
+                    ts::DefaultValuesRequest.Types.NestedEnum.DefaultValue,
                 },
-                SingleResourceNameAsAResourceName = AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
+                SingleResourceNameAsAResourceName = ts::AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
                 RepeatedResourceNameAsAResourceNames =
                 {
-                    AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
+                    ts::AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
                 },
                 SingleWildcardResourceAsResourceName = new UnparsedResourceName("a/wildcard/resource"),
                 RepeatedWildcardResourceAsResourceNames =
                 {
                     new UnparsedResourceName("a/wildcard/resource"),
                 },
-                MultiPatternResourceNameAsMultiPatternResourceName = MultiPatternResourceName.FromRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
+                MultiPatternResourceNameAsMultiPatternResourceName = ts::MultiPatternResourceName.FromRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
                 RepeatedMultiPatternResourceNameAsMultiPatternResourceNames =
                 {
-                    MultiPatternResourceName.FromRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
+                    ts::MultiPatternResourceName.FromRootAItem("[ROOT_A_ID]", "[ITEM_ID]"),
                 },
                 MapIntString = { { 0, "" }, },
                 SingleWrappedDouble = 0,
@@ -218,7 +218,7 @@ namespace Testing.Snippets.Snippets
                 RepeatedWrappedBytes = { ByteString.Empty, },
             };
             // Make the request
-            Response response = await snippetsClient.MethodDefaultValuesAsync(request);
+            ts::Response response = await snippetsClient.MethodDefaultValuesAsync(request);
             // End snippet
         }
 
@@ -227,19 +227,19 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodDefaultValues(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, IEnumerable<string>, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
             IEnumerable<double> repeatedDouble = new double[] { 0, };
-            IEnumerable<DefaultValuesRequest.Types.NestedMessage> repeatedNestedMessage = new DefaultValuesRequest.Types.NestedMessage[]
+            IEnumerable<ts::DefaultValuesRequest.Types.NestedMessage> repeatedNestedMessage = new ts::DefaultValuesRequest.Types.NestedMessage[]
             {
-                new DefaultValuesRequest.Types.NestedMessage(),
+                new ts::DefaultValuesRequest.Types.NestedMessage(),
             };
             IEnumerable<string> repeatedResourceName = new string[]
             {
                 "items/[ITEM_ID]/parts/[PART_ID]",
             };
             // Make the request
-            Response response = snippetsClient.MethodDefaultValues(repeatedDouble, repeatedNestedMessage, repeatedResourceName);
+            ts::Response response = snippetsClient.MethodDefaultValues(repeatedDouble, repeatedNestedMessage, repeatedResourceName);
             // End snippet
         }
 
@@ -249,19 +249,19 @@ namespace Testing.Snippets.Snippets
             // Snippet: MethodDefaultValuesAsync(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, IEnumerable<string>, CallSettings)
             // Additional: MethodDefaultValuesAsync(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, IEnumerable<string>, CancellationToken)
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             IEnumerable<double> repeatedDouble = new double[] { 0, };
-            IEnumerable<DefaultValuesRequest.Types.NestedMessage> repeatedNestedMessage = new DefaultValuesRequest.Types.NestedMessage[]
+            IEnumerable<ts::DefaultValuesRequest.Types.NestedMessage> repeatedNestedMessage = new ts::DefaultValuesRequest.Types.NestedMessage[]
             {
-                new DefaultValuesRequest.Types.NestedMessage(),
+                new ts::DefaultValuesRequest.Types.NestedMessage(),
             };
             IEnumerable<string> repeatedResourceName = new string[]
             {
                 "items/[ITEM_ID]/parts/[PART_ID]",
             };
             // Make the request
-            Response response = await snippetsClient.MethodDefaultValuesAsync(repeatedDouble, repeatedNestedMessage, repeatedResourceName);
+            ts::Response response = await snippetsClient.MethodDefaultValuesAsync(repeatedDouble, repeatedNestedMessage, repeatedResourceName);
             // End snippet
         }
 
@@ -270,19 +270,19 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodDefaultValues(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, IEnumerable<AResourceName>, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
             IEnumerable<double> repeatedDouble = new double[] { 0, };
-            IEnumerable<DefaultValuesRequest.Types.NestedMessage> repeatedNestedMessage = new DefaultValuesRequest.Types.NestedMessage[]
+            IEnumerable<ts::DefaultValuesRequest.Types.NestedMessage> repeatedNestedMessage = new ts::DefaultValuesRequest.Types.NestedMessage[]
             {
-                new DefaultValuesRequest.Types.NestedMessage(),
+                new ts::DefaultValuesRequest.Types.NestedMessage(),
             };
-            IEnumerable<AResourceName> repeatedResourceName = new AResourceName[]
+            IEnumerable<ts::AResourceName> repeatedResourceName = new ts::AResourceName[]
             {
-                AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
+                ts::AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
             };
             // Make the request
-            Response response = snippetsClient.MethodDefaultValues(repeatedDouble, repeatedNestedMessage, repeatedResourceName);
+            ts::Response response = snippetsClient.MethodDefaultValues(repeatedDouble, repeatedNestedMessage, repeatedResourceName);
             // End snippet
         }
 
@@ -292,19 +292,19 @@ namespace Testing.Snippets.Snippets
             // Snippet: MethodDefaultValuesAsync(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, IEnumerable<AResourceName>, CallSettings)
             // Additional: MethodDefaultValuesAsync(IEnumerable<double>, IEnumerable<DefaultValuesRequest.Types.NestedMessage>, IEnumerable<AResourceName>, CancellationToken)
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             IEnumerable<double> repeatedDouble = new double[] { 0, };
-            IEnumerable<DefaultValuesRequest.Types.NestedMessage> repeatedNestedMessage = new DefaultValuesRequest.Types.NestedMessage[]
+            IEnumerable<ts::DefaultValuesRequest.Types.NestedMessage> repeatedNestedMessage = new ts::DefaultValuesRequest.Types.NestedMessage[]
             {
-                new DefaultValuesRequest.Types.NestedMessage(),
+                new ts::DefaultValuesRequest.Types.NestedMessage(),
             };
-            IEnumerable<AResourceName> repeatedResourceName = new AResourceName[]
+            IEnumerable<ts::AResourceName> repeatedResourceName = new ts::AResourceName[]
             {
-                AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
+                ts::AResourceName.FromItemPart("[ITEM_ID]", "[PART_ID]"),
             };
             // Make the request
-            Response response = await snippetsClient.MethodDefaultValuesAsync(repeatedDouble, repeatedNestedMessage, repeatedResourceName);
+            ts::Response response = await snippetsClient.MethodDefaultValuesAsync(repeatedDouble, repeatedNestedMessage, repeatedResourceName);
             // End snippet
         }
 
@@ -313,9 +313,9 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodOneSignature(SignatureRequest, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
-            SignatureRequest request = new SignatureRequest
+            ts::SignatureRequest request = new ts::SignatureRequest
             {
                 AString = "",
                 AnInt = 0,
@@ -323,7 +323,7 @@ namespace Testing.Snippets.Snippets
                 MapIntString = { { 0, "" }, },
             };
             // Make the request
-            Response response = snippetsClient.MethodOneSignature(request);
+            ts::Response response = snippetsClient.MethodOneSignature(request);
             // End snippet
         }
 
@@ -333,9 +333,9 @@ namespace Testing.Snippets.Snippets
             // Snippet: MethodOneSignatureAsync(SignatureRequest, CallSettings)
             // Additional: MethodOneSignatureAsync(SignatureRequest, CancellationToken)
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            SignatureRequest request = new SignatureRequest
+            ts::SignatureRequest request = new ts::SignatureRequest
             {
                 AString = "",
                 AnInt = 0,
@@ -343,7 +343,7 @@ namespace Testing.Snippets.Snippets
                 MapIntString = { { 0, "" }, },
             };
             // Make the request
-            Response response = await snippetsClient.MethodOneSignatureAsync(request);
+            ts::Response response = await snippetsClient.MethodOneSignatureAsync(request);
             // End snippet
         }
 
@@ -352,13 +352,13 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodOneSignature(string, int, bool, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
             string aString = "";
             int anInt = 0;
             bool aBool = false;
             // Make the request
-            Response response = snippetsClient.MethodOneSignature(aString, anInt, aBool);
+            ts::Response response = snippetsClient.MethodOneSignature(aString, anInt, aBool);
             // End snippet
         }
 
@@ -368,13 +368,13 @@ namespace Testing.Snippets.Snippets
             // Snippet: MethodOneSignatureAsync(string, int, bool, CallSettings)
             // Additional: MethodOneSignatureAsync(string, int, bool, CancellationToken)
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             string aString = "";
             int anInt = 0;
             bool aBool = false;
             // Make the request
-            Response response = await snippetsClient.MethodOneSignatureAsync(aString, anInt, aBool);
+            ts::Response response = await snippetsClient.MethodOneSignatureAsync(aString, anInt, aBool);
             // End snippet
         }
 
@@ -383,9 +383,9 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodThreeSignatures(SignatureRequest, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
-            SignatureRequest request = new SignatureRequest
+            ts::SignatureRequest request = new ts::SignatureRequest
             {
                 AString = "",
                 AnInt = 0,
@@ -393,7 +393,7 @@ namespace Testing.Snippets.Snippets
                 MapIntString = { { 0, "" }, },
             };
             // Make the request
-            Response response = snippetsClient.MethodThreeSignatures(request);
+            ts::Response response = snippetsClient.MethodThreeSignatures(request);
             // End snippet
         }
 
@@ -403,9 +403,9 @@ namespace Testing.Snippets.Snippets
             // Snippet: MethodThreeSignaturesAsync(SignatureRequest, CallSettings)
             // Additional: MethodThreeSignaturesAsync(SignatureRequest, CancellationToken)
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            SignatureRequest request = new SignatureRequest
+            ts::SignatureRequest request = new ts::SignatureRequest
             {
                 AString = "",
                 AnInt = 0,
@@ -413,7 +413,7 @@ namespace Testing.Snippets.Snippets
                 MapIntString = { { 0, "" }, },
             };
             // Make the request
-            Response response = await snippetsClient.MethodThreeSignaturesAsync(request);
+            ts::Response response = await snippetsClient.MethodThreeSignaturesAsync(request);
             // End snippet
         }
 
@@ -422,13 +422,13 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodThreeSignatures(string, int, bool, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
             string aString = "";
             int anInt = 0;
             bool aBool = false;
             // Make the request
-            Response response = snippetsClient.MethodThreeSignatures(aString, anInt, aBool);
+            ts::Response response = snippetsClient.MethodThreeSignatures(aString, anInt, aBool);
             // End snippet
         }
 
@@ -438,13 +438,13 @@ namespace Testing.Snippets.Snippets
             // Snippet: MethodThreeSignaturesAsync(string, int, bool, CallSettings)
             // Additional: MethodThreeSignaturesAsync(string, int, bool, CancellationToken)
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             string aString = "";
             int anInt = 0;
             bool aBool = false;
             // Make the request
-            Response response = await snippetsClient.MethodThreeSignaturesAsync(aString, anInt, aBool);
+            ts::Response response = await snippetsClient.MethodThreeSignaturesAsync(aString, anInt, aBool);
             // End snippet
         }
 
@@ -453,12 +453,12 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodThreeSignatures(string, bool, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
             string aString = "";
             bool aBool = false;
             // Make the request
-            Response response = snippetsClient.MethodThreeSignatures(aString, aBool);
+            ts::Response response = snippetsClient.MethodThreeSignatures(aString, aBool);
             // End snippet
         }
 
@@ -468,12 +468,12 @@ namespace Testing.Snippets.Snippets
             // Snippet: MethodThreeSignaturesAsync(string, bool, CallSettings)
             // Additional: MethodThreeSignaturesAsync(string, bool, CancellationToken)
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             string aString = "";
             bool aBool = false;
             // Make the request
-            Response response = await snippetsClient.MethodThreeSignaturesAsync(aString, aBool);
+            ts::Response response = await snippetsClient.MethodThreeSignaturesAsync(aString, aBool);
             // End snippet
         }
 
@@ -482,9 +482,9 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodThreeSignatures(CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Make the request
-            Response response = snippetsClient.MethodThreeSignatures();
+            ts::Response response = snippetsClient.MethodThreeSignatures();
             // End snippet
         }
 
@@ -494,9 +494,9 @@ namespace Testing.Snippets.Snippets
             // Snippet: MethodThreeSignaturesAsync(CallSettings)
             // Additional: MethodThreeSignaturesAsync(CancellationToken)
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Make the request
-            Response response = await snippetsClient.MethodThreeSignaturesAsync();
+            ts::Response response = await snippetsClient.MethodThreeSignaturesAsync();
             // End snippet
         }
 
@@ -505,9 +505,9 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodMapSignature(SignatureRequest, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
-            SignatureRequest request = new SignatureRequest
+            ts::SignatureRequest request = new ts::SignatureRequest
             {
                 AString = "",
                 AnInt = 0,
@@ -515,7 +515,7 @@ namespace Testing.Snippets.Snippets
                 MapIntString = { { 0, "" }, },
             };
             // Make the request
-            Response response = snippetsClient.MethodMapSignature(request);
+            ts::Response response = snippetsClient.MethodMapSignature(request);
             // End snippet
         }
 
@@ -525,9 +525,9 @@ namespace Testing.Snippets.Snippets
             // Snippet: MethodMapSignatureAsync(SignatureRequest, CallSettings)
             // Additional: MethodMapSignatureAsync(SignatureRequest, CancellationToken)
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            SignatureRequest request = new SignatureRequest
+            ts::SignatureRequest request = new ts::SignatureRequest
             {
                 AString = "",
                 AnInt = 0,
@@ -535,7 +535,7 @@ namespace Testing.Snippets.Snippets
                 MapIntString = { { 0, "" }, },
             };
             // Make the request
-            Response response = await snippetsClient.MethodMapSignatureAsync(request);
+            ts::Response response = await snippetsClient.MethodMapSignatureAsync(request);
             // End snippet
         }
 
@@ -544,11 +544,11 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodMapSignature(IDictionary<int,string>, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
             IDictionary<int, string> mapIntString = new Dictionary<int, string> { { 0, "" }, };
             // Make the request
-            Response response = snippetsClient.MethodMapSignature(mapIntString);
+            ts::Response response = snippetsClient.MethodMapSignature(mapIntString);
             // End snippet
         }
 
@@ -558,11 +558,11 @@ namespace Testing.Snippets.Snippets
             // Snippet: MethodMapSignatureAsync(IDictionary<int,string>, CallSettings)
             // Additional: MethodMapSignatureAsync(IDictionary<int,string>, CancellationToken)
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             IDictionary<int, string> mapIntString = new Dictionary<int, string> { { 0, "" }, };
             // Make the request
-            Response response = await snippetsClient.MethodMapSignatureAsync(mapIntString);
+            ts::Response response = await snippetsClient.MethodMapSignatureAsync(mapIntString);
             // End snippet
         }
 
@@ -571,16 +571,16 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodResourceSignature(ResourceSignatureRequest, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
-            ResourceSignatureRequest request = new ResourceSignatureRequest
+            ts::ResourceSignatureRequest request = new ts::ResourceSignatureRequest
             {
-                FirstNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
-                SecondNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
-                ThirdNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                FirstNameAsSimpleResourceName = ts::SimpleResourceName.FromItem("[ITEM_ID]"),
+                SecondNameAsSimpleResourceName = ts::SimpleResourceName.FromItem("[ITEM_ID]"),
+                ThirdNameAsSimpleResourceName = ts::SimpleResourceName.FromItem("[ITEM_ID]"),
             };
             // Make the request
-            Response response = snippetsClient.MethodResourceSignature(request);
+            ts::Response response = snippetsClient.MethodResourceSignature(request);
             // End snippet
         }
 
@@ -590,16 +590,16 @@ namespace Testing.Snippets.Snippets
             // Snippet: MethodResourceSignatureAsync(ResourceSignatureRequest, CallSettings)
             // Additional: MethodResourceSignatureAsync(ResourceSignatureRequest, CancellationToken)
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            ResourceSignatureRequest request = new ResourceSignatureRequest
+            ts::ResourceSignatureRequest request = new ts::ResourceSignatureRequest
             {
-                FirstNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
-                SecondNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
-                ThirdNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                FirstNameAsSimpleResourceName = ts::SimpleResourceName.FromItem("[ITEM_ID]"),
+                SecondNameAsSimpleResourceName = ts::SimpleResourceName.FromItem("[ITEM_ID]"),
+                ThirdNameAsSimpleResourceName = ts::SimpleResourceName.FromItem("[ITEM_ID]"),
             };
             // Make the request
-            Response response = await snippetsClient.MethodResourceSignatureAsync(request);
+            ts::Response response = await snippetsClient.MethodResourceSignatureAsync(request);
             // End snippet
         }
 
@@ -608,13 +608,13 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodResourceSignature(string, string, string, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
             string firstName = "items/[ITEM_ID]";
             string secondName = "items/[ITEM_ID]";
             string thirdName = "items/[ITEM_ID]";
             // Make the request
-            Response response = snippetsClient.MethodResourceSignature(firstName, secondName, thirdName);
+            ts::Response response = snippetsClient.MethodResourceSignature(firstName, secondName, thirdName);
             // End snippet
         }
 
@@ -624,13 +624,13 @@ namespace Testing.Snippets.Snippets
             // Snippet: MethodResourceSignatureAsync(string, string, string, CallSettings)
             // Additional: MethodResourceSignatureAsync(string, string, string, CancellationToken)
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             string firstName = "items/[ITEM_ID]";
             string secondName = "items/[ITEM_ID]";
             string thirdName = "items/[ITEM_ID]";
             // Make the request
-            Response response = await snippetsClient.MethodResourceSignatureAsync(firstName, secondName, thirdName);
+            ts::Response response = await snippetsClient.MethodResourceSignatureAsync(firstName, secondName, thirdName);
             // End snippet
         }
 
@@ -639,13 +639,13 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodResourceSignature(SimpleResourceName, SimpleResourceName, SimpleResourceName, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
-            SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
-            SimpleResourceName secondName = SimpleResourceName.FromItem("[ITEM_ID]");
-            SimpleResourceName thirdName = SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName firstName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName secondName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName thirdName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
             // Make the request
-            Response response = snippetsClient.MethodResourceSignature(firstName, secondName, thirdName);
+            ts::Response response = snippetsClient.MethodResourceSignature(firstName, secondName, thirdName);
             // End snippet
         }
 
@@ -655,13 +655,13 @@ namespace Testing.Snippets.Snippets
             // Snippet: MethodResourceSignatureAsync(SimpleResourceName, SimpleResourceName, SimpleResourceName, CallSettings)
             // Additional: MethodResourceSignatureAsync(SimpleResourceName, SimpleResourceName, SimpleResourceName, CancellationToken)
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
-            SimpleResourceName secondName = SimpleResourceName.FromItem("[ITEM_ID]");
-            SimpleResourceName thirdName = SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName firstName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName secondName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName thirdName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
             // Make the request
-            Response response = await snippetsClient.MethodResourceSignatureAsync(firstName, secondName, thirdName);
+            ts::Response response = await snippetsClient.MethodResourceSignatureAsync(firstName, secondName, thirdName);
             // End snippet
         }
 
@@ -670,11 +670,11 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodResourceSignature(string, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
             string firstName = "items/[ITEM_ID]";
             // Make the request
-            Response response = snippetsClient.MethodResourceSignature(firstName);
+            ts::Response response = snippetsClient.MethodResourceSignature(firstName);
             // End snippet
         }
 
@@ -684,11 +684,11 @@ namespace Testing.Snippets.Snippets
             // Snippet: MethodResourceSignatureAsync(string, CallSettings)
             // Additional: MethodResourceSignatureAsync(string, CancellationToken)
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             string firstName = "items/[ITEM_ID]";
             // Make the request
-            Response response = await snippetsClient.MethodResourceSignatureAsync(firstName);
+            ts::Response response = await snippetsClient.MethodResourceSignatureAsync(firstName);
             // End snippet
         }
 
@@ -697,11 +697,11 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodResourceSignature(SimpleResourceName, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
-            SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName firstName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
             // Make the request
-            Response response = snippetsClient.MethodResourceSignature(firstName);
+            ts::Response response = snippetsClient.MethodResourceSignature(firstName);
             // End snippet
         }
 
@@ -711,11 +711,11 @@ namespace Testing.Snippets.Snippets
             // Snippet: MethodResourceSignatureAsync(SimpleResourceName, CallSettings)
             // Additional: MethodResourceSignatureAsync(SimpleResourceName, CancellationToken)
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName firstName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
             // Make the request
-            Response response = await snippetsClient.MethodResourceSignatureAsync(firstName);
+            ts::Response response = await snippetsClient.MethodResourceSignatureAsync(firstName);
             // End snippet
         }
 
@@ -724,17 +724,17 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodRepeatedResourceSignature(RepeatedResourceSignatureRequest, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
-            RepeatedResourceSignatureRequest request = new RepeatedResourceSignatureRequest
+            ts::RepeatedResourceSignatureRequest request = new ts::RepeatedResourceSignatureRequest
             {
                 SimpleResourceNames =
                 {
-                    SimpleResourceName.FromItem("[ITEM_ID]"),
+                    ts::SimpleResourceName.FromItem("[ITEM_ID]"),
                 },
             };
             // Make the request
-            Response response = snippetsClient.MethodRepeatedResourceSignature(request);
+            ts::Response response = snippetsClient.MethodRepeatedResourceSignature(request);
             // End snippet
         }
 
@@ -744,17 +744,17 @@ namespace Testing.Snippets.Snippets
             // Snippet: MethodRepeatedResourceSignatureAsync(RepeatedResourceSignatureRequest, CallSettings)
             // Additional: MethodRepeatedResourceSignatureAsync(RepeatedResourceSignatureRequest, CancellationToken)
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            RepeatedResourceSignatureRequest request = new RepeatedResourceSignatureRequest
+            ts::RepeatedResourceSignatureRequest request = new ts::RepeatedResourceSignatureRequest
             {
                 SimpleResourceNames =
                 {
-                    SimpleResourceName.FromItem("[ITEM_ID]"),
+                    ts::SimpleResourceName.FromItem("[ITEM_ID]"),
                 },
             };
             // Make the request
-            Response response = await snippetsClient.MethodRepeatedResourceSignatureAsync(request);
+            ts::Response response = await snippetsClient.MethodRepeatedResourceSignatureAsync(request);
             // End snippet
         }
 
@@ -763,11 +763,11 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodRepeatedResourceSignature(IEnumerable<string>, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
             IEnumerable<string> names = new string[] { "items/[ITEM_ID]", };
             // Make the request
-            Response response = snippetsClient.MethodRepeatedResourceSignature(names);
+            ts::Response response = snippetsClient.MethodRepeatedResourceSignature(names);
             // End snippet
         }
 
@@ -777,11 +777,11 @@ namespace Testing.Snippets.Snippets
             // Snippet: MethodRepeatedResourceSignatureAsync(IEnumerable<string>, CallSettings)
             // Additional: MethodRepeatedResourceSignatureAsync(IEnumerable<string>, CancellationToken)
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             IEnumerable<string> names = new string[] { "items/[ITEM_ID]", };
             // Make the request
-            Response response = await snippetsClient.MethodRepeatedResourceSignatureAsync(names);
+            ts::Response response = await snippetsClient.MethodRepeatedResourceSignatureAsync(names);
             // End snippet
         }
 
@@ -790,14 +790,14 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodRepeatedResourceSignature(IEnumerable<SimpleResourceName>, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
-            IEnumerable<SimpleResourceName> names = new SimpleResourceName[]
+            IEnumerable<ts::SimpleResourceName> names = new ts::SimpleResourceName[]
             {
-                SimpleResourceName.FromItem("[ITEM_ID]"),
+                ts::SimpleResourceName.FromItem("[ITEM_ID]"),
             };
             // Make the request
-            Response response = snippetsClient.MethodRepeatedResourceSignature(names);
+            ts::Response response = snippetsClient.MethodRepeatedResourceSignature(names);
             // End snippet
         }
 
@@ -807,14 +807,14 @@ namespace Testing.Snippets.Snippets
             // Snippet: MethodRepeatedResourceSignatureAsync(IEnumerable<SimpleResourceName>, CallSettings)
             // Additional: MethodRepeatedResourceSignatureAsync(IEnumerable<SimpleResourceName>, CancellationToken)
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            IEnumerable<SimpleResourceName> names = new SimpleResourceName[]
+            IEnumerable<ts::SimpleResourceName> names = new ts::SimpleResourceName[]
             {
-                SimpleResourceName.FromItem("[ITEM_ID]"),
+                ts::SimpleResourceName.FromItem("[ITEM_ID]"),
             };
             // Make the request
-            Response response = await snippetsClient.MethodRepeatedResourceSignatureAsync(names);
+            ts::Response response = await snippetsClient.MethodRepeatedResourceSignatureAsync(names);
             // End snippet
         }
 
@@ -823,9 +823,9 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodLroSignatures(SignatureRequest, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
-            SignatureRequest request = new SignatureRequest
+            ts::SignatureRequest request = new ts::SignatureRequest
             {
                 AString = "",
                 AnInt = 0,
@@ -833,22 +833,22 @@ namespace Testing.Snippets.Snippets
                 MapIntString = { { 0, "" }, },
             };
             // Make the request
-            Operation<LroResponse, LroMetadata> response = snippetsClient.MethodLroSignatures(request);
+            Operation<ts::LroResponse, ts::LroMetadata> response = snippetsClient.MethodLroSignatures(request);
 
             // Poll until the returned long-running operation is complete
-            Operation<LroResponse, LroMetadata> completedResponse = response.PollUntilCompleted();
+            Operation<ts::LroResponse, ts::LroMetadata> completedResponse = response.PollUntilCompleted();
             // Retrieve the operation result
-            LroResponse result = completedResponse.Result;
+            ts::LroResponse result = completedResponse.Result;
 
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<LroResponse, LroMetadata> retrievedResponse = snippetsClient.PollOnceMethodLroSignatures(operationName);
+            Operation<ts::LroResponse, ts::LroMetadata> retrievedResponse = snippetsClient.PollOnceMethodLroSignatures(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
             {
                 // If it has completed, then access the result
-                LroResponse retrievedResult = retrievedResponse.Result;
+                ts::LroResponse retrievedResult = retrievedResponse.Result;
             }
             // End snippet
         }
@@ -859,9 +859,9 @@ namespace Testing.Snippets.Snippets
             // Snippet: MethodLroSignaturesAsync(SignatureRequest, CallSettings)
             // Additional: MethodLroSignaturesAsync(SignatureRequest, CancellationToken)
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            SignatureRequest request = new SignatureRequest
+            ts::SignatureRequest request = new ts::SignatureRequest
             {
                 AString = "",
                 AnInt = 0,
@@ -869,22 +869,22 @@ namespace Testing.Snippets.Snippets
                 MapIntString = { { 0, "" }, },
             };
             // Make the request
-            Operation<LroResponse, LroMetadata> response = await snippetsClient.MethodLroSignaturesAsync(request);
+            Operation<ts::LroResponse, ts::LroMetadata> response = await snippetsClient.MethodLroSignaturesAsync(request);
 
             // Poll until the returned long-running operation is complete
-            Operation<LroResponse, LroMetadata> completedResponse = await response.PollUntilCompletedAsync();
+            Operation<ts::LroResponse, ts::LroMetadata> completedResponse = await response.PollUntilCompletedAsync();
             // Retrieve the operation result
-            LroResponse result = completedResponse.Result;
+            ts::LroResponse result = completedResponse.Result;
 
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<LroResponse, LroMetadata> retrievedResponse = await snippetsClient.PollOnceMethodLroSignaturesAsync(operationName);
+            Operation<ts::LroResponse, ts::LroMetadata> retrievedResponse = await snippetsClient.PollOnceMethodLroSignaturesAsync(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
             {
                 // If it has completed, then access the result
-                LroResponse retrievedResult = retrievedResponse.Result;
+                ts::LroResponse retrievedResult = retrievedResponse.Result;
             }
             // End snippet
         }
@@ -894,28 +894,28 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodLroSignatures(string, int, bool, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
             string aString = "";
             int anInt = 0;
             bool aBool = false;
             // Make the request
-            Operation<LroResponse, LroMetadata> response = snippetsClient.MethodLroSignatures(aString, anInt, aBool);
+            Operation<ts::LroResponse, ts::LroMetadata> response = snippetsClient.MethodLroSignatures(aString, anInt, aBool);
 
             // Poll until the returned long-running operation is complete
-            Operation<LroResponse, LroMetadata> completedResponse = response.PollUntilCompleted();
+            Operation<ts::LroResponse, ts::LroMetadata> completedResponse = response.PollUntilCompleted();
             // Retrieve the operation result
-            LroResponse result = completedResponse.Result;
+            ts::LroResponse result = completedResponse.Result;
 
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<LroResponse, LroMetadata> retrievedResponse = snippetsClient.PollOnceMethodLroSignatures(operationName);
+            Operation<ts::LroResponse, ts::LroMetadata> retrievedResponse = snippetsClient.PollOnceMethodLroSignatures(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
             {
                 // If it has completed, then access the result
-                LroResponse retrievedResult = retrievedResponse.Result;
+                ts::LroResponse retrievedResult = retrievedResponse.Result;
             }
             // End snippet
         }
@@ -926,28 +926,28 @@ namespace Testing.Snippets.Snippets
             // Snippet: MethodLroSignaturesAsync(string, int, bool, CallSettings)
             // Additional: MethodLroSignaturesAsync(string, int, bool, CancellationToken)
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             string aString = "";
             int anInt = 0;
             bool aBool = false;
             // Make the request
-            Operation<LroResponse, LroMetadata> response = await snippetsClient.MethodLroSignaturesAsync(aString, anInt, aBool);
+            Operation<ts::LroResponse, ts::LroMetadata> response = await snippetsClient.MethodLroSignaturesAsync(aString, anInt, aBool);
 
             // Poll until the returned long-running operation is complete
-            Operation<LroResponse, LroMetadata> completedResponse = await response.PollUntilCompletedAsync();
+            Operation<ts::LroResponse, ts::LroMetadata> completedResponse = await response.PollUntilCompletedAsync();
             // Retrieve the operation result
-            LroResponse result = completedResponse.Result;
+            ts::LroResponse result = completedResponse.Result;
 
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<LroResponse, LroMetadata> retrievedResponse = await snippetsClient.PollOnceMethodLroSignaturesAsync(operationName);
+            Operation<ts::LroResponse, ts::LroMetadata> retrievedResponse = await snippetsClient.PollOnceMethodLroSignaturesAsync(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
             {
                 // If it has completed, then access the result
-                LroResponse retrievedResult = retrievedResponse.Result;
+                ts::LroResponse retrievedResult = retrievedResponse.Result;
             }
             // End snippet
         }
@@ -957,31 +957,31 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodLroResourceSignature(ResourceSignatureRequest, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
-            ResourceSignatureRequest request = new ResourceSignatureRequest
+            ts::ResourceSignatureRequest request = new ts::ResourceSignatureRequest
             {
-                FirstNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
-                SecondNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
-                ThirdNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                FirstNameAsSimpleResourceName = ts::SimpleResourceName.FromItem("[ITEM_ID]"),
+                SecondNameAsSimpleResourceName = ts::SimpleResourceName.FromItem("[ITEM_ID]"),
+                ThirdNameAsSimpleResourceName = ts::SimpleResourceName.FromItem("[ITEM_ID]"),
             };
             // Make the request
-            Operation<LroResponse, LroMetadata> response = snippetsClient.MethodLroResourceSignature(request);
+            Operation<ts::LroResponse, ts::LroMetadata> response = snippetsClient.MethodLroResourceSignature(request);
 
             // Poll until the returned long-running operation is complete
-            Operation<LroResponse, LroMetadata> completedResponse = response.PollUntilCompleted();
+            Operation<ts::LroResponse, ts::LroMetadata> completedResponse = response.PollUntilCompleted();
             // Retrieve the operation result
-            LroResponse result = completedResponse.Result;
+            ts::LroResponse result = completedResponse.Result;
 
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<LroResponse, LroMetadata> retrievedResponse = snippetsClient.PollOnceMethodLroResourceSignature(operationName);
+            Operation<ts::LroResponse, ts::LroMetadata> retrievedResponse = snippetsClient.PollOnceMethodLroResourceSignature(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
             {
                 // If it has completed, then access the result
-                LroResponse retrievedResult = retrievedResponse.Result;
+                ts::LroResponse retrievedResult = retrievedResponse.Result;
             }
             // End snippet
         }
@@ -992,31 +992,31 @@ namespace Testing.Snippets.Snippets
             // Snippet: MethodLroResourceSignatureAsync(ResourceSignatureRequest, CallSettings)
             // Additional: MethodLroResourceSignatureAsync(ResourceSignatureRequest, CancellationToken)
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            ResourceSignatureRequest request = new ResourceSignatureRequest
+            ts::ResourceSignatureRequest request = new ts::ResourceSignatureRequest
             {
-                FirstNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
-                SecondNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
-                ThirdNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                FirstNameAsSimpleResourceName = ts::SimpleResourceName.FromItem("[ITEM_ID]"),
+                SecondNameAsSimpleResourceName = ts::SimpleResourceName.FromItem("[ITEM_ID]"),
+                ThirdNameAsSimpleResourceName = ts::SimpleResourceName.FromItem("[ITEM_ID]"),
             };
             // Make the request
-            Operation<LroResponse, LroMetadata> response = await snippetsClient.MethodLroResourceSignatureAsync(request);
+            Operation<ts::LroResponse, ts::LroMetadata> response = await snippetsClient.MethodLroResourceSignatureAsync(request);
 
             // Poll until the returned long-running operation is complete
-            Operation<LroResponse, LroMetadata> completedResponse = await response.PollUntilCompletedAsync();
+            Operation<ts::LroResponse, ts::LroMetadata> completedResponse = await response.PollUntilCompletedAsync();
             // Retrieve the operation result
-            LroResponse result = completedResponse.Result;
+            ts::LroResponse result = completedResponse.Result;
 
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<LroResponse, LroMetadata> retrievedResponse = await snippetsClient.PollOnceMethodLroResourceSignatureAsync(operationName);
+            Operation<ts::LroResponse, ts::LroMetadata> retrievedResponse = await snippetsClient.PollOnceMethodLroResourceSignatureAsync(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
             {
                 // If it has completed, then access the result
-                LroResponse retrievedResult = retrievedResponse.Result;
+                ts::LroResponse retrievedResult = retrievedResponse.Result;
             }
             // End snippet
         }
@@ -1026,28 +1026,28 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodLroResourceSignature(string, string, string, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
             string firstName = "items/[ITEM_ID]";
             string secondName = "items/[ITEM_ID]";
             string thirdName = "items/[ITEM_ID]";
             // Make the request
-            Operation<LroResponse, LroMetadata> response = snippetsClient.MethodLroResourceSignature(firstName, secondName, thirdName);
+            Operation<ts::LroResponse, ts::LroMetadata> response = snippetsClient.MethodLroResourceSignature(firstName, secondName, thirdName);
 
             // Poll until the returned long-running operation is complete
-            Operation<LroResponse, LroMetadata> completedResponse = response.PollUntilCompleted();
+            Operation<ts::LroResponse, ts::LroMetadata> completedResponse = response.PollUntilCompleted();
             // Retrieve the operation result
-            LroResponse result = completedResponse.Result;
+            ts::LroResponse result = completedResponse.Result;
 
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<LroResponse, LroMetadata> retrievedResponse = snippetsClient.PollOnceMethodLroResourceSignature(operationName);
+            Operation<ts::LroResponse, ts::LroMetadata> retrievedResponse = snippetsClient.PollOnceMethodLroResourceSignature(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
             {
                 // If it has completed, then access the result
-                LroResponse retrievedResult = retrievedResponse.Result;
+                ts::LroResponse retrievedResult = retrievedResponse.Result;
             }
             // End snippet
         }
@@ -1058,28 +1058,28 @@ namespace Testing.Snippets.Snippets
             // Snippet: MethodLroResourceSignatureAsync(string, string, string, CallSettings)
             // Additional: MethodLroResourceSignatureAsync(string, string, string, CancellationToken)
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             string firstName = "items/[ITEM_ID]";
             string secondName = "items/[ITEM_ID]";
             string thirdName = "items/[ITEM_ID]";
             // Make the request
-            Operation<LroResponse, LroMetadata> response = await snippetsClient.MethodLroResourceSignatureAsync(firstName, secondName, thirdName);
+            Operation<ts::LroResponse, ts::LroMetadata> response = await snippetsClient.MethodLroResourceSignatureAsync(firstName, secondName, thirdName);
 
             // Poll until the returned long-running operation is complete
-            Operation<LroResponse, LroMetadata> completedResponse = await response.PollUntilCompletedAsync();
+            Operation<ts::LroResponse, ts::LroMetadata> completedResponse = await response.PollUntilCompletedAsync();
             // Retrieve the operation result
-            LroResponse result = completedResponse.Result;
+            ts::LroResponse result = completedResponse.Result;
 
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<LroResponse, LroMetadata> retrievedResponse = await snippetsClient.PollOnceMethodLroResourceSignatureAsync(operationName);
+            Operation<ts::LroResponse, ts::LroMetadata> retrievedResponse = await snippetsClient.PollOnceMethodLroResourceSignatureAsync(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
             {
                 // If it has completed, then access the result
-                LroResponse retrievedResult = retrievedResponse.Result;
+                ts::LroResponse retrievedResult = retrievedResponse.Result;
             }
             // End snippet
         }
@@ -1089,28 +1089,28 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodLroResourceSignature(SimpleResourceName, SimpleResourceName, SimpleResourceName, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
-            SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
-            SimpleResourceName secondName = SimpleResourceName.FromItem("[ITEM_ID]");
-            SimpleResourceName thirdName = SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName firstName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName secondName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName thirdName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
             // Make the request
-            Operation<LroResponse, LroMetadata> response = snippetsClient.MethodLroResourceSignature(firstName, secondName, thirdName);
+            Operation<ts::LroResponse, ts::LroMetadata> response = snippetsClient.MethodLroResourceSignature(firstName, secondName, thirdName);
 
             // Poll until the returned long-running operation is complete
-            Operation<LroResponse, LroMetadata> completedResponse = response.PollUntilCompleted();
+            Operation<ts::LroResponse, ts::LroMetadata> completedResponse = response.PollUntilCompleted();
             // Retrieve the operation result
-            LroResponse result = completedResponse.Result;
+            ts::LroResponse result = completedResponse.Result;
 
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<LroResponse, LroMetadata> retrievedResponse = snippetsClient.PollOnceMethodLroResourceSignature(operationName);
+            Operation<ts::LroResponse, ts::LroMetadata> retrievedResponse = snippetsClient.PollOnceMethodLroResourceSignature(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
             {
                 // If it has completed, then access the result
-                LroResponse retrievedResult = retrievedResponse.Result;
+                ts::LroResponse retrievedResult = retrievedResponse.Result;
             }
             // End snippet
         }
@@ -1121,28 +1121,28 @@ namespace Testing.Snippets.Snippets
             // Snippet: MethodLroResourceSignatureAsync(SimpleResourceName, SimpleResourceName, SimpleResourceName, CallSettings)
             // Additional: MethodLroResourceSignatureAsync(SimpleResourceName, SimpleResourceName, SimpleResourceName, CancellationToken)
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
-            SimpleResourceName secondName = SimpleResourceName.FromItem("[ITEM_ID]");
-            SimpleResourceName thirdName = SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName firstName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName secondName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName thirdName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
             // Make the request
-            Operation<LroResponse, LroMetadata> response = await snippetsClient.MethodLroResourceSignatureAsync(firstName, secondName, thirdName);
+            Operation<ts::LroResponse, ts::LroMetadata> response = await snippetsClient.MethodLroResourceSignatureAsync(firstName, secondName, thirdName);
 
             // Poll until the returned long-running operation is complete
-            Operation<LroResponse, LroMetadata> completedResponse = await response.PollUntilCompletedAsync();
+            Operation<ts::LroResponse, ts::LroMetadata> completedResponse = await response.PollUntilCompletedAsync();
             // Retrieve the operation result
-            LroResponse result = completedResponse.Result;
+            ts::LroResponse result = completedResponse.Result;
 
             // Or get the name of the operation
             string operationName = response.Name;
             // This name can be stored, then the long-running operation retrieved later by name
-            Operation<LroResponse, LroMetadata> retrievedResponse = await snippetsClient.PollOnceMethodLroResourceSignatureAsync(operationName);
+            Operation<ts::LroResponse, ts::LroMetadata> retrievedResponse = await snippetsClient.PollOnceMethodLroResourceSignatureAsync(operationName);
             // Check if the retrieved long-running operation has completed
             if (retrievedResponse.IsCompleted)
             {
                 // If it has completed, then access the result
-                LroResponse retrievedResult = retrievedResponse.Result;
+                ts::LroResponse retrievedResult = retrievedResponse.Result;
             }
             // End snippet
         }
@@ -1152,9 +1152,9 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodServerStreaming(SignatureRequest, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
-            SignatureRequest request = new SignatureRequest
+            ts::SignatureRequest request = new ts::SignatureRequest
             {
                 AString = "",
                 AnInt = 0,
@@ -1162,14 +1162,14 @@ namespace Testing.Snippets.Snippets
                 MapIntString = { { 0, "" }, },
             };
             // Make the request, returning a streaming response
-            SnippetsClient.MethodServerStreamingStream response = snippetsClient.MethodServerStreaming(request);
+            ts::SnippetsClient.MethodServerStreamingStream response = snippetsClient.MethodServerStreaming(request);
 
             // Read streaming responses from server until complete
             // Note that C# 8 code can use await foreach
-            AsyncResponseStream<Response> responseStream = response.GetResponseStream();
+            AsyncResponseStream<ts::Response> responseStream = response.GetResponseStream();
             while (await responseStream.MoveNextAsync())
             {
-                Response responseItem = responseStream.Current;
+                ts::Response responseItem = responseStream.Current;
                 // Do something with streamed response
             }
             // The response stream has completed
@@ -1181,19 +1181,19 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodServerStreaming(string, bool, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
             string aString = "";
             bool aBool = false;
             // Make the request, returning a streaming response
-            SnippetsClient.MethodServerStreamingStream response = snippetsClient.MethodServerStreaming(aString, aBool);
+            ts::SnippetsClient.MethodServerStreamingStream response = snippetsClient.MethodServerStreaming(aString, aBool);
 
             // Read streaming responses from server until complete
             // Note that C# 8 code can use await foreach
-            AsyncResponseStream<Response> responseStream = response.GetResponseStream();
+            AsyncResponseStream<ts::Response> responseStream = response.GetResponseStream();
             while (await responseStream.MoveNextAsync())
             {
-                Response responseItem = responseStream.Current;
+                ts::Response responseItem = responseStream.Current;
                 // Do something with streamed response
             }
             // The response stream has completed
@@ -1205,16 +1205,16 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodServerStreaming(CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Make the request, returning a streaming response
-            SnippetsClient.MethodServerStreamingStream response = snippetsClient.MethodServerStreaming();
+            ts::SnippetsClient.MethodServerStreamingStream response = snippetsClient.MethodServerStreaming();
 
             // Read streaming responses from server until complete
             // Note that C# 8 code can use await foreach
-            AsyncResponseStream<Response> responseStream = response.GetResponseStream();
+            AsyncResponseStream<ts::Response> responseStream = response.GetResponseStream();
             while (await responseStream.MoveNextAsync())
             {
-                Response responseItem = responseStream.Current;
+                ts::Response responseItem = responseStream.Current;
                 // Do something with streamed response
             }
             // The response stream has completed
@@ -1226,23 +1226,23 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodServerStreamingResources(ResourceSignatureRequest, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
-            ResourceSignatureRequest request = new ResourceSignatureRequest
+            ts::ResourceSignatureRequest request = new ts::ResourceSignatureRequest
             {
-                FirstNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
-                SecondNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
-                ThirdNameAsSimpleResourceName = SimpleResourceName.FromItem("[ITEM_ID]"),
+                FirstNameAsSimpleResourceName = ts::SimpleResourceName.FromItem("[ITEM_ID]"),
+                SecondNameAsSimpleResourceName = ts::SimpleResourceName.FromItem("[ITEM_ID]"),
+                ThirdNameAsSimpleResourceName = ts::SimpleResourceName.FromItem("[ITEM_ID]"),
             };
             // Make the request, returning a streaming response
-            SnippetsClient.MethodServerStreamingResourcesStream response = snippetsClient.MethodServerStreamingResources(request);
+            ts::SnippetsClient.MethodServerStreamingResourcesStream response = snippetsClient.MethodServerStreamingResources(request);
 
             // Read streaming responses from server until complete
             // Note that C# 8 code can use await foreach
-            AsyncResponseStream<Response> responseStream = response.GetResponseStream();
+            AsyncResponseStream<ts::Response> responseStream = response.GetResponseStream();
             while (await responseStream.MoveNextAsync())
             {
-                Response responseItem = responseStream.Current;
+                ts::Response responseItem = responseStream.Current;
                 // Do something with streamed response
             }
             // The response stream has completed
@@ -1254,20 +1254,20 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodServerStreamingResources(string, string, string, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
             string firstName = "items/[ITEM_ID]";
             string secondName = "items/[ITEM_ID]";
             string thirdName = "items/[ITEM_ID]";
             // Make the request, returning a streaming response
-            SnippetsClient.MethodServerStreamingResourcesStream response = snippetsClient.MethodServerStreamingResources(firstName, secondName, thirdName);
+            ts::SnippetsClient.MethodServerStreamingResourcesStream response = snippetsClient.MethodServerStreamingResources(firstName, secondName, thirdName);
 
             // Read streaming responses from server until complete
             // Note that C# 8 code can use await foreach
-            AsyncResponseStream<Response> responseStream = response.GetResponseStream();
+            AsyncResponseStream<ts::Response> responseStream = response.GetResponseStream();
             while (await responseStream.MoveNextAsync())
             {
-                Response responseItem = responseStream.Current;
+                ts::Response responseItem = responseStream.Current;
                 // Do something with streamed response
             }
             // The response stream has completed
@@ -1279,20 +1279,20 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodServerStreamingResources(SimpleResourceName, SimpleResourceName, SimpleResourceName, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
-            SimpleResourceName firstName = SimpleResourceName.FromItem("[ITEM_ID]");
-            SimpleResourceName secondName = SimpleResourceName.FromItem("[ITEM_ID]");
-            SimpleResourceName thirdName = SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName firstName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName secondName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
+            ts::SimpleResourceName thirdName = ts::SimpleResourceName.FromItem("[ITEM_ID]");
             // Make the request, returning a streaming response
-            SnippetsClient.MethodServerStreamingResourcesStream response = snippetsClient.MethodServerStreamingResources(firstName, secondName, thirdName);
+            ts::SnippetsClient.MethodServerStreamingResourcesStream response = snippetsClient.MethodServerStreamingResources(firstName, secondName, thirdName);
 
             // Read streaming responses from server until complete
             // Note that C# 8 code can use await foreach
-            AsyncResponseStream<Response> responseStream = response.GetResponseStream();
+            AsyncResponseStream<ts::Response> responseStream = response.GetResponseStream();
             while (await responseStream.MoveNextAsync())
             {
-                Response responseItem = responseStream.Current;
+                ts::Response responseItem = responseStream.Current;
                 // Do something with streamed response
             }
             // The response stream has completed
@@ -1304,9 +1304,9 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: MethodBidiStreaming(CallSettings, BidirectionalStreamingSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize streaming call, retrieving the stream object
-            SnippetsClient.MethodBidiStreamingStream response = snippetsClient.MethodBidiStreaming();
+            ts::SnippetsClient.MethodBidiStreamingStream response = snippetsClient.MethodBidiStreaming();
 
             // Sending requests and retrieving responses can be arbitrarily interleaved
             // Exact sequence will depend on client/server behavior
@@ -1315,10 +1315,10 @@ namespace Testing.Snippets.Snippets
             Task responseHandlerTask = Task.Run(async () =>
             {
                 // Note that C# 8 code can use await foreach
-                AsyncResponseStream<Response> responseStream = response.GetResponseStream();
+                AsyncResponseStream<ts::Response> responseStream = response.GetResponseStream();
                 while (await responseStream.MoveNextAsync())
                 {
-                    Response responseItem = responseStream.Current;
+                    ts::Response responseItem = responseStream.Current;
                     // Do something with streamed response
                 }
                 // The response stream has completed
@@ -1329,7 +1329,7 @@ namespace Testing.Snippets.Snippets
             while (!done)
             {
                 // Initialize a request
-                SignatureRequest request = new SignatureRequest
+                ts::SignatureRequest request = new ts::SignatureRequest
                 {
                     AString = "",
                     AnInt = 0,
@@ -1354,7 +1354,7 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: TaskMethod(Task, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
             ts::Task request = new ts::Task { };
             // Make the request
@@ -1368,7 +1368,7 @@ namespace Testing.Snippets.Snippets
             // Snippet: TaskMethodAsync(Task, CallSettings)
             // Additional: TaskMethodAsync(Task, CancellationToken)
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
             ts::Task request = new ts::Task { };
             // Make the request
@@ -1381,15 +1381,15 @@ namespace Testing.Snippets.Snippets
         {
             // Snippet: OneOfMethod(OneOfRequest, CallSettings)
             // Create client
-            SnippetsClient snippetsClient = SnippetsClient.Create();
+            ts::SnippetsClient snippetsClient = ts::SnippetsClient.Create();
             // Initialize request argument(s)
-            OneOfRequest request = new OneOfRequest
+            ts::OneOfRequest request = new ts::OneOfRequest
             {
                 NonOneOfString = "",
                 AString = "",
             };
             // Make the request
-            Response response = snippetsClient.OneOfMethod(request);
+            ts::Response response = snippetsClient.OneOfMethod(request);
             // End snippet
         }
 
@@ -1399,15 +1399,15 @@ namespace Testing.Snippets.Snippets
             // Snippet: OneOfMethodAsync(OneOfRequest, CallSettings)
             // Additional: OneOfMethodAsync(OneOfRequest, CancellationToken)
             // Create client
-            SnippetsClient snippetsClient = await SnippetsClient.CreateAsync();
+            ts::SnippetsClient snippetsClient = await ts::SnippetsClient.CreateAsync();
             // Initialize request argument(s)
-            OneOfRequest request = new OneOfRequest
+            ts::OneOfRequest request = new ts::OneOfRequest
             {
                 NonOneOfString = "",
                 AString = "",
             };
             // Make the request
-            Response response = await snippetsClient.OneOfMethodAsync(request);
+            ts::Response response = await snippetsClient.OneOfMethodAsync(request);
             // End snippet
         }
     }

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.GeneratedSnippets/VoidReturnClient.VoidMethodAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.GeneratedSnippets/VoidReturnClient.VoidMethodAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.VoidReturn.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_VoidReturn_VoidMethod_async_flattened]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.GeneratedSnippets/VoidReturnClient.VoidMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.GeneratedSnippets/VoidReturnClient.VoidMethodRequestObjectAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.VoidReturn.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_VoidReturn_VoidMethod_async]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.GeneratedSnippets/VoidReturnClient.VoidMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.GeneratedSnippets/VoidReturnClient.VoidMethodRequestObjectSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.VoidReturn.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_VoidReturn_VoidMethod_sync]
     using Testing.VoidReturn;

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.GeneratedSnippets/VoidReturnClient.VoidMethodResourceNamesAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.GeneratedSnippets/VoidReturnClient.VoidMethodResourceNamesAsyncSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.VoidReturn.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_VoidReturn_VoidMethod_async_flattened_resourceNames]
     using System.Threading.Tasks;

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.GeneratedSnippets/VoidReturnClient.VoidMethodResourceNamesSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.GeneratedSnippets/VoidReturnClient.VoidMethodResourceNamesSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.VoidReturn.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_VoidReturn_VoidMethod_sync_flattened_resourceNames]
     using Testing.VoidReturn;

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.GeneratedSnippets/VoidReturnClient.VoidMethodSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.GeneratedSnippets/VoidReturnClient.VoidMethodSnippet.g.cs
@@ -14,7 +14,7 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.VoidReturn.Snippets
+namespace GoogleCSharpSnippets
 {
     // [START unknown_generated_VoidReturn_VoidMethod_sync_flattened]
     using Testing.VoidReturn;

--- a/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.Snippets/VoidReturnClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/VoidReturn/Testing.VoidReturn.Snippets/VoidReturnClientSnippets.g.cs
@@ -14,9 +14,10 @@
 
 // Generated code. DO NOT EDIT!
 
-namespace Testing.VoidReturn.Snippets
+namespace GoogleCSharpSnippets
 {
     using System.Threading.Tasks;
+    using Testing.VoidReturn;
 
     /// <summary>Generated snippets.</summary>
     public sealed class AllGeneratedVoidReturnClientSnippets

--- a/Google.Api.Generator.Utils/SourceFileContext.cs
+++ b/Google.Api.Generator.Utils/SourceFileContext.cs
@@ -118,12 +118,10 @@ namespace Google.Api.Generator.Utils
                 IReadOnlyDictionary<string, string> wellKnownNamespaceAliases,
                 IReadOnlyCollection<Regex> avoidAliasingNamespaceRegex,
                 IReadOnlyCollection<string> forcedAliases,
-                IEnumerable<Typ> packageTyps,
-                bool maySkipOwnNamespaceImport) : base(clock) =>
-                (_wellKnownNamespaceAliases, _avoidAliasingNamespaceRegex, _forcedAliases, _packageTyps, _maySkipOwnNamespaceImport) =
-                (wellKnownNamespaceAliases, avoidAliasingNamespaceRegex, forcedAliases, packageTyps, maySkipOwnNamespaceImport);
+                IEnumerable<Typ> packageTyps) : base(clock) =>
+                (_wellKnownNamespaceAliases, _avoidAliasingNamespaceRegex, _forcedAliases, _packageTyps) =
+                (wellKnownNamespaceAliases, avoidAliasingNamespaceRegex, forcedAliases, packageTyps);
 
-            private readonly bool _maySkipOwnNamespaceImport;
             private readonly IReadOnlyDictionary<string, string> _wellKnownNamespaceAliases;
             private readonly IReadOnlyCollection<Regex> _avoidAliasingNamespaceRegex;
             private readonly IReadOnlyCollection<string> _forcedAliases;
@@ -163,7 +161,7 @@ namespace Google.Api.Generator.Utils
                 // that either.
                 if (!_seenNamespaces.TryGetValue(typ.Namespace, out bool maySkipImport) || maySkipImport)
                 {
-                    _seenNamespaces[typ.Namespace] = _maySkipOwnNamespaceImport && IsParentOrSameNamespace(typ.Namespace, Namespace);
+                    _seenNamespaces[typ.Namespace] = IsParentOrSameNamespace(typ.Namespace, Namespace);
                 }
                 // Track the type as seen.
                 _seenTypes.Add(typ);
@@ -514,9 +512,8 @@ namespace Google.Api.Generator.Utils
             IReadOnlyCollection<Regex> avoidAliasingNamespaceRegex,
             IReadOnlyCollection<string> forcedAliases,
             // We need these here to take into account in collisions.
-            IEnumerable<Typ> packageTyps,
-            bool maySkipOwnNamespaceImport) =>
-            new Unaliased(clock, wellKnownNamespaceAliases, avoidAliasingNamespaceRegex, forcedAliases, packageTyps, maySkipOwnNamespaceImport);
+            IEnumerable<Typ> packageTyps) =>
+            new Unaliased(clock, wellKnownNamespaceAliases, avoidAliasingNamespaceRegex, forcedAliases, packageTyps);
 
         public static SourceFileContext CreateFullyQualified(IClock clock) => new FullyQualified(clock);
 

--- a/Google.Api.Generator/CodeGenerator.cs
+++ b/Google.Api.Generator/CodeGenerator.cs
@@ -267,7 +267,7 @@ namespace Google.Api.Generator
                     // TODO: Consider removing this once we have integrated the snippet-per-file snippets
                     // with docs generation.
                     var serviceSnippetsCtx = SourceFileContext.CreateUnaliased(
-                        clock, WellknownNamespaceAliases, AvoidAliasingNamespaceRegex, forcedAliases, packageTyps, maySkipOwnNamespaceImport: true);
+                        clock, WellknownNamespaceAliases, AvoidAliasingNamespaceRegex, forcedAliases, packageTyps);
                     var serviceSnippetsCode = SnippetCodeGenerator.Generate(serviceSnippetsCtx, serviceDetails);
                     var serviceSnippetsFilename = $"{serviceSnippetsPathPrefix}{serviceDetails.ClientAbstractTyp.Name}Snippets.g.cs";
                     yield return new ResultFile(serviceSnippetsFilename, serviceSnippetsCode);
@@ -276,7 +276,7 @@ namespace Google.Api.Generator
                     foreach (var snippetGenerator in SnippetCodeGenerator.SnippetsGenerators(serviceDetails))
                     {
                         var snippetCtx = SourceFileContext.CreateUnaliased(
-                            clock, WellknownNamespaceAliases, AvoidAliasingNamespaceRegex, forcedAliases, packageTyps, maySkipOwnNamespaceImport: false);
+                            clock, WellknownNamespaceAliases, AvoidAliasingNamespaceRegex, forcedAliases, packageTyps);
                         var (snippetCode, snippetMetadata) = snippetGenerator.Generate(snippetCtx);
                         snippetMetadata.File = $"{serviceDetails.ClientAbstractTyp.Name}.{snippetGenerator.SnippetMethodName}Snippet.g.cs";
                         var snippetFile = $"{snippetsPathPrefix}{snippetMetadata.File}";

--- a/Google.Api.Generator/Generation/ServiceDetails.cs
+++ b/Google.Api.Generator/Generation/ServiceDetails.cs
@@ -50,7 +50,10 @@ namespace Google.Api.Generator.Generation
             ProtoPackage = desc.File.Package;
             PackageVersion = ProtoPackage.Split('.').FirstOrDefault(part => ApiVersionPattern.IsMatch(part));
             DocLines = desc.Declaration.DocLines().ToList();
-            SnippetsNamespace = $"{ns}.Snippets";
+            // For snippets, we use a namespace unrelated to the library as that's likely to be similar to
+            // user code. Imports are cleaner, with less type name clashes, etc. which in turn means less
+            // namespace aliasing.
+            SnippetsNamespace = "GoogleCSharpSnippets";
             // Must come early; used by `MethodDetails.Create()`
             MethodGrpcConfigsByName = grpcServiceConfig?.MethodConfig
                 .SelectMany(conf => conf.Name.Select(name => (name, conf)))


### PR DESCRIPTION
This is closer that how user code would look like in that the their namespace is unlikely to resemble those of the libraries they are using. Snippets will requireless namespace aliasing which will make them cleaner.