### PR TITLE
chore: Update Microsoft.CodeAnalysis.CSharp and System.Collections.Immutable

### DIFF
--- a/Google.Api.Generator.Utils/Formatting/WhitespaceFormatter.cs
+++ b/Google.Api.Generator.Utils/Formatting/WhitespaceFormatter.cs
@@ -358,7 +358,7 @@ namespace Google.Api.Generator.Utils.Formatting
                 {
                     var preTrivia = s.GetLeadingTrivia().SelectMany(FormatInCodeComment).Append(_indentTrivia);
                     var postTrivia = s.GetTrailingTrivia().SelectMany(FormatInCodeComment).Prepend(NewLine);
-                    return Visit(s).WithLeadingTrivia(preTrivia).WithTrailingTrivia(postTrivia);
+                    return (StatementSyntax) Visit(s).WithLeadingTrivia(preTrivia).WithTrailingTrivia(postTrivia);
                 })));
             }
             node = node.WithOpenBraceToken(node.OpenBraceToken.WithLeadingTrivia(NewLine, _indentTrivia).WithTrailingNewLine());
@@ -492,7 +492,7 @@ namespace Google.Api.Generator.Utils.Formatting
             if (node.Span.Length < 20)
             {
                 // Crude <20 to only make short initializer expressions stay on a single line.
-                node = node.WithExpressions(SeparatedList<SyntaxNode>(nodeExprs
+                node = node.WithExpressions(SeparatedList<ExpressionSyntax>(nodeExprs
                     .SelectMany(x => new SyntaxNodeOrToken[] { x.WithLeadingSpace(), Token(SyntaxKind.CommaToken) }).SkipLast(isComplex ? 1 : 0)));
                 node = node.WithOpenBraceToken(node.OpenBraceToken.WithLeadingSpace());
                 node = node.WithCloseBraceToken(node.CloseBraceToken.WithLeadingSpace());
@@ -513,7 +513,7 @@ namespace Google.Api.Generator.Utils.Formatting
                         items = items.SkipLast(2).Concat(items
                             .TakeLast(2).Take(1).Select(x => x.WithTrailingTrivia(NewLine))).ToList();
                     }
-                    node = node.WithExpressions(SeparatedList<SyntaxNode>(items));
+                    node = node.WithExpressions(SeparatedList<ExpressionSyntax>(items));
                 }
                 node = node.WithOpenBraceToken(node.OpenBraceToken.WithLeadingTrivia(NewLine, _indentTrivia).WithTrailingNewLine());
                 node = node.WithCloseBraceToken(node.CloseBraceToken.WithLeadingTrivia(_indentTrivia));

--- a/Google.Api.Generator.Utils/Google.Api.Generator.Utils.csproj
+++ b/Google.Api.Generator.Utils/Google.Api.Generator.Utils.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
     <PackageReference Include="Google.Api.Gax" Version="4.4.0" />
   </ItemGroup>
 </Project>

--- a/Google.Api.Generator/Google.Api.Generator.csproj
+++ b/Google.Api.Generator/Google.Api.Generator.csproj
@@ -14,8 +14,7 @@
     <PackageReference Include="Google.Cloud.Location" Version="2.0.0" />
     <PackageReference Include="Google.LongRunning" Version="3.0.0" />
     <PackageReference Include="Google.Protobuf" Version="3.23.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="YamlDotNet" Version="13.7.1" />
   </ItemGroup>


### PR DESCRIPTION
- We don't need Microsoft.CodeAnalysis.CSharp in both Google.Api.Generator and Google.Api.Generator.Utils
- Now that .NET 8 is released, it's fine to update to 8.0 libraries for generation purposes (no customer dependencies)
- An implicit conversion in SyntaxList was removed in Roslyn, requiring updates in WhitespaceFormatter