### PR TITLE
chore: Remove redundant package reference

### DIFF
--- a/Google.Api.Generator.Rest/Google.Api.Generator.Rest.csproj
+++ b/Google.Api.Generator.Rest/Google.Api.Generator.Rest.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Apis.Discovery.v1" Version="1.62.0" />
-    <PackageReference Include="Google.Apis" Version="1.62.0" />
     <ProjectReference Include="..\Google.Api.Generator.Utils\Google.Api.Generator.Utils.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
I suspect this was introduced at some point where it wasn't the default for the Discovery dependency - but it makes updating that dependency harder.