### PR TITLE
chore: Use invariant string formatting in the GAPIC generator

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTest.cs
+++ b/Google.Api.Generator.Tests/ProtoTest.cs
@@ -20,6 +20,7 @@ using Google.Api.Generator.Utils;
 using Google.Protobuf.Reflection;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using Xunit;
@@ -306,6 +307,32 @@ namespace Google.Api.Generator.Tests
             requestNumericEnumJsonEncoding: true,
             ignoreSnippets: true,
             ignoreApiMetadataFile: false);
+
+        [Fact]
+        public void ShowcaseInFrenchCulture()
+        {
+            var oldCulture = CultureInfo.CurrentCulture;
+            var oldUiCulture = CultureInfo.CurrentUICulture;
+            CultureInfo.CurrentCulture = new CultureInfo("fr-FR");
+            CultureInfo.CurrentUICulture = new CultureInfo("fr-FR");
+            try
+            {
+                ProtoTestSingle(testProtoNames: new[] { "compliance", "echo", "identity", "messaging", "sequence", "testing" },
+                    sourceDir: "Showcase/google/showcase/v1beta1",
+                    outputDir: "Showcase",
+                    package: "google.showcase.v1beta1",
+                    serviceConfigPath: "showcase_v1beta1.yaml",
+                    transports: ApiTransports.Grpc | ApiTransports.Rest,
+                    requestNumericEnumJsonEncoding: true,
+                    ignoreSnippets: true,
+                    ignoreApiMetadataFile: false);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = oldCulture;
+                CultureInfo.CurrentUICulture = oldUiCulture;
+            }
+        }
 
         [Fact]
         public void PublishingSettings() => ProtoTestSingle(

--- a/Google.Api.Generator/Generation/ServiceSettingsCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceSettingsCodeGenerator.cs
@@ -25,6 +25,7 @@ using System.Collections.Generic;
 using System.Linq;
 using static Google.Api.Generator.Utils.Roslyn.Modifier;
 using static Google.Api.Generator.Utils.Roslyn.RoslynBuilder;
+using static System.FormattableString;
 
 namespace Google.Api.Generator.Generation
 {
@@ -149,10 +150,10 @@ namespace Google.Api.Generator.Generation
                             _ctx.Type(typeof(CallSettingsExtensions)).Call(nameof(CallSettingsExtensions.WithRetry))(initializer, retryExpression);
                         xmlRemarks = XmlDoc.Remarks(
                             XmlDoc.UL(
-                                $"Initial retry delay: {(int)retry.InitialBackoff.TotalMilliseconds} milliseconds.",
-                                $"Retry delay multiplier: {retry.BackoffMultiplier}",
-                                $"Retry maximum delay: {(int)retry.MaxBackoff.TotalMilliseconds} milliseconds.",
-                                $"Maximum attempts: {(retry.MaxAttempts == int.MaxValue ? "Unlimited" : retry.MaxAttempts.ToString())}",
+                                Invariant($"Initial retry delay: {(int)retry.InitialBackoff.TotalMilliseconds} milliseconds."),
+                                Invariant($"Retry delay multiplier: {retry.BackoffMultiplier}"),
+                                Invariant($"Retry maximum delay: {(int)retry.MaxBackoff.TotalMilliseconds} milliseconds."),
+                                Invariant($"Maximum attempts: {(retry.MaxAttempts == int.MaxValue ? "Unlimited" : retry.MaxAttempts.ToString())}"),
                                 GetRetriableErrorCodeDocs().ToArray(),
                                 timeoutRemark));
 
@@ -228,10 +229,10 @@ namespace Google.Api.Generator.Generation
                         XmlDoc.C($"{_svc.ClientAbstractTyp.Name}.{method.SyncMethodName}"), " and ",
                         XmlDoc.C($"{_svc.ClientAbstractTyp.Name}.{method.AsyncMethodName}"), "."),
                     XmlDoc.Remarks("Uses default ", _ctx.Type<PollSettings>(), " of:", XmlDoc.UL(
-                        $"Initial delay: {(int)s_lroDefaultPollSettings.Delay.TotalSeconds} seconds.",
-                        $"Delay multiplier: {s_lroDefaultPollSettings.DelayMultiplier}",
-                        $"Maximum delay: {(int)s_lroDefaultPollSettings.MaxDelay.TotalSeconds} seconds.",
-                        $"Total timeout: {(int)s_lroDefaultPollSettings.Expiration.Timeout.Value.TotalHours} hours.")))
+                        Invariant($"Initial delay: {(int)s_lroDefaultPollSettings.Delay.TotalSeconds} seconds."),
+                        Invariant($"Delay multiplier: {s_lroDefaultPollSettings.DelayMultiplier}"),
+                        Invariant($"Maximum delay: {(int)s_lroDefaultPollSettings.MaxDelay.TotalSeconds} seconds."),
+                        Invariant($"Total timeout: {(int)s_lroDefaultPollSettings.Expiration.Timeout.Value.TotalHours} hours."))))
                 .WithAdditionalAnnotations(s_cloneSetting);
 
         private PropertyDeclarationSyntax BidiSettingsProperty(MethodDetails.BidiStreaming method) =>

--- a/Google.Api.Generator/Logging.cs
+++ b/Google.Api.Generator/Logging.cs
@@ -16,8 +16,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.IO;
-using System.Net.Http.Headers;
-using System.Reflection.Metadata;
+using static System.FormattableString;
 
 namespace Google.Api.Generator;
 
@@ -60,7 +59,7 @@ internal static class Logging
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
             string message = formatter(state, exception);
-            string line = $"{DateTime.UtcNow:yyyy-MM-dd'T'HH:mm:ss.fff} {logLevel} - {message}";
+            string line = Invariant($"{DateTime.UtcNow:yyyy-MM-dd'T'HH:mm:ss.fff} {logLevel} - {message}");
             _writer.WriteLine(line);
         }
     }


### PR DESCRIPTION
(Marked as chore rather than fix as this won't be an end-user-visible change, given that we always run this in English/US-English. But it *is* fixing a development-time bug.)

Note that this isn't specified for *all* interpolated string literals - just ones which would be affected by culture. Most of the time we're just concatenating strings.