### PR TITLE
refactor: Add conditional ("Maybe") XML doc generation methods

### DIFF
--- a/Google.Api.Generator.Rest/Models/DataModel.cs
+++ b/Google.Api.Generator.Rest/Models/DataModel.cs
@@ -109,11 +109,9 @@ namespace Google.Api.Generator.Rest.Models
             var cls = Class(Modifier.Public, Typ, Parent is null ? new[] { ctx.Type<IDirectResponseSchema>() } : Array.Empty<TypeSyntax>());
             using (ctx.InClass(Typ))
             {
-                if (_schema.Description is string description)
-                {
-                    cls = cls.WithXmlDoc(XmlDoc.Summary(description));
-                }
-                cls = cls.AddMembers(Properties.SelectMany(p => p.GeneratePropertyDeclarations(ctx)).ToArray());
+                cls = cls
+                    .MaybeWithXmlDoc(XmlDoc.MaybeSummary(_schema.Description))
+                    .AddMembers(Properties.SelectMany(p => p.GeneratePropertyDeclarations(ctx)).ToArray());
 
                 // Top-level data models automatically have an etag property if one isn't otherwise generated.
                 if (Parent is null && !Properties.Any(p => p.Name == "etag"))

--- a/Google.Api.Generator.Rest/Models/DataPropertyModel.cs
+++ b/Google.Api.Generator.Rest/Models/DataPropertyModel.cs
@@ -82,11 +82,8 @@ namespace Google.Api.Generator.Rest.Models
         {
             var propertyTyp = SchemaTypes.GetTypFromSchema(Parent.Package, _schema, Name, ctx.CurrentTyp, inParameter: false);
             var property = AutoProperty(Modifier.Public | Modifier.Virtual, ctx.Type(propertyTyp), PropertyName, hasSetter: true)
-                .WithAttribute(ctx.Type<JsonPropertyAttribute>())(Name);
-            if (_schema.Description is object)
-            {
-                property = property.WithXmlDoc(XmlDoc.Summary(_schema.Description));
-            }
+                .WithAttribute(ctx.Type<JsonPropertyAttribute>())(Name)
+                .MaybeWithXmlDoc(XmlDoc.MaybeSummary(_schema.Description));
             return new[] { property };
         }
 
@@ -100,11 +97,8 @@ namespace Google.Api.Generator.Rest.Models
             }
             // DateTime values generate three properties: one raw as a string, one DateTimeOffset version, and one (obsolete) DateTime version.
             var rawProperty = AutoProperty(Modifier.Public | Modifier.Virtual, ctx.Type<string>(), PropertyName + "Raw", hasSetter: true)
-                .WithAttribute(ctx.Type<JsonPropertyAttribute>())(Name);
-            if (_schema.Description is object)
-            {
-                rawProperty = rawProperty.WithXmlDoc(XmlDoc.Summary(_schema.Description));
-            }
+                .WithAttribute(ctx.Type<JsonPropertyAttribute>())(Name)
+                .MaybeWithXmlDoc(XmlDoc.MaybeSummary(_schema.Description));
             yield return rawProperty;
 
             var valueParameter = Parameter(ctx.Type<DateTimeOffset?>(), "value");
@@ -150,11 +144,8 @@ namespace Google.Api.Generator.Rest.Models
                 .WithSetBody(
                     objectField.Assign(ctx.Type(typeof(Utilities)).Call(nameof(Utilities.DeserializeForGoogleFormat))(valueParameter)),
                     rawField.Assign(valueParameter)
-                );
-            if (_schema.Description is object)
-            {
-                rawProperty = rawProperty.WithXmlDoc(XmlDoc.Summary(_schema.Description));
-            }
+                )
+                .MaybeWithXmlDoc(XmlDoc.MaybeSummary(_schema.Description));
 
             var dtoProperty = Property(Modifier.Public | Modifier.Virtual, ctx.Type<DateTimeOffset?>(), PropertyName + "DateTimeOffset")
                 .WithAttribute(ctx.Type<JsonIgnoreAttribute>())()

--- a/Google.Api.Generator.Rest/Models/EnumMemberModel.cs
+++ b/Google.Api.Generator.Rest/Models/EnumMemberModel.cs
@@ -53,15 +53,9 @@ namespace Google.Api.Generator.Rest.Models
             NumericValue = numericValue;
         }
 
-        public EnumMemberDeclarationSyntax GenerateDeclaration(SourceFileContext ctx)
-        {
-            var declaration = EnumMember(MemberName, NumericValue)
-                .WithAttribute(ctx.Type<StringValueAttribute>())(OriginalValue);
-            if (Description is object)
-            {
-                declaration = declaration.WithXmlDoc(XmlDoc.Summary(Description));
-            }
-            return declaration;
-        }
+        public EnumMemberDeclarationSyntax GenerateDeclaration(SourceFileContext ctx) =>
+            EnumMember(MemberName, NumericValue)
+                .WithAttribute(ctx.Type<StringValueAttribute>())(OriginalValue)
+                .MaybeWithXmlDoc(XmlDoc.MaybeSummary(Description));
     }
 }

--- a/Google.Api.Generator.Rest/Models/EnumModel.cs
+++ b/Google.Api.Generator.Rest/Models/EnumModel.cs
@@ -56,16 +56,9 @@ namespace Google.Api.Generator.Rest.Models
                 .ToReadOnlyList(pair => new EnumMemberModel(pair.text, pair.description, package.PackageEnumStorage.GetOrAddEnumValue(enumStorageKey, pair.text)));
         }
 
-        public EnumDeclarationSyntax GenerateDeclaration(SourceFileContext ctx)
-        {
-            var declaration = Enum(Modifier.Public, Typ.Nested(ctx.CurrentTyp, TypeName, isEnum: true))
-                (Members.Select(m => m.GenerateDeclaration(ctx)).ToArray());
-
-            if (Description is string description)
-            {
-                declaration = declaration.WithXmlDoc(XmlDoc.Summary(description));
-            }
-            return declaration;
-        }
+        public EnumDeclarationSyntax GenerateDeclaration(SourceFileContext ctx) =>
+            Enum(Modifier.Public, Typ.Nested(ctx.CurrentTyp, TypeName, isEnum: true))
+                (Members.Select(m => m.GenerateDeclaration(ctx)).ToArray())
+                .MaybeWithXmlDoc(XmlDoc.MaybeSummary(Description));
     }
 }

--- a/Google.Api.Generator.Rest/Models/MethodModel.cs
+++ b/Google.Api.Generator.Rest/Models/MethodModel.cs
@@ -122,11 +122,8 @@ namespace Google.Api.Generator.Rest.Models
         private ClassDeclarationSyntax GenerateRequestType(SourceFileContext ctx)
         {
             var baseType = ctx.Type(Typ.Generic(Package.GenericBaseRequestTypDef, ResponseTyp));
-            var cls = Class(Modifier.Public, RequestTyp, baseType);
-            if (_restMethod.Description is object)
-            {
-                cls = cls.WithXmlDoc(XmlDoc.Summary(_restMethod.Description));
-            }
+            var cls = Class(Modifier.Public, RequestTyp, baseType)
+                .MaybeWithXmlDoc(XmlDoc.MaybeSummary(_restMethod.Description));
 
             using (ctx.InClass(RequestTyp))
             {

--- a/Google.Api.Generator.Rest/Models/ParameterModel.cs
+++ b/Google.Api.Generator.Rest/Models/ParameterModel.cs
@@ -173,11 +173,8 @@ namespace Google.Api.Generator.Rest.Models
             // The DateTimeOffset and string properties are slightly awkward, as we need to reference the raw property from the getters and setters of the DTO,
             // but we refer to the DTO property from the raw property's XML doc.
             var rawProperty = AutoProperty(Modifier.Public | Modifier.Virtual, ctx.Type<string>(), PropertyName + "Raw", hasSetter: true, setterIsPrivate: true)
-                .WithAttribute(ctx.Type<RequestParameterAttribute>())(Name, locationExpression);
-            if (_schema.Description is object)
-            {
-                rawProperty = rawProperty.WithXmlDoc(XmlDoc.Summary(_schema.Description));
-            }
+                .WithAttribute(ctx.Type<RequestParameterAttribute>())(Name, locationExpression)
+                .MaybeWithXmlDoc(XmlDoc.MaybeSummary(_schema.Description));
 
             var dtoProperty = Property(Modifier.Public | Modifier.Virtual, ctx.Type(typeof(DateTimeOffset?)), PropertyName + "DateTimeOffset")
                 .WithGetBody(Return(ctx.Type(typeof(DiscoveryFormat)).Call(nameof(DiscoveryFormat.ParseDateTimeToDateTimeOffset))(rawProperty)))
@@ -231,10 +228,6 @@ namespace Google.Api.Generator.Rest.Models
                     rawProperty.Assign(ctx.Type(typeof(DiscoveryFormat)).Call(nameof(DiscoveryFormat.FormatDateTimeOffsetToGoogleDateTime))(valueParameter)),
                     objectField.Assign(valueParameter)
                 );
-            if (_schema.Description is object)
-            {
-                //dtoProperty = dtoProperty.WithXmlDoc(XmlDoc.Summary(_schema.Description));
-            }
             rawProperty = rawProperty.WithXmlDoc(XmlDoc.Summary("String representation of ", dtoProperty, ", formatted for inclusion in the HTTP request."));
 
             var objectProperty = Property(Modifier.Public | Modifier.Virtual, ctx.Type<object>(), PropertyName)

--- a/Google.Api.Generator.Utils/Roslyn/RoslynExtensions.cs
+++ b/Google.Api.Generator.Utils/Roslyn/RoslynExtensions.cs
@@ -44,6 +44,9 @@ namespace Google.Api.Generator.Utils.Roslyn
             ? token.WithTrailingTrivia(triv.Concat(token.TrailingTrivia))
             : token.WithTrailingTrivia(triv);
 
+        public static T MaybeWithXmlDoc<T>(this T node, DocumentationCommentTriviaSyntax xmlDoc) where T : SyntaxNode =>
+            xmlDoc is null ? node : node.WithLeadingTrivia(Trivia(xmlDoc));
+
         public static T WithXmlDoc<T>(this T node, params DocumentationCommentTriviaSyntax[] xmlDoc) where T : SyntaxNode =>
             node.WithLeadingTrivia(xmlDoc.Select(Trivia));
 

--- a/Google.Api.Generator.Utils/Roslyn/XmlDoc.cs
+++ b/Google.Api.Generator.Utils/Roslyn/XmlDoc.cs
@@ -73,6 +73,7 @@ namespace Google.Api.Generator.Utils.Roslyn
         private static DocumentationCommentTriviaSyntax XmlDocElement<T>(IEnumerable<object> parts, Func<XmlNodeSyntax[], T> fn) where T : XmlNodeSyntax =>
             DocumentationCommentTrivia(SyntaxKind.SingleLineDocumentationCommentTrivia, SingletonList<XmlNodeSyntax>(fn(parts.Select(ToNode).ToArray())));
 
+        public static DocumentationCommentTriviaSyntax MaybeSummary(object part) => part is null ? null : Summary(part);
         public static DocumentationCommentTriviaSyntax Summary(params object[] parts) => XmlDocElement(parts, XmlSummaryElement);
         public static DocumentationCommentTriviaSyntax SummaryPreFormatted(IEnumerable<string> lines) => Summary(lines.ToArray()).WithAdditionalAnnotations(Annotations.Preformatted);
         public static DocumentationCommentTriviaSyntax Remarks(params object[] parts) => XmlDocElement(parts, XmlRemarksElement);


### PR DESCRIPTION
This allows us to avoid `if` statements where we may not have a summary. I believe this is only currently useful in the REST generator.

Fixes #706.

I'm currently regenerating everything in google-api-dotnet-client to validate that it's a no-op change.