### PR TITLE
feat: Validate the choice of paginated resource field

### DIFF
--- a/Google.Api.Generator.Tests/ProtoTests/Paginated/Paginated.proto
+++ b/Google.Api.Generator.Tests/ProtoTests/Paginated/Paginated.proto
@@ -39,8 +39,10 @@ message Request {
 message Response {
   message NestedResult { }
   string next_page_token = 1;
-  repeated int32 not_results = 2; // primitive fields are not valid resource candidates.
-  repeated NestedResult results = 3; // First non-primitive (msg|string) field by order and number.
+  // Note: previously results came after not_results, but that failed newer validation.
+  // (We want to fail if we get odd input like that.)
+  repeated NestedResult results = 2; // First non-primitive (msg|string) field by order and number.
+  repeated int32 not_results = 3; // Primitive fields are not valid resource candidates.
   repeated string also_not_results = 4; // Non-first field not the resource.
 }
 

--- a/Google.Api.Generator/Generation/MethodDetails.cs
+++ b/Google.Api.Generator/Generation/MethodDetails.cs
@@ -60,6 +60,15 @@ namespace Google.Api.Generator.Generation
             public Paginated(ServiceDetails svc, MethodDescriptor desc,
                 FieldDescriptor responseResourceField, int pageSizeFieldNumber, int pageTokenFieldNumber) : base(svc, desc)
             {
+                // Possibly-temporary validation: the resource field should always be the lowest-numbered
+                // repeated field in the response message. This check can be removed if/when we receive
+                // pagination configuration via an annotation.
+                var lowestNumberedRepeatedField = responseResourceField.ContainingType.Fields.InFieldNumberOrder().FirstOrDefault(f => f.IsRepeated);
+                if (responseResourceField != lowestNumberedRepeatedField)
+                {
+                    throw new InvalidOperationException($"Error: field {responseResourceField.FullName} is not the lowest-numbered repeated field ({lowestNumberedRepeatedField?.FullName ?? "(None)"})");
+                }
+
                 ResourceTyp = ProtoTyp.Of(responseResourceField, forceRepeated: false);
                 // For map fields, ResourceTyp is a constructed KeyValuePair<,> type: we need the open type in a cref.
                 ResourceTypForCref = responseResourceField.IsMap
@@ -74,6 +83,7 @@ namespace Google.Api.Generator.Generation
                 PageSizeFieldNumber = pageSizeFieldNumber;
                 PageTokenFieldNumber = pageTokenFieldNumber;
             }
+
             public override Typ ApiCallTyp { get; }
             public override Typ SyncReturnTyp { get; }
             public override Typ AsyncReturnTyp { get; }


### PR DESCRIPTION
This check will potentially be removed later, if we get explicit configuration.

It's almost certainly "correct by construction" from all the conditions where we call the constructor, but it's handy to validate in a single location.

Fixes b/337763481.