### PR TITLE
build: Update Microsoft.Extensions.Logging.Abstractions dependency

### DIFF
--- a/Google.Api.Generator.Utils/Google.Api.Generator.Utils.csproj
+++ b/Google.Api.Generator.Utils/Google.Api.Generator.Utils.csproj
@@ -7,6 +7,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
     <PackageReference Include="Google.Api.Gax" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I'm hoping that once this is merged, if we retry #783 then it should only attempt to update dotnet-sdk and we'll be able to close it without it re-opening.