### PR TITLE
chore: Remove unneeded console output

### DIFF
--- a/Google.Api.Generator.Testing/TextComparer.cs
+++ b/Google.Api.Generator.Testing/TextComparer.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Google.Api.Generator.Utils;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -71,7 +70,6 @@ namespace Google.Api.Generator.Testing
                 }
                 if (missing.line != null)
                 {
-                    Console.WriteLine(string.Join(Environment.NewLine, actualLines));
                     throw new XunitException($"Failed to find expected line {missing.lineNumber + 1} in '{Path.GetFileName(actualFile.RelativePath)}'\n" +
                         $"  Expected line:  '{missing.line}'\n" +
                         $"  Generated line: '{missingActualLine}'");


### PR DESCRIPTION
This used to be useful, but now that we write out all the generated files anyway, diffing or copying those is a simpler way of examining the output.