### PR TITLE
feat: Generate calls to GetEffectiveSettings in the client builder

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1/BasicClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1/BasicClient.g.cs
@@ -104,14 +104,14 @@ namespace Testing.Basic.V1
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return BasicClient.Create(callInvoker, Settings, Logger);
+            return BasicClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         private async stt::Task<BasicClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return BasicClient.Create(callInvoker, Settings, Logger);
+            return BasicClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated/DeprecatedClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated/DeprecatedClient.g.cs
@@ -143,14 +143,14 @@ namespace Testing.Deprecated
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return DeprecatedClient.Create(callInvoker, Settings, Logger);
+            return DeprecatedClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         private async stt::Task<DeprecatedClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return DeprecatedClient.Create(callInvoker, Settings, Logger);
+            return DeprecatedClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords/KeywordsClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords/KeywordsClient.g.cs
@@ -117,14 +117,14 @@ namespace Testing.Keywords
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return KeywordsClient.Create(callInvoker, Settings, Logger);
+            return KeywordsClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         private async stt::Task<KeywordsClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return KeywordsClient.Create(callInvoker, Settings, Logger);
+            return KeywordsClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>

--- a/Google.Api.Generator.Tests/ProtoTests/MethodSignatures/Testing.MethodSignatures/MethodSignaturesClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/MethodSignatures/Testing.MethodSignatures/MethodSignaturesClient.g.cs
@@ -210,14 +210,14 @@ namespace Testing.MethodSignatures
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return MethodSignaturesClient.Create(callInvoker, Settings, Logger);
+            return MethodSignaturesClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         private async stt::Task<MethodSignaturesClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return MethodSignaturesClient.Create(callInvoker, Settings, Logger);
+            return MethodSignaturesClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>

--- a/Google.Api.Generator.Tests/ProtoTests/Mixins/Testing.Mixins/MixinServiceClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Mixins/Testing.Mixins/MixinServiceClient.g.cs
@@ -122,14 +122,14 @@ namespace Testing.Mixins
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return MixinServiceClient.Create(callInvoker, Settings, Logger);
+            return MixinServiceClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         private async stt::Task<MixinServiceClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return MixinServiceClient.Create(callInvoker, Settings, Logger);
+            return MixinServiceClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/RenamedServiceNameClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/RenamedServiceNameClient.g.cs
@@ -105,14 +105,14 @@ namespace Testing.PublishingSettings
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return RenamedServiceNameClient.Create(callInvoker, Settings, Logger);
+            return RenamedServiceNameClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         private async stt::Task<RenamedServiceNameClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return RenamedServiceNameClient.Create(callInvoker, Settings, Logger);
+            return RenamedServiceNameClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithHandwrittenSignaturesClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithHandwrittenSignaturesClient.g.cs
@@ -108,14 +108,14 @@ namespace Testing.PublishingSettings
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return ServiceWithHandwrittenSignaturesClient.Create(callInvoker, Settings, Logger);
+            return ServiceWithHandwrittenSignaturesClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         private async stt::Task<ServiceWithHandwrittenSignaturesClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return ServiceWithHandwrittenSignaturesClient.Create(callInvoker, Settings, Logger);
+            return ServiceWithHandwrittenSignaturesClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithResourcesClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithResourcesClient.g.cs
@@ -105,14 +105,14 @@ namespace Testing.PublishingSettings
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return ServiceWithResourcesClient.Create(callInvoker, Settings, Logger);
+            return ServiceWithResourcesClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         private async stt::Task<ServiceWithResourcesClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return ServiceWithResourcesClient.Create(callInvoker, Settings, Logger);
+            return ServiceWithResourcesClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames/ResourceNamesClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames/ResourceNamesClient.g.cs
@@ -176,14 +176,14 @@ namespace Testing.ResourceNames
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return ResourceNamesClient.Create(callInvoker, Settings, Logger);
+            return ResourceNamesClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         private async stt::Task<ResourceNamesClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return ResourceNamesClient.Create(callInvoker, Settings, Logger);
+            return ResourceNamesClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/ComplianceClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/ComplianceClient.g.cs
@@ -236,14 +236,14 @@ namespace Google.Showcase.V1Beta1
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return ComplianceClient.Create(callInvoker, Settings, Logger);
+            return ComplianceClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         private async stt::Task<ComplianceClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return ComplianceClient.Create(callInvoker, Settings, Logger);
+            return ComplianceClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/EchoClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/EchoClient.g.cs
@@ -260,14 +260,14 @@ namespace Google.Showcase.V1Beta1
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return EchoClient.Create(callInvoker, Settings, Logger);
+            return EchoClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         private async stt::Task<EchoClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return EchoClient.Create(callInvoker, Settings, Logger);
+            return EchoClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/IdentityClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/IdentityClient.g.cs
@@ -172,14 +172,14 @@ namespace Google.Showcase.V1Beta1
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return IdentityClient.Create(callInvoker, Settings, Logger);
+            return IdentityClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         private async stt::Task<IdentityClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return IdentityClient.Create(callInvoker, Settings, Logger);
+            return IdentityClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/MessagingClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/MessagingClient.g.cs
@@ -325,14 +325,14 @@ namespace Google.Showcase.V1Beta1
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return MessagingClient.Create(callInvoker, Settings, Logger);
+            return MessagingClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         private async stt::Task<MessagingClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return MessagingClient.Create(callInvoker, Settings, Logger);
+            return MessagingClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/SequenceServiceClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/SequenceServiceClient.g.cs
@@ -146,14 +146,14 @@ namespace Google.Showcase.V1Beta1
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return SequenceServiceClient.Create(callInvoker, Settings, Logger);
+            return SequenceServiceClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         private async stt::Task<SequenceServiceClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return SequenceServiceClient.Create(callInvoker, Settings, Logger);
+            return SequenceServiceClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/TestingClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/TestingClient.g.cs
@@ -211,14 +211,14 @@ namespace Google.Showcase.V1Beta1
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return TestingClient.Create(callInvoker, Settings, Logger);
+            return TestingClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         private async stt::Task<TestingClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return TestingClient.Create(callInvoker, Settings, Logger);
+            return TestingClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>

--- a/Google.Api.Generator/Generation/ServiceBuilderCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceBuilderCodeGenerator.cs
@@ -103,11 +103,13 @@ namespace Google.Api.Generator.Generation
         {
             var callInvoker = Local(_ctx.Type<CallInvoker>(), "callInvoker");
             var logger = Property(Public, _ctx.Type<ILogger>(), nameof(ClientBuilderBase<string>.Logger));
+            var settingsClone = IdentifierName("Settings").Call("Clone", conditional: true)();
+            var effectiveSettings = This.Call("GetEffectiveSettings")(settingsClone);
             return Method(Private, _ctx.Type(_svc.ClientAbstractTyp), "BuildImpl")()
                 .WithBody(
                     This.Call("Validate")(),
                     callInvoker.WithInitializer(This.Call("CreateCallInvoker")()),
-                    Return(_ctx.Type(_svc.ClientAbstractTyp).Call("Create")(callInvoker, Settings(), logger)));
+                    Return(_ctx.Type(_svc.ClientAbstractTyp).Call("Create")(callInvoker, effectiveSettings, logger)));
         }
 
         private MethodDeclarationSyntax BuildAsyncImpl()
@@ -115,11 +117,13 @@ namespace Google.Api.Generator.Generation
             var cancellationToken = Parameter(_ctx.Type<CancellationToken>(), "cancellationToken");
             var callInvoker = Local(_ctx.Type<CallInvoker>(), "callInvoker");
             var logger = Property(Public, _ctx.Type<ILogger>(), nameof(ClientBuilderBase<string>.Logger));
+            var settingsClone = IdentifierName("Settings").Call("Clone", conditional: true)();
+            var effectiveSettings = This.Call("GetEffectiveSettings")(settingsClone);
             return Method(Private | Async, _ctx.Type(Typ.Generic(typeof(Task<>), _svc.ClientAbstractTyp)), "BuildAsyncImpl")(cancellationToken)
                 .WithBody(
                     This.Call("Validate")(),
                     callInvoker.WithInitializer(Await(This.Call("CreateCallInvokerAsync")(cancellationToken).ConfigureAwait())),
-                    Return(_ctx.Type(_svc.ClientAbstractTyp).Call("Create")(callInvoker, Settings(), logger)));
+                    Return(_ctx.Type(_svc.ClientAbstractTyp).Call("Create")(callInvoker, effectiveSettings, logger)));
         }
 
         private MethodDeclarationSyntax GetChannelPool() =>


### PR DESCRIPTION
This is part of API key support. It's not expected to build yet, as it'll need a new version of GAX (which hasn't been published yet).