### PR TITLE
feat: Generate Raw and DateTimeOffset properties for google-datetime properties

### DIFF
--- a/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.ManufacturerCenter.v1/Google.Apis.ManufacturerCenter.v1.cs
+++ b/Google.Api.Generator.Rest.Tests/GoldenTestData/Google.Apis.ManufacturerCenter.v1/Google.Apis.ManufacturerCenter.v1.cs
@@ -1119,9 +1119,42 @@ namespace Google.Apis.ManufacturerCenter.v1.Data
         [Newtonsoft.Json.JsonPropertyAttribute("severity")]
         public virtual string Severity { get; set; }
 
+        private string _timestampRaw;
+
+        private object _timestamp;
+
         /// <summary>The timestamp when this issue appeared.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("timestamp")]
-        public virtual object Timestamp { get; set; }
+        public virtual string TimestampRaw
+        {
+            get => _timestampRaw;
+            set
+            {
+                _timestamp = Google.Apis.Util.Utilities.DeserializeForGoogleFormat(value);
+                _timestampRaw = value;
+            }
+        }
+
+        /// <summary><seealso cref="object"/> representation of <see cref="TimestampRaw"/>.</summary>
+        [Newtonsoft.Json.JsonIgnoreAttribute]
+        [System.ObsoleteAttribute("This property is obsolete and may behave unexpectedly; please use TimestampDateTimeOffset instead.")]
+        public virtual object Timestamp
+        {
+            get => _timestamp;
+            set
+            {
+                _timestampRaw = Google.Apis.Util.Utilities.SerializeForGoogleFormat(value);
+                _timestamp = value;
+            }
+        }
+
+        /// <summary><seealso cref="System.DateTimeOffset"/> representation of <see cref="TimestampRaw"/>.</summary>
+        [Newtonsoft.Json.JsonIgnoreAttribute]
+        public virtual System.DateTimeOffset? TimestampDateTimeOffset
+        {
+            get => Google.Apis.Util.Utilities.GetDateTimeOffsetFromString(TimestampRaw);
+            set => TimestampRaw = Google.Apis.Util.Utilities.GetStringFromDateTimeOffset(value);
+        }
 
         /// <summary>Short title describing the nature of the issue.</summary>
         [Newtonsoft.Json.JsonPropertyAttribute("title")]

--- a/Google.Api.Generator.Rest/Google.Api.Generator.Rest.csproj
+++ b/Google.Api.Generator.Rest/Google.Api.Generator.Rest.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Apis.Discovery.v1" Version="1.60.0" />
-    <PackageReference Include="Google.Apis" Version="1.61.0-beta01" />
+    <PackageReference Include="Google.Apis" Version="1.61.0-beta02" />
     <ProjectReference Include="..\Google.Api.Generator.Utils\Google.Api.Generator.Utils.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
We keep separate string and object representations for the sake of compatibility.