### PR TITLE
chore: Update Google.Api.CommonProtos to version 2.11.0

### DIFF
--- a/Google.Api.Generator/Generation/PackageApiMetadataGenerator.cs
+++ b/Google.Api.Generator/Generation/PackageApiMetadataGenerator.cs
@@ -16,7 +16,6 @@ using Google.Api.Gax.Grpc;
 using Google.Api.Generator.ProtoUtils;
 using Google.Api.Generator.Utils;
 using Google.Api.Generator.Utils.Roslyn;
-using Google.Cloud.Iam.V1;
 using Google.Cloud.Location;
 using Google.LongRunning;
 using Google.Protobuf;
@@ -27,6 +26,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using iam = Google.Cloud.Iam.V1;
 using static Google.Api.Generator.Utils.Roslyn.Modifier;
 using static Google.Api.Generator.Utils.Roslyn.RoslynBuilder;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -42,7 +42,7 @@ namespace Google.Api.Generator.Generation
         private static readonly Dictionary<string, FileDescriptor[]> MixinToFileDescriptors = new Dictionary<string, FileDescriptor[]>
         {
             { Operations.Descriptor.FullName, new[] { OperationsReflection.Descriptor } },
-            { IAMPolicy.Descriptor.FullName, new[] { PolicyReflection.Descriptor, IamPolicyReflection.Descriptor, OptionsReflection.Descriptor } },
+            { iam::IAMPolicy.Descriptor.FullName, new[] { iam::PolicyReflection.Descriptor, iam::IamPolicyReflection.Descriptor, iam::OptionsReflection.Descriptor } },
             { Locations.Descriptor.FullName, new[] { LocationsReflection.Descriptor } }
         };
 

--- a/Google.Api.Generator/Google.Api.Generator.csproj
+++ b/Google.Api.Generator/Google.Api.Generator.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Google.Api.CommonProtos" Version="2.10.0" />
+    <PackageReference Include="Google.Api.CommonProtos" Version="2.11.0" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="4.4.0" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="3.0.0" />
     <PackageReference Include="Google.Cloud.Location" Version="2.0.0" />


### PR DESCRIPTION
This requires a tweak to the PackageApiMetadataGenerator, as an unqualified reference to PolicyReflection now resolves to Google.Api.PolicyReflection instead of Google.Cloud.Iam.V1.PolicyReflection. This won't affect users - it's only because our code is in a *namespace* starting with Google.Api, which takes priority over using directives.