### PR TITLE
feat: Implement api_version support in the generator

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1/BasicClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1/BasicClient.g.cs
@@ -245,7 +245,11 @@ namespace Testing.Basic.V1
         {
             GrpcClient = grpcClient;
             BasicSettings effectiveSettings = settings ?? BasicSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(new gaxgrpc::ClientHelper.Options
+            {
+                Settings = effectiveSettings,
+                Logger = logger,
+            });
             _callAMethod = clientHelper.BuildApiCall<Request, Response>("AMethod", grpcClient.AMethodAsync, grpcClient.AMethod, effectiveSettings.AMethodSettings);
             Modify_ApiCall(ref _callAMethod);
             Modify_AMethodApiCall(ref _callAMethod);

--- a/Google.Api.Generator.Tests/ProtoTests/BasicServerStreaming/Testing.BasicServerStreaming/BasicServerStreamingClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/BasicServerStreaming/Testing.BasicServerStreaming/BasicServerStreamingClient.g.cs
@@ -56,7 +56,11 @@ namespace Testing.BasicServerStreaming
         public BasicServerStreamingClientImpl(BasicServerStreaming.BasicServerStreamingClient grpcClient, mel::ILogger logger)
         {
             BasicServerStreamingSettings effectiveSettings = null;
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(new gaxgrpc::ClientHelper.Options
+            {
+                Settings = effectiveSettings,
+                Logger = logger,
+            });
             // TEST_START
             _callMethodServer = clientHelper.BuildApiCall<Request, Response>("MethodServer", grpcClient.MethodServer, effectiveSettings.MethodServerSettings);
             // TEST_END

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated/DeprecatedClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated/DeprecatedClient.g.cs
@@ -421,7 +421,11 @@ namespace Testing.Deprecated
         {
             GrpcClient = grpcClient;
             DeprecatedSettings effectiveSettings = settings ?? DeprecatedSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(new gaxgrpc::ClientHelper.Options
+            {
+                Settings = effectiveSettings,
+                Logger = logger,
+            });
             _callDeprecatedFieldMethod = clientHelper.BuildApiCall<DeprecatedFieldRequest, Response>("DeprecatedFieldMethod", grpcClient.DeprecatedFieldMethodAsync, grpcClient.DeprecatedFieldMethod, effectiveSettings.DeprecatedFieldMethodSettings);
             Modify_ApiCall(ref _callDeprecatedFieldMethod);
             Modify_DeprecatedFieldMethodApiCall(ref _callDeprecatedFieldMethod);

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated/DeprecatedServiceClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated/DeprecatedServiceClient.g.cs
@@ -287,7 +287,11 @@ namespace Testing.Deprecated
         {
             GrpcClient = grpcClient;
             DeprecatedServiceSettings effectiveSettings = settings ?? DeprecatedServiceSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(new gaxgrpc::ClientHelper.Options
+            {
+                Settings = effectiveSettings,
+                Logger = logger,
+            });
             _callNonDeprecatedMethod = clientHelper.BuildApiCall<Request, Response>("NonDeprecatedMethod", grpcClient.NonDeprecatedMethodAsync, grpcClient.NonDeprecatedMethod, effectiveSettings.NonDeprecatedMethodSettings);
             Modify_ApiCall(ref _callNonDeprecatedMethod);
             Modify_NonDeprecatedMethodApiCall(ref _callNonDeprecatedMethod);

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords/KeywordsClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords/KeywordsClient.g.cs
@@ -483,7 +483,11 @@ namespace Testing.Keywords
         {
             GrpcClient = grpcClient;
             KeywordsSettings effectiveSettings = settings ?? KeywordsSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(new gaxgrpc::ClientHelper.Options
+            {
+                Settings = effectiveSettings,
+                Logger = logger,
+            });
             _callMethod1 = clientHelper.BuildApiCall<Request, Response>("Method1", grpcClient.Method1Async, grpcClient.Method1, effectiveSettings.Method1Settings);
             Modify_ApiCall(ref _callMethod1);
             Modify_Method1ApiCall(ref _callMethod1);

--- a/Google.Api.Generator.Tests/ProtoTests/MethodSignatures/Testing.MethodSignatures/MethodSignaturesClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/MethodSignatures/Testing.MethodSignatures/MethodSignaturesClient.g.cs
@@ -1371,7 +1371,11 @@ namespace Testing.MethodSignatures
         {
             GrpcClient = grpcClient;
             MethodSignaturesSettings effectiveSettings = settings ?? MethodSignaturesSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(new gaxgrpc::ClientHelper.Options
+            {
+                Settings = effectiveSettings,
+                Logger = logger,
+            });
             _callSimpleMethod = clientHelper.BuildApiCall<SimpleRequest, Response>("SimpleMethod", grpcClient.SimpleMethodAsync, grpcClient.SimpleMethod, effectiveSettings.SimpleMethodSettings);
             Modify_ApiCall(ref _callSimpleMethod);
             Modify_SimpleMethodApiCall(ref _callSimpleMethod);

--- a/Google.Api.Generator.Tests/ProtoTests/Mixins/Testing.Mixins/MixinServiceClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Mixins/Testing.Mixins/MixinServiceClient.g.cs
@@ -268,7 +268,11 @@ namespace Testing.Mixins
         {
             GrpcClient = grpcClient;
             MixinServiceSettings effectiveSettings = settings ?? MixinServiceSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(new gaxgrpc::ClientHelper.Options
+            {
+                Settings = effectiveSettings,
+                Logger = logger,
+            });
             LocationsClient = new gcl::LocationsClientImpl(grpcClient.CreateLocationsClient(), effectiveSettings.LocationsSettings, logger);
             IAMPolicyClient = new gciv::IAMPolicyClientImpl(grpcClient.CreateIAMPolicyClient(), effectiveSettings.IAMPolicySettings, logger);
             _callMethod = clientHelper.BuildApiCall<Request, Response>("Method", grpcClient.MethodAsync, grpcClient.Method, effectiveSettings.MethodSettings);

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/PublishingSettings.proto
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/PublishingSettings.proto
@@ -59,6 +59,13 @@ service ServiceWithMethodSettings {
   rpc PaginatedAutoPopulated(PaginatedRequest) returns (PaginatedResponse);
 }
 
+// This is a service using the api_version extension.
+service ServiceWithApiVersion {
+  option (google.api.api_version) = "v1_20240313";
+  // Test summary text for AMethod
+  rpc AMethod(Request) returns(Response);
+}
+
 message Request {
   string string_1 = 1;
   string string_2 = 2;

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/PublishingSettingsFakes.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/PublishingSettingsFakes.cs
@@ -109,6 +109,22 @@ public partial class ServiceWithMethodSettings
     }
 }
 
+public class ServiceWithApiVersion
+{
+    public static ServiceDescriptor Descriptor => null;
+
+    // Fake gRPC client
+    public class ServiceWithApiVersionClient
+    {
+        public ServiceWithApiVersionClient() { }
+        public ServiceWithApiVersionClient(CallInvoker callInvoker) { }
+        public virtual AsyncUnaryCall<Response> AMethodAsync(Request request, CallOptions options) => throw new NotImplementedException();
+        public virtual Response AMethod(Request request, CallOptions options) => throw new NotImplementedException();
+        public virtual AsyncUnaryCall<Empty> VoidMethodAsync(Request request, CallOptions options) => throw new NotImplementedException();
+        public virtual Empty VoidMethod(Request request, CallOptions options) => throw new NotImplementedException();
+    }
+}
+
 public partial class Request : ProtoMsgFake<Request>
 {
     public string String1 { get; set; }

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithApiVersionClient.AMethodRequestObjectAsyncSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithApiVersionClient.AMethodRequestObjectAsyncSnippet.g.cs
@@ -1,0 +1,50 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace GoogleCSharpSnippets
+{
+    // [START unknown_generated_ServiceWithApiVersion_AMethod_async]
+    using System.Threading.Tasks;
+    using Testing.PublishingSettings;
+
+    public sealed partial class GeneratedServiceWithApiVersionClientSnippets
+    {
+        /// <summary>Snippet for AMethodAsync</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated and should be regarded as a code template only.
+        /// It will require modifications to work:
+        /// - It may require correct/in-range values for request initialization.
+        /// - It may require specifying regional endpoints when creating the service client as shown in
+        ///   https://cloud.google.com/dotnet/docs/reference/help/client-configuration#endpoint.
+        /// </remarks>
+        public async Task AMethodRequestObjectAsync()
+        {
+            // Create client
+            ServiceWithApiVersionClient serviceWithApiVersionClient = await ServiceWithApiVersionClient.CreateAsync();
+            // Initialize request argument(s)
+            Request request = new Request
+            {
+                String1 = "",
+                String2 = "",
+                RequestId = "",
+                RequestIdWithPresence = "",
+            };
+            // Make the request
+            Response response = await serviceWithApiVersionClient.AMethodAsync(request);
+        }
+    }
+    // [END unknown_generated_ServiceWithApiVersion_AMethod_async]
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithApiVersionClient.AMethodRequestObjectSnippet.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/ServiceWithApiVersionClient.AMethodRequestObjectSnippet.g.cs
@@ -1,0 +1,49 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace GoogleCSharpSnippets
+{
+    // [START unknown_generated_ServiceWithApiVersion_AMethod_sync]
+    using Testing.PublishingSettings;
+
+    public sealed partial class GeneratedServiceWithApiVersionClientSnippets
+    {
+        /// <summary>Snippet for AMethod</summary>
+        /// <remarks>
+        /// This snippet has been automatically generated and should be regarded as a code template only.
+        /// It will require modifications to work:
+        /// - It may require correct/in-range values for request initialization.
+        /// - It may require specifying regional endpoints when creating the service client as shown in
+        ///   https://cloud.google.com/dotnet/docs/reference/help/client-configuration#endpoint.
+        /// </remarks>
+        public void AMethodRequestObject()
+        {
+            // Create client
+            ServiceWithApiVersionClient serviceWithApiVersionClient = ServiceWithApiVersionClient.Create();
+            // Initialize request argument(s)
+            Request request = new Request
+            {
+                String1 = "",
+                String2 = "",
+                RequestId = "",
+                RequestIdWithPresence = "",
+            };
+            // Make the request
+            Response response = serviceWithApiVersionClient.AMethod(request);
+        }
+    }
+    // [END unknown_generated_ServiceWithApiVersion_AMethod_sync]
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/snippet_metadata_testing.publishingsettings.json
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.GeneratedSnippets/snippet_metadata_testing.publishingsettings.json
@@ -107,6 +107,103 @@
       ]
     },
     {
+      "regionTag": "unknown_generated_ServiceWithApiVersion_AMethod_sync",
+      "title": "AMethodRequestObject",
+      "description": "Snippet for AMethod",
+      "file": "ServiceWithApiVersionClient.AMethodRequestObjectSnippet.g.cs",
+      "language": "C_SHARP",
+      "clientMethod": {
+        "shortName": "AMethod",
+        "fullName": "Testing.PublishingSettings.ServiceWithApiVersionClient.AMethod",
+        "parameters": [
+          {
+            "type": "Testing.PublishingSettings.Request",
+            "name": "request"
+          },
+          {
+            "type": "Google.Api.Gax.Grpc.CallSettings",
+            "name": "callSettings"
+          }
+        ],
+        "resultType": "Testing.PublishingSettings.Response",
+        "client": {
+          "shortName": "ServiceWithApiVersionClient",
+          "fullName": "Testing.PublishingSettings.ServiceWithApiVersionClient"
+        },
+        "method": {
+          "shortName": "AMethod",
+          "fullName": "testing.publishingsettings.ServiceWithApiVersion.AMethod",
+          "service": {
+            "shortName": "ServiceWithApiVersion",
+            "fullName": "testing.publishingsettings.ServiceWithApiVersion"
+          }
+        }
+      },
+      "canonical": true,
+      "origin": "API_DEFINITION",
+      "segments": [
+        {
+          "start": 20,
+          "end": 47,
+          "type": "FULL"
+        },
+        {
+          "start": 34,
+          "end": 45,
+          "type": "SHORT"
+        }
+      ]
+    },
+    {
+      "regionTag": "unknown_generated_ServiceWithApiVersion_AMethod_async",
+      "title": "AMethodRequestObjectAsync",
+      "description": "Snippet for AMethodAsync",
+      "file": "ServiceWithApiVersionClient.AMethodRequestObjectAsyncSnippet.g.cs",
+      "language": "C_SHARP",
+      "clientMethod": {
+        "shortName": "AMethodAsync",
+        "fullName": "Testing.PublishingSettings.ServiceWithApiVersionClient.AMethodAsync",
+        "async": true,
+        "parameters": [
+          {
+            "type": "Testing.PublishingSettings.Request",
+            "name": "request"
+          },
+          {
+            "type": "Google.Api.Gax.Grpc.CallSettings",
+            "name": "callSettings"
+          }
+        ],
+        "resultType": "System.Threading.Tasks.Task<Testing.PublishingSettings.Response>",
+        "client": {
+          "shortName": "ServiceWithApiVersionClient",
+          "fullName": "Testing.PublishingSettings.ServiceWithApiVersionClient"
+        },
+        "method": {
+          "shortName": "AMethod",
+          "fullName": "testing.publishingsettings.ServiceWithApiVersion.AMethod",
+          "service": {
+            "shortName": "ServiceWithApiVersion",
+            "fullName": "testing.publishingsettings.ServiceWithApiVersion"
+          }
+        }
+      },
+      "canonical": true,
+      "origin": "API_DEFINITION",
+      "segments": [
+        {
+          "start": 20,
+          "end": 48,
+          "type": "FULL"
+        },
+        {
+          "start": 35,
+          "end": 46,
+          "type": "SHORT"
+        }
+      ]
+    },
+    {
       "regionTag": "unknown_generated_ServiceWithHandwrittenSignatures_AMethod_sync",
       "title": "AMethodRequestObject",
       "description": "Snippet for AMethod",

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.Snippets/ServiceWithApiVersionClientSnippets.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings.Snippets/ServiceWithApiVersionClientSnippets.g.cs
@@ -1,0 +1,64 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+namespace GoogleCSharpSnippets
+{
+    using System.Threading.Tasks;
+    using Testing.PublishingSettings;
+
+    /// <summary>Generated snippets.</summary>
+    public sealed class AllGeneratedServiceWithApiVersionClientSnippets
+    {
+        /// <summary>Snippet for AMethod</summary>
+        public void AMethodRequestObject()
+        {
+            // Snippet: AMethod(Request, CallSettings)
+            // Create client
+            ServiceWithApiVersionClient serviceWithApiVersionClient = ServiceWithApiVersionClient.Create();
+            // Initialize request argument(s)
+            Request request = new Request
+            {
+                String1 = "",
+                String2 = "",
+                RequestId = "",
+                RequestIdWithPresence = "",
+            };
+            // Make the request
+            Response response = serviceWithApiVersionClient.AMethod(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for AMethodAsync</summary>
+        public async Task AMethodRequestObjectAsync()
+        {
+            // Snippet: AMethodAsync(Request, CallSettings)
+            // Additional: AMethodAsync(Request, CancellationToken)
+            // Create client
+            ServiceWithApiVersionClient serviceWithApiVersionClient = await ServiceWithApiVersionClient.CreateAsync();
+            // Initialize request argument(s)
+            Request request = new Request
+            {
+                String1 = "",
+                String2 = "",
+                RequestId = "",
+                RequestIdWithPresence = "",
+            };
+            // Make the request
+            Response response = await serviceWithApiVersionClient.AMethodAsync(request);
+            // End snippet
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/RenamedServiceNameClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/RenamedServiceNameClient.g.cs
@@ -243,7 +243,11 @@ namespace Testing.PublishingSettings
         {
             GrpcClient = grpcClient;
             RenamedServiceNameSettings effectiveSettings = settings ?? RenamedServiceNameSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(new gaxgrpc::ClientHelper.Options
+            {
+                Settings = effectiveSettings,
+                Logger = logger,
+            });
             _callAMethod = clientHelper.BuildApiCall<Request, Response>("AMethod", grpcClient.AMethodAsync, grpcClient.AMethod, effectiveSettings.AMethodSettings);
             Modify_ApiCall(ref _callAMethod);
             Modify_AMethodApiCall(ref _callAMethod);

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithApiVersionClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithApiVersionClient.g.cs
@@ -1,0 +1,295 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code. DO NOT EDIT!
+
+#pragma warning disable CS8981
+using gax = Google.Api.Gax;
+using gaxgrpc = Google.Api.Gax.Grpc;
+using proto = Google.Protobuf;
+using grpccore = Grpc.Core;
+using grpcinter = Grpc.Core.Interceptors;
+using mel = Microsoft.Extensions.Logging;
+using sys = System;
+using scg = System.Collections.Generic;
+using sco = System.Collections.ObjectModel;
+using st = System.Threading;
+using stt = System.Threading.Tasks;
+
+namespace Testing.PublishingSettings
+{
+    /// <summary>Settings for <see cref="ServiceWithApiVersionClient"/> instances.</summary>
+    public sealed partial class ServiceWithApiVersionSettings : gaxgrpc::ServiceSettingsBase
+    {
+        /// <summary>Get a new instance of the default <see cref="ServiceWithApiVersionSettings"/>.</summary>
+        /// <returns>A new instance of the default <see cref="ServiceWithApiVersionSettings"/>.</returns>
+        public static ServiceWithApiVersionSettings GetDefault() => new ServiceWithApiVersionSettings();
+
+        /// <summary>
+        /// Constructs a new <see cref="ServiceWithApiVersionSettings"/> object with default settings.
+        /// </summary>
+        public ServiceWithApiVersionSettings()
+        {
+        }
+
+        private ServiceWithApiVersionSettings(ServiceWithApiVersionSettings existing) : base(existing)
+        {
+            gax::GaxPreconditions.CheckNotNull(existing, nameof(existing));
+            AMethodSettings = existing.AMethodSettings;
+            OnCopy(existing);
+        }
+
+        partial void OnCopy(ServiceWithApiVersionSettings existing);
+
+        /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>ServiceWithApiVersionClient.AMethod</c> and <c>ServiceWithApiVersionClient.AMethodAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// <list type="bullet">
+        /// <item><description>This call will not be retried.</description></item>
+        /// <item><description>No timeout is applied.</description></item>
+        /// </list>
+        /// </remarks>
+        public gaxgrpc::CallSettings AMethodSettings { get; set; } = gaxgrpc::CallSettings.FromExpiration(gax::Expiration.None);
+
+        /// <summary>Creates a deep clone of this object, with all the same property values.</summary>
+        /// <returns>A deep clone of this <see cref="ServiceWithApiVersionSettings"/> object.</returns>
+        public ServiceWithApiVersionSettings Clone() => new ServiceWithApiVersionSettings(this);
+    }
+
+    /// <summary>
+    /// Builder class for <see cref="ServiceWithApiVersionClient"/> to provide simple configuration of credentials,
+    /// endpoint etc.
+    /// </summary>
+    public sealed partial class ServiceWithApiVersionClientBuilder : gaxgrpc::ClientBuilderBase<ServiceWithApiVersionClient>
+    {
+        /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
+        public ServiceWithApiVersionSettings Settings { get; set; }
+
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ServiceWithApiVersionClientBuilder() : base(ServiceWithApiVersionClient.ServiceMetadata)
+        {
+        }
+
+        partial void InterceptBuild(ref ServiceWithApiVersionClient client);
+
+        partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ServiceWithApiVersionClient> task);
+
+        /// <summary>Builds the resulting client.</summary>
+        public override ServiceWithApiVersionClient Build()
+        {
+            ServiceWithApiVersionClient client = null;
+            InterceptBuild(ref client);
+            return client ?? BuildImpl();
+        }
+
+        /// <summary>Builds the resulting client asynchronously.</summary>
+        public override stt::Task<ServiceWithApiVersionClient> BuildAsync(st::CancellationToken cancellationToken = default)
+        {
+            stt::Task<ServiceWithApiVersionClient> task = null;
+            InterceptBuildAsync(cancellationToken, ref task);
+            return task ?? BuildAsyncImpl(cancellationToken);
+        }
+
+        private ServiceWithApiVersionClient BuildImpl()
+        {
+            Validate();
+            grpccore::CallInvoker callInvoker = CreateCallInvoker();
+            return ServiceWithApiVersionClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
+        }
+
+        private async stt::Task<ServiceWithApiVersionClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
+        {
+            Validate();
+            grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
+            return ServiceWithApiVersionClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
+        }
+
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
+        protected override gaxgrpc::ChannelPool GetChannelPool() => ServiceWithApiVersionClient.ChannelPool;
+    }
+
+    /// <summary>ServiceWithApiVersion client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// This is a service using the api_version extension.
+    /// </remarks>
+    public abstract partial class ServiceWithApiVersionClient
+    {
+        /// <summary>
+        /// The default endpoint for the ServiceWithApiVersion service, which is a host of "" and a port of 443.
+        /// </summary>
+        public static string DefaultEndpoint { get; } = ":443";
+
+        /// <summary>The default ServiceWithApiVersion scopes.</summary>
+        /// <remarks>The default ServiceWithApiVersion scopes are:<list type="bullet"></list></remarks>
+        public static scg::IReadOnlyList<string> DefaultScopes { get; } = new sco::ReadOnlyCollection<string>(new string[] { });
+
+        /// <summary>The service metadata associated with this client type.</summary>
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(ServiceWithApiVersion.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
+
+        /// <summary>
+        /// Asynchronously creates a <see cref="ServiceWithApiVersionClient"/> using the default credentials, endpoint
+        /// and settings. To specify custom credentials or other settings, use
+        /// <see cref="ServiceWithApiVersionClientBuilder"/>.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// The <see cref="st::CancellationToken"/> to use while creating the client.
+        /// </param>
+        /// <returns>The task representing the created <see cref="ServiceWithApiVersionClient"/>.</returns>
+        public static stt::Task<ServiceWithApiVersionClient> CreateAsync(st::CancellationToken cancellationToken = default) =>
+            new ServiceWithApiVersionClientBuilder().BuildAsync(cancellationToken);
+
+        /// <summary>
+        /// Synchronously creates a <see cref="ServiceWithApiVersionClient"/> using the default credentials, endpoint
+        /// and settings. To specify custom credentials or other settings, use
+        /// <see cref="ServiceWithApiVersionClientBuilder"/>.
+        /// </summary>
+        /// <returns>The created <see cref="ServiceWithApiVersionClient"/>.</returns>
+        public static ServiceWithApiVersionClient Create() => new ServiceWithApiVersionClientBuilder().Build();
+
+        /// <summary>
+        /// Creates a <see cref="ServiceWithApiVersionClient"/> which uses the specified call invoker for remote
+        /// operations.
+        /// </summary>
+        /// <param name="callInvoker">
+        /// The <see cref="grpccore::CallInvoker"/> for remote operations. Must not be null.
+        /// </param>
+        /// <param name="settings">Optional <see cref="ServiceWithApiVersionSettings"/>.</param>
+        /// <param name="logger">Optional <see cref="mel::ILogger"/>.</param>
+        /// <returns>The created <see cref="ServiceWithApiVersionClient"/>.</returns>
+        internal static ServiceWithApiVersionClient Create(grpccore::CallInvoker callInvoker, ServiceWithApiVersionSettings settings = null, mel::ILogger logger = null)
+        {
+            gax::GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker));
+            grpcinter::Interceptor interceptor = settings?.Interceptor;
+            if (interceptor != null)
+            {
+                callInvoker = grpcinter::CallInvokerExtensions.Intercept(callInvoker, interceptor);
+            }
+            ServiceWithApiVersion.ServiceWithApiVersionClient grpcClient = new ServiceWithApiVersion.ServiceWithApiVersionClient(callInvoker);
+            return new ServiceWithApiVersionClientImpl(grpcClient, settings, logger);
+        }
+
+        /// <summary>
+        /// Shuts down any channels automatically created by <see cref="Create()"/> and
+        /// <see cref="CreateAsync(st::CancellationToken)"/>. Channels which weren't automatically created are not
+        /// affected.
+        /// </summary>
+        /// <remarks>
+        /// After calling this method, further calls to <see cref="Create()"/> and
+        /// <see cref="CreateAsync(st::CancellationToken)"/> will create new channels, which could in turn be shut down
+        /// by another call to this method.
+        /// </remarks>
+        /// <returns>A task representing the asynchronous shutdown operation.</returns>
+        public static stt::Task ShutdownDefaultChannelsAsync() => ChannelPool.ShutdownChannelsAsync();
+
+        /// <summary>The underlying gRPC ServiceWithApiVersion client</summary>
+        public virtual ServiceWithApiVersion.ServiceWithApiVersionClient GrpcClient => throw new sys::NotImplementedException();
+
+        /// <summary>
+        /// Test summary text for AMethod
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The RPC response.</returns>
+        public virtual Response AMethod(Request request, gaxgrpc::CallSettings callSettings = null) =>
+            throw new sys::NotImplementedException();
+
+        /// <summary>
+        /// Test summary text for AMethod
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual stt::Task<Response> AMethodAsync(Request request, gaxgrpc::CallSettings callSettings = null) =>
+            throw new sys::NotImplementedException();
+
+        /// <summary>
+        /// Test summary text for AMethod
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="cancellationToken">A <see cref="st::CancellationToken"/> to use for this RPC.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual stt::Task<Response> AMethodAsync(Request request, st::CancellationToken cancellationToken) =>
+            AMethodAsync(request, gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
+    }
+
+    /// <summary>ServiceWithApiVersion client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// This is a service using the api_version extension.
+    /// </remarks>
+    public sealed partial class ServiceWithApiVersionClientImpl : ServiceWithApiVersionClient
+    {
+        private readonly gaxgrpc::ApiCall<Request, Response> _callAMethod;
+
+        /// <summary>
+        /// Constructs a client wrapper for the ServiceWithApiVersion service, with the specified gRPC client and
+        /// settings.
+        /// </summary>
+        /// <param name="grpcClient">The underlying gRPC client.</param>
+        /// <param name="settings">The base <see cref="ServiceWithApiVersionSettings"/> used within this client.</param>
+        /// <param name="logger">Optional <see cref="mel::ILogger"/> to use within this client.</param>
+        public ServiceWithApiVersionClientImpl(ServiceWithApiVersion.ServiceWithApiVersionClient grpcClient, ServiceWithApiVersionSettings settings, mel::ILogger logger)
+        {
+            GrpcClient = grpcClient;
+            ServiceWithApiVersionSettings effectiveSettings = settings ?? ServiceWithApiVersionSettings.GetDefault();
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(new gaxgrpc::ClientHelper.Options
+            {
+                Settings = effectiveSettings,
+                Logger = logger,
+            });
+            _callAMethod = clientHelper.BuildApiCall<Request, Response>("AMethod", grpcClient.AMethodAsync, grpcClient.AMethod, effectiveSettings.AMethodSettings);
+            Modify_ApiCall(ref _callAMethod);
+            Modify_AMethodApiCall(ref _callAMethod);
+            OnConstruction(grpcClient, effectiveSettings, clientHelper);
+        }
+
+        partial void Modify_ApiCall<TRequest, TResponse>(ref gaxgrpc::ApiCall<TRequest, TResponse> call) where TRequest : class, proto::IMessage<TRequest> where TResponse : class, proto::IMessage<TResponse>;
+
+        partial void Modify_AMethodApiCall(ref gaxgrpc::ApiCall<Request, Response> call);
+
+        partial void OnConstruction(ServiceWithApiVersion.ServiceWithApiVersionClient grpcClient, ServiceWithApiVersionSettings effectiveSettings, gaxgrpc::ClientHelper clientHelper);
+
+        /// <summary>The underlying gRPC ServiceWithApiVersion client</summary>
+        public override ServiceWithApiVersion.ServiceWithApiVersionClient GrpcClient { get; }
+
+        partial void Modify_Request(ref Request request, ref gaxgrpc::CallSettings settings);
+
+        /// <summary>
+        /// Test summary text for AMethod
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The RPC response.</returns>
+        public override Response AMethod(Request request, gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_Request(ref request, ref callSettings);
+            return _callAMethod.Sync(request, callSettings);
+        }
+
+        /// <summary>
+        /// Test summary text for AMethod
+        /// </summary>
+        /// <param name="request">The request object containing all of the parameters for the API call.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public override stt::Task<Response> AMethodAsync(Request request, gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_Request(ref request, ref callSettings);
+            return _callAMethod.Async(request, callSettings);
+        }
+    }
+}

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithApiVersionClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithApiVersionClient.g.cs
@@ -250,6 +250,7 @@ namespace Testing.PublishingSettings
             {
                 Settings = effectiveSettings,
                 Logger = logger,
+                ApiVersion = "v1_20240313",
             });
             _callAMethod = clientHelper.BuildApiCall<Request, Response>("AMethod", grpcClient.AMethodAsync, grpcClient.AMethod, effectiveSettings.AMethodSettings);
             Modify_ApiCall(ref _callAMethod);

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithHandwrittenSignaturesClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithHandwrittenSignaturesClient.g.cs
@@ -295,7 +295,11 @@ namespace Testing.PublishingSettings
         {
             GrpcClient = grpcClient;
             ServiceWithHandwrittenSignaturesSettings effectiveSettings = settings ?? ServiceWithHandwrittenSignaturesSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(new gaxgrpc::ClientHelper.Options
+            {
+                Settings = effectiveSettings,
+                Logger = logger,
+            });
             _callAMethod = clientHelper.BuildApiCall<Request, Response>("AMethod", grpcClient.AMethodAsync, grpcClient.AMethod, effectiveSettings.AMethodSettings);
             Modify_ApiCall(ref _callAMethod);
             Modify_AMethodApiCall(ref _callAMethod);

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithMethodSettingsClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithMethodSettingsClient.g.cs
@@ -478,7 +478,11 @@ namespace Testing.PublishingSettings
         {
             GrpcClient = grpcClient;
             ServiceWithMethodSettingsSettings effectiveSettings = settings ?? ServiceWithMethodSettingsSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(new gaxgrpc::ClientHelper.Options
+            {
+                Settings = effectiveSettings,
+                Logger = logger,
+            });
             LroAutoPopulatedOperationsClient = new lro::OperationsClientImpl(grpcClient.CreateOperationsClient(), effectiveSettings.LroAutoPopulatedOperationsSettings, logger);
             _callUnaryAutoPopulated = clientHelper.BuildApiCall<Request, Response>("UnaryAutoPopulated", grpcClient.UnaryAutoPopulatedAsync, grpcClient.UnaryAutoPopulated, effectiveSettings.UnaryAutoPopulatedSettings);
             Modify_ApiCall(ref _callUnaryAutoPopulated);

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithResourcesClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithResourcesClient.g.cs
@@ -244,7 +244,11 @@ namespace Testing.PublishingSettings
         {
             GrpcClient = grpcClient;
             ServiceWithResourcesSettings effectiveSettings = settings ?? ServiceWithResourcesSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(new gaxgrpc::ClientHelper.Options
+            {
+                Settings = effectiveSettings,
+                Logger = logger,
+            });
             _callAMethod = clientHelper.BuildApiCall<ResourceRequest, Resource>("AMethod", grpcClient.AMethodAsync, grpcClient.AMethod, effectiveSettings.AMethodSettings);
             Modify_ApiCall(ref _callAMethod);
             Modify_AMethodApiCall(ref _callAMethod);

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames/ResourceNamesClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames/ResourceNamesClient.g.cs
@@ -1600,7 +1600,11 @@ namespace Testing.ResourceNames
         {
             GrpcClient = grpcClient;
             ResourceNamesSettings effectiveSettings = settings ?? ResourceNamesSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(new gaxgrpc::ClientHelper.Options
+            {
+                Settings = effectiveSettings,
+                Logger = logger,
+            });
             _callSinglePatternMethod = clientHelper.BuildApiCall<SinglePattern, Response>("SinglePatternMethod", grpcClient.SinglePatternMethodAsync, grpcClient.SinglePatternMethod, effectiveSettings.SinglePatternMethodSettings);
             Modify_ApiCall(ref _callSinglePatternMethod);
             Modify_SinglePatternMethodApiCall(ref _callSinglePatternMethod);

--- a/Google.Api.Generator.Tests/ProtoTests/RoutingHeaders/Testing.RoutingHeaders/RoutingHeadersClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/RoutingHeaders/Testing.RoutingHeaders/RoutingHeadersClient.g.cs
@@ -59,7 +59,11 @@ namespace Testing.RoutingHeaders
         {
             GrpcClient = grpcClient;
             RoutingHeadersSettings effectiveSettings = settings ?? RoutingHeadersSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(new gaxgrpc::ClientHelper.Options
+            {
+                Settings = effectiveSettings,
+                Logger = logger,
+            });
             _callNoUrlMethod = clientHelper.BuildApiCall<SimpleRequest, Response>("NoUrlMethod", grpcClient.NoUrlMethodAsync, grpcClient.NoUrlMethod, effectiveSettings.NoUrlMethodSettings);
             Modify_ApiCall(ref _callNoUrlMethod);
             Modify_NoUrlMethodApiCall(ref _callNoUrlMethod);

--- a/Google.Api.Generator.Tests/ProtoTests/RoutingHeadersExplicit/Testing.RoutingHeadersExplicit/RoutingHeadersExplicitClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/RoutingHeadersExplicit/Testing.RoutingHeadersExplicit/RoutingHeadersExplicitClient.g.cs
@@ -66,7 +66,11 @@ namespace Testing.RoutingHeadersExplicit
             // TEST_START
             GrpcClient = grpcClient;
             RoutingHeadersExplicitSettings effectiveSettings = settings ?? RoutingHeadersExplicitSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(new gaxgrpc::ClientHelper.Options
+            {
+                Settings = effectiveSettings,
+                Logger = logger,
+            });
             _callNoRouting = clientHelper.BuildApiCall<SimpleRequest, Response>("NoRouting", grpcClient.NoRoutingAsync, grpcClient.NoRouting, effectiveSettings.NoRoutingSettings);
             Modify_ApiCall(ref _callNoRouting);
             Modify_NoRoutingApiCall(ref _callNoRouting);

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/ComplianceClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/ComplianceClient.g.cs
@@ -690,7 +690,11 @@ namespace Google.Showcase.V1Beta1
         {
             GrpcClient = grpcClient;
             ComplianceSettings effectiveSettings = settings ?? ComplianceSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(new gaxgrpc::ClientHelper.Options
+            {
+                Settings = effectiveSettings,
+                Logger = logger,
+            });
             LocationsClient = new gcl::LocationsClientImpl(grpcClient.CreateLocationsClient(), effectiveSettings.LocationsSettings, logger);
             IAMPolicyClient = new gciv::IAMPolicyClientImpl(grpcClient.CreateIAMPolicyClient(), effectiveSettings.IAMPolicySettings, logger);
             _callRepeatDataBody = clientHelper.BuildApiCall<RepeatRequest, RepeatResponse>("RepeatDataBody", grpcClient.RepeatDataBodyAsync, grpcClient.RepeatDataBody, effectiveSettings.RepeatDataBodySettings);

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/EchoClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/EchoClient.g.cs
@@ -659,7 +659,11 @@ namespace Google.Showcase.V1Beta1
         {
             GrpcClient = grpcClient;
             EchoSettings effectiveSettings = settings ?? EchoSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(new gaxgrpc::ClientHelper.Options
+            {
+                Settings = effectiveSettings,
+                Logger = logger,
+            });
             WaitOperationsClient = new lro::OperationsClientImpl(grpcClient.CreateOperationsClient(), effectiveSettings.WaitOperationsSettings, logger);
             LocationsClient = new gcl::LocationsClientImpl(grpcClient.CreateLocationsClient(), effectiveSettings.LocationsSettings, logger);
             IAMPolicyClient = new gciv::IAMPolicyClientImpl(grpcClient.CreateIAMPolicyClient(), effectiveSettings.IAMPolicySettings, logger);

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/IdentityClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/IdentityClient.g.cs
@@ -750,7 +750,11 @@ namespace Google.Showcase.V1Beta1
         {
             GrpcClient = grpcClient;
             IdentitySettings effectiveSettings = settings ?? IdentitySettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(new gaxgrpc::ClientHelper.Options
+            {
+                Settings = effectiveSettings,
+                Logger = logger,
+            });
             LocationsClient = new gcl::LocationsClientImpl(grpcClient.CreateLocationsClient(), effectiveSettings.LocationsSettings, logger);
             IAMPolicyClient = new gciv::IAMPolicyClientImpl(grpcClient.CreateIAMPolicyClient(), effectiveSettings.IAMPolicySettings, logger);
             _callCreateUser = clientHelper.BuildApiCall<CreateUserRequest, User>("CreateUser", grpcClient.CreateUserAsync, grpcClient.CreateUser, effectiveSettings.CreateUserSettings);

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/MessagingClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/MessagingClient.g.cs
@@ -1741,7 +1741,11 @@ namespace Google.Showcase.V1Beta1
         {
             GrpcClient = grpcClient;
             MessagingSettings effectiveSettings = settings ?? MessagingSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(new gaxgrpc::ClientHelper.Options
+            {
+                Settings = effectiveSettings,
+                Logger = logger,
+            });
             SearchBlurbsOperationsClient = new lro::OperationsClientImpl(grpcClient.CreateOperationsClient(), effectiveSettings.SearchBlurbsOperationsSettings, logger);
             LocationsClient = new gcl::LocationsClientImpl(grpcClient.CreateLocationsClient(), effectiveSettings.LocationsSettings, logger);
             IAMPolicyClient = new gciv::IAMPolicyClientImpl(grpcClient.CreateIAMPolicyClient(), effectiveSettings.IAMPolicySettings, logger);

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/SequenceServiceClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/SequenceServiceClient.g.cs
@@ -517,7 +517,11 @@ namespace Google.Showcase.V1Beta1
         {
             GrpcClient = grpcClient;
             SequenceServiceSettings effectiveSettings = settings ?? SequenceServiceSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(new gaxgrpc::ClientHelper.Options
+            {
+                Settings = effectiveSettings,
+                Logger = logger,
+            });
             LocationsClient = new gcl::LocationsClientImpl(grpcClient.CreateLocationsClient(), effectiveSettings.LocationsSettings, logger);
             IAMPolicyClient = new gciv::IAMPolicyClientImpl(grpcClient.CreateIAMPolicyClient(), effectiveSettings.IAMPolicySettings, logger);
             _callCreateSequence = clientHelper.BuildApiCall<CreateSequenceRequest, Sequence>("CreateSequence", grpcClient.CreateSequenceAsync, grpcClient.CreateSequence, effectiveSettings.CreateSequenceSettings);

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/TestingClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/TestingClient.g.cs
@@ -569,7 +569,11 @@ namespace Google.Showcase.V1Beta1
         {
             GrpcClient = grpcClient;
             TestingSettings effectiveSettings = settings ?? TestingSettings.GetDefault();
-            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(effectiveSettings, logger);
+            gaxgrpc::ClientHelper clientHelper = new gaxgrpc::ClientHelper(new gaxgrpc::ClientHelper.Options
+            {
+                Settings = effectiveSettings,
+                Logger = logger,
+            });
             LocationsClient = new gcl::LocationsClientImpl(grpcClient.CreateLocationsClient(), effectiveSettings.LocationsSettings, logger);
             IAMPolicyClient = new gciv::IAMPolicyClientImpl(grpcClient.CreateIAMPolicyClient(), effectiveSettings.IAMPolicySettings, logger);
             _callCreateSession = clientHelper.BuildApiCall<CreateSessionRequest, Session>("CreateSession", grpcClient.CreateSessionAsync, grpcClient.CreateSession, effectiveSettings.CreateSessionSettings);

--- a/Google.Api.Generator/CodeGenerator.cs
+++ b/Google.Api.Generator/CodeGenerator.cs
@@ -43,6 +43,7 @@ namespace Google.Api.Generator
             ClientExtensions.DefaultHost,
             ClientExtensions.MethodSignature,
             ClientExtensions.OauthScopes,
+            ClientExtensions.ApiVersion,
             OperationsExtensions.OperationInfo,
             FieldInfoExtensions.FieldInfo,
             FieldBehaviorExtensions.FieldBehavior,

--- a/Google.Api.Generator/Generation/LroAdaptationGenerator.cs
+++ b/Google.Api.Generator/Generation/LroAdaptationGenerator.cs
@@ -157,8 +157,8 @@ namespace Google.Api.Generator.Generation
                                     {
                                         return null;
                                     }
-                                // Note: not using indexer on MessageDescriptor, as the code below provides more helpful diagnostics.
-                                var operationField = lroDetails.OperationDescriptor.Fields.InDeclarationOrder().FirstOrDefault(f => f.Name == operationFieldName);
+                                    // Note: not using indexer on MessageDescriptor, as the code below provides more helpful diagnostics.
+                                    var operationField = lroDetails.OperationDescriptor.Fields.InDeclarationOrder().FirstOrDefault(f => f.Name == operationFieldName);
                                     if (operationField is null)
                                     {
                                         throw new InvalidOperationException($"No field '{operationFieldName}' in message {lroDetails.OperationDescriptor.FullName}");

--- a/Google.Api.Generator/Generation/ServiceDetails.cs
+++ b/Google.Api.Generator/Generation/ServiceDetails.cs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Api.Gax;
 using Google.Api.Generator.ProtoUtils;
 using Google.Api.Generator.Utils;
 using Google.Cloud;
-using Google.Cloud.Location;
 using Google.Cloud.Iam.V1;
+using Google.Cloud.Location;
 using Google.Protobuf.Reflection;
 using Grpc.ServiceConfig;
 using System;
@@ -24,8 +25,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text.RegularExpressions;
-using Google.Api.Gax;
-using Grpc.Core;
 
 namespace Google.Api.Generator.Generation
 {
@@ -34,7 +33,7 @@ namespace Google.Api.Generator.Generation
     /// </summary>
     internal class ServiceDetails
     {
-        private static readonly Regex ApiVersionPattern = new Regex("^[vV][0-9]+.*");
+        private static readonly Regex PackageVersionPattern = new Regex("^[vV][0-9]+.*");
 
         private static readonly Dictionary<string, MixinDetails> AvailableMixins = new[]
         {
@@ -49,7 +48,12 @@ namespace Google.Api.Generator.Generation
             Catalog = catalog;
             Namespace = ns;
             ProtoPackage = desc.File.Package;
-            PackageVersion = ProtoPackage.Split('.').FirstOrDefault(part => ApiVersionPattern.IsMatch(part));
+            ApiVersion = desc.GetExtension(ClientExtensions.ApiVersion);
+            if (ApiVersion == "")
+            {
+                ApiVersion = null;
+            }
+            PackageVersion = ProtoPackage.Split('.').FirstOrDefault(PackageVersionPattern.IsMatch);
             DocLines = desc.Declaration.DocLines().ToList();
             // For snippets, we use a namespace unrelated to the library as that's likely to be similar to
             // user code. Imports are cleaner, with less type name clashes, etc. which in turn means less
@@ -126,6 +130,12 @@ namespace Google.Api.Generator.Generation
         /// May be null.
         /// </summary>
         public string PackageVersion { get; }
+
+        /// <summary>
+        /// The API version (as declared in the api_version service extension), or null
+        /// if there's no such version.
+        /// </summary>
+        public string ApiVersion { get; }
 
         /// <summary>The name of this service to be used in documentation.</summary>
         public string DocumentationName { get; }

--- a/Google.Api.Generator/Generation/ServiceImplClientClassGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceImplClientClassGenerator.cs
@@ -110,7 +110,7 @@ namespace Google.Api.Generator.Generation
                 .WithBody(
                     grpcClientProperty.Assign(grpcClient),
                     effectiveSettings.WithInitializer(settings.NullCoalesce(_ctx.Type(_svc.SettingsTyp).Call("GetDefault")())),
-                    clientHelper.WithInitializer(New(_ctx.Type<ClientHelper>())(effectiveSettings, logger)),
+                    clientHelper.WithInitializer(ClientHelperInitializer()),
                     _svc.Methods.OfType<MethodDetails.StandardLro>().Select(m => StandardLroClient(m, logger)),
                     _svc.Methods.OfType<MethodDetails.NonStandardLro>().Select(m => NonStandardLroClient(m, logger)),
                     _svc.Mixins.Select(m => MixinClient(m, logger)),
@@ -123,6 +123,16 @@ namespace Google.Api.Generator.Generation
                     XmlDoc.Param(settings, "The base ", settings.Type, " used within this client."),
                     XmlDoc.Param(logger, "Optional ", logger.Type, " to use within this client.")
                 );
+
+            object ClientHelperInitializer()
+            {
+                var assignments = new List<ObjectInitExpr>
+                {
+                    new(nameof(ClientHelper.Options.Settings), effectiveSettings),
+                    new(nameof(ClientHelper.Options.Logger), logger)
+                };
+                return New(_ctx.Type<ClientHelper>())(New(_ctx.Type<ClientHelper.Options>())().WithInitializer(assignments.ToArray()));
+            }
 
             SyntaxNode StandardLroClient(MethodDetails.StandardLro lro, ParameterSyntax logger)
             {

--- a/Google.Api.Generator/Generation/ServiceImplClientClassGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceImplClientClassGenerator.cs
@@ -131,6 +131,10 @@ namespace Google.Api.Generator.Generation
                     new(nameof(ClientHelper.Options.Settings), effectiveSettings),
                     new(nameof(ClientHelper.Options.Logger), logger)
                 };
+                if (_svc.ApiVersion is string apiVersion)
+                {
+                    assignments.Add(new ObjectInitExpr(nameof(ClientHelper.Options.ApiVersion), apiVersion));
+                }
                 return New(_ctx.Type<ClientHelper>())(New(_ctx.Type<ClientHelper.Options>())().WithInitializer(assignments.ToArray()));
             }
 


### PR DESCRIPTION
This won't currently build, as it requires both the common protos and GAX to be published.

It's ready for review though.