### PR TITLE
chore: Remove unnecessary direct dependencies

### DIFF
--- a/Google.Api.Generator/Google.Api.Generator.csproj
+++ b/Google.Api.Generator/Google.Api.Generator.csproj
@@ -8,12 +8,10 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Google.Api.CommonProtos" Version="2.12.0" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="4.4.0" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="3.0.0" />
     <PackageReference Include="Google.Cloud.Location" Version="2.0.0" />
     <PackageReference Include="Google.LongRunning" Version="3.0.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.23.0" />
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="YamlDotNet" Version="13.7.1" />


### PR DESCRIPTION
Both Google.Protobuf and Google.Api.CommonProtos are available indirectly from Google.Api.Gax.Grpc. Removing them reduces churn from updates, and avoids potential clashes where the direct dependency is earlier than an indirect one.

We can reintroduce direct dependencies when we need to rely on something that isn't yet part of Google.Api.Gax.Grpc.