### PR TITLE
chore: Remove legacy features configuration in REST generator configuration

### DIFF
--- a/Google.Api.Generator.Rest.Tests/TestResources.cs
+++ b/Google.Api.Generator.Rest.Tests/TestResources.cs
@@ -51,8 +51,6 @@ namespace Google.Api.Generator.Rest.Tests
             {
                 ReleaseVersion = "1.54.0",
                 CurrentSupportVersion = "1.54.0",
-                Net40SupportVersion = "1.10.0",
-                PclSupportVersion = "1.25.0",
                 CloudPackageMap = new Dictionary<string, string>
                 {
                     { "Google.Apis.Storage.v1", "Google.Cloud.Storage.V1" },

--- a/Google.Api.Generator.Rest/Models/Features.cs
+++ b/Google.Api.Generator.Rest/Models/Features.cs
@@ -30,16 +30,6 @@ namespace Google.Api.Generator.Rest.Models
         public string CurrentSupportVersion { get; set; }
 
         /// <summary>
-        /// Version of PCL support library.
-        /// </summary>
-        public string PclSupportVersion { get; set; }
-
-        /// <summary>
-        /// Version of net40 support library.
-        /// </summary>
-        public string Net40SupportVersion { get; set; }
-
-        /// <summary>
         /// Map from REST library to GAPIC library to inform uses of the preferred package.
         /// </summary>
         public IReadOnlyDictionary<string, string> CloudPackageMap { get; set; } =


### PR DESCRIPTION
These haven't been used since #465 removed support for net40 and PCLs.