### PR TITLE
feat: Include the api_version in GAPIC generated summary docs.

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithApiVersionClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithApiVersionClient.g.cs
@@ -121,7 +121,9 @@ namespace Testing.PublishingSettings
         protected override gaxgrpc::ChannelPool GetChannelPool() => ServiceWithApiVersionClient.ChannelPool;
     }
 
-    /// <summary>ServiceWithApiVersion client wrapper, for convenient use.</summary>
+    /// <summary>
+    /// ServiceWithApiVersion client wrapper, for convenient use. This client implements API version v1_20240313.
+    /// </summary>
     /// <remarks>
     /// This is a service using the api_version extension.
     /// </remarks>

--- a/Google.Api.Generator/Generation/ServiceAbstractClientClassCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceAbstractClientClassCodeGenerator.cs
@@ -46,10 +46,14 @@ namespace Google.Api.Generator.Generation
 
         private ClassDeclarationSyntax Generate()
         {
+            string summaryPrefix = $"{_svc.DocumentationName} client wrapper, for convenient use.";
+            string summaryDoc = _svc.ApiVersion is null
+                ? summaryPrefix
+                : $"{summaryPrefix} This client implements API version {_svc.ApiVersion}.";
             var cls = Class(Public | Abstract | Partial, _svc.ClientAbstractTyp)
                 .MaybeWithAttribute(_svc.IsDeprecated, () => _ctx.Type<ObsoleteAttribute>())()
                 .WithXmlDoc(
-                    XmlDoc.Summary($"{_svc.DocumentationName} client wrapper, for convenient use."),
+                    XmlDoc.Summary(summaryDoc),
                     XmlDoc.RemarksPreFormatted(_svc.DocLines));
             using (_ctx.InClass(cls))
             {


### PR DESCRIPTION
(Ideally we should include this in release notes as well, but this is a start.)

I'm definitely open to changes to the exact format of the text.