### PR TITLE
chore: Update Discovery reference to 1.64.0

### DIFF
--- a/Google.Api.Generator.Rest/Google.Api.Generator.Rest.csproj
+++ b/Google.Api.Generator.Rest/Google.Api.Generator.Rest.csproj
@@ -6,8 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Apis.Discovery.v1" Version="1.63.0" />
-    <PackageReference Include="Google.Apis" Version="1.64.0-alpha01" />
+    <PackageReference Include="Google.Apis.Discovery.v1" Version="1.64.0" />
     <ProjectReference Include="..\Google.Api.Generator.Utils\Google.Api.Generator.Utils.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
At this point, we don't need the Google.Apis 1.64.0-alpha01 reference any more, as we get 1.64.0 transitively.