### PR TITLE
chore: Remove unnecessary dependencies.

### DIFF
--- a/Google.Api.Generator/CodeGenerator.cs
+++ b/Google.Api.Generator/CodeGenerator.cs
@@ -71,8 +71,6 @@ namespace Google.Api.Generator
             { typeof(Google.Protobuf.WellKnownTypes.Any).Namespace, "wkt" },
             { typeof(Google.LongRunning.Operation).Namespace, "lro" },
             { typeof(Google.Protobuf.ByteString).Namespace, "proto" },
-            { typeof(Moq.Mock).Namespace, "moq" },
-            { typeof(Xunit.Assert).Namespace, "xunit" },
         };
 
         /// <summary>

--- a/Google.Api.Generator/Google.Api.Generator.csproj
+++ b/Google.Api.Generator/Google.Api.Generator.csproj
@@ -15,10 +15,8 @@
     <PackageReference Include="Google.LongRunning" Version="3.0.0" />
     <PackageReference Include="Google.Protobuf" Version="3.23.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
-    <PackageReference Include="Moq" Version="4.20.2" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="YamlDotNet" Version="13.1.1" />
   </ItemGroup>
 


### PR DESCRIPTION
These are left-over from when we generated unit tests.