### PR TITLE
feat: Order using directive aliases by alias rather than target

### DIFF
--- a/Google.Api.Generator.IntegrationTests/EchoTest.cs
+++ b/Google.Api.Generator.IntegrationTests/EchoTest.cs
@@ -57,7 +57,7 @@ namespace Google.Api.Generator.IntegrationTests
                 var client = CreateClient();
                 var stream = client.Expand(new ExpandRequest { Content = content });
                 var items = await stream.GetResponseStream().Select(resp => resp.Content).ToListAsync();
-                Assert.Equal(content, string.Join(" ", items));                
+                Assert.Equal(content, string.Join(" ", items));
             }
         }
     }

--- a/Google.Api.Generator.Rest.Tests/GeneratedCodeTest.cs
+++ b/Google.Api.Generator.Rest.Tests/GeneratedCodeTest.cs
@@ -54,7 +54,7 @@ public class GeneratedCodeTest
         bucket.TimeCreatedDateTimeOffset = new DateTimeOffset(2023, 6, 14, 12, 34, 45, 123, TimeSpan.Zero);
         AssertStorageBucketCreatedTimeProperties(bucket);
         Assert.Equal("2023-06-14T12:34:45.123Z", bucket.TimeCreatedRaw);
-        Assert.Equal(new DateTime(2023, 6, 14, 12, 34, 45, 123, DateTimeKind.Utc).ToLocalTime(), bucket.TimeCreated);        
+        Assert.Equal(new DateTime(2023, 6, 14, 12, 34, 45, 123, DateTimeKind.Utc).ToLocalTime(), bucket.TimeCreated);
     }
 
     [Fact]

--- a/Google.Api.Generator.Rest/Lists.cs
+++ b/Google.Api.Generator.Rest/Lists.cs
@@ -15,7 +15,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace Google.Api.Generator.Rest
 {

--- a/Google.Api.Generator.Rest/Models/DataModel.cs
+++ b/Google.Api.Generator.Rest/Models/DataModel.cs
@@ -96,7 +96,7 @@ namespace Google.Api.Generator.Rest.Models
             }
             if (_schema.AdditionalProperties is object)
             {
-                ret = SchemaTypes.GetTypFromAdditionalProperties(Package, _schema.AdditionalProperties, Name, ret, inParameter: false);                
+                ret = SchemaTypes.GetTypFromAdditionalProperties(Package, _schema.AdditionalProperties, Name, ret, inParameter: false);
             }
             return ret;
         }

--- a/Google.Api.Generator.Rest/Models/DataPropertyModel.cs
+++ b/Google.Api.Generator.Rest/Models/DataPropertyModel.cs
@@ -40,7 +40,7 @@ namespace Google.Api.Generator.Rest.Models
         /// The name in the discovery doc
         /// </summary>
         public string Name { get; }
-        
+
         /// <summary>
         /// The name in the C# code.
         /// </summary>

--- a/Google.Api.Generator.Rest/Models/ParameterModel.cs
+++ b/Google.Api.Generator.Rest/Models/ParameterModel.cs
@@ -107,7 +107,7 @@ namespace Google.Api.Generator.Rest.Models
             Typ = SchemaTypes.GetTypFromSchema(package, schema, name, currentTyp: parentTyp, inParameter: true);
 
             // Some validation for things that are theoretically feasible, but not currently supported.
-            if (IsRequired)                
+            if (IsRequired)
             {
                 if (schema.Format is string format && (format.StartsWith("google-", StringComparison.Ordinal) || format == "date-time"))
                 {

--- a/Google.Api.Generator.Rest/Models/ResourceModel.cs
+++ b/Google.Api.Generator.Rest/Models/ResourceModel.cs
@@ -60,7 +60,7 @@ namespace Google.Api.Generator.Rest.Models
             Methods = discoveryResource.Methods.ToReadOnlyList(pair => new MethodModel(package, this, pair.Key, pair.Value));
         }
 
-        public PropertyDeclarationSyntax GenerateProperty(SourceFileContext ctx) => 
+        public PropertyDeclarationSyntax GenerateProperty(SourceFileContext ctx) =>
             AutoProperty(Modifier.Public | Modifier.Virtual, ctx.Type(Typ), PropertyName)
                 .WithXmlDoc(XmlDoc.Summary($"Gets the {PropertyName} resource."));
 

--- a/Google.Api.Generator.Rest/Program.cs
+++ b/Google.Api.Generator.Rest/Program.cs
@@ -39,7 +39,7 @@ namespace Google.Api.Generator.Rest
             string json = File.ReadAllText(args[0]);
             string outputDirectory = args[1];
             string featuresJson = File.ReadAllText(args[2]);
-            
+
             string enumStorageFile = args[3];
             string enumStorageJson = File.Exists(enumStorageFile) ? File.ReadAllText(enumStorageFile) : "{}";
             var enumStorage = PackageEnumStorage.FromJson(enumStorageJson);

--- a/Google.Api.Generator.Tests/Invoker.cs
+++ b/Google.Api.Generator.Tests/Invoker.cs
@@ -92,7 +92,7 @@ namespace Google.Api.Generator.Tests
                 process.OutputDataReceived += handler;
                 process.BeginErrorReadLine();
                 process.BeginOutputReadLine();
-                var exited = process.WaitForExit((int)timeout.TotalMilliseconds);
+                var exited = process.WaitForExit((int) timeout.TotalMilliseconds);
 
                 // Avoid any extra data being added to our output while we're processing assertions.
                 process.ErrorDataReceived -= handler;

--- a/Google.Api.Generator.Tests/ProtoTest.cs
+++ b/Google.Api.Generator.Tests/ProtoTest.cs
@@ -166,7 +166,7 @@ namespace Google.Api.Generator.Tests
         {
             string sourceDir = testProtoNames.First();
             var protoPaths = testProtoNames.Select(x => Path.Combine("ProtoTests", sourceDir, $"{x}.proto"));
-            string package =  $"testing.{sourceDir.ToLowerInvariant()}";
+            string package = $"testing.{sourceDir.ToLowerInvariant()}";
 
             if (serviceConfigPath is string)
             {

--- a/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1/BasicClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1/BasicClient.g.cs
@@ -17,15 +17,15 @@
 #pragma warning disable CS8981
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
 using mel = Microsoft.Extensions.Logging;
-using sys = System;
+using proto = Google.Protobuf;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
 using st = System.Threading;
 using stt = System.Threading.Tasks;
+using sys = System;
 
 namespace Testing.Basic.V1
 {

--- a/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1/ServiceCollectionExtensions.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1/ServiceCollectionExtensions.g.cs
@@ -17,8 +17,8 @@
 #pragma warning disable CS8981
 using gaxgrpc = Google.Api.Gax.Grpc;
 using gpr = Google.Protobuf.Reflection;
-using sys = System;
 using scg = System.Collections.Generic;
+using sys = System;
 using tbv = Testing.Basic.V1;
 
 namespace Microsoft.Extensions.DependencyInjection

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated/DeprecatedClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated/DeprecatedClient.g.cs
@@ -17,15 +17,15 @@
 #pragma warning disable CS8981
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
 using mel = Microsoft.Extensions.Logging;
-using sys = System;
+using proto = Google.Protobuf;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
 using st = System.Threading;
 using stt = System.Threading.Tasks;
+using sys = System;
 
 namespace Testing.Deprecated
 {

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated/DeprecatedServiceClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated/DeprecatedServiceClient.g.cs
@@ -17,15 +17,15 @@
 #pragma warning disable CS8981
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
 using mel = Microsoft.Extensions.Logging;
-using sys = System;
+using proto = Google.Protobuf;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
 using st = System.Threading;
 using stt = System.Threading.Tasks;
+using sys = System;
 
 namespace Testing.Deprecated
 {

--- a/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated/ServiceCollectionExtensions.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Deprecated/Testing.Deprecated/ServiceCollectionExtensions.g.cs
@@ -17,8 +17,8 @@
 #pragma warning disable CS8981
 using gaxgrpc = Google.Api.Gax.Grpc;
 using gpr = Google.Protobuf.Reflection;
-using sys = System;
 using scg = System.Collections.Generic;
+using sys = System;
 using td = Testing.Deprecated;
 
 namespace Microsoft.Extensions.DependencyInjection

--- a/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords/KeywordsClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Keywords/Testing.Keywords/KeywordsClient.g.cs
@@ -17,15 +17,15 @@
 #pragma warning disable CS8981
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
 using mel = Microsoft.Extensions.Logging;
-using sys = System;
+using proto = Google.Protobuf;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
 using st = System.Threading;
 using stt = System.Threading.Tasks;
+using sys = System;
 
 namespace Testing.Keywords
 {

--- a/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro/LroFakes.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro/LroFakes.cs
@@ -42,7 +42,8 @@ namespace Testing.Lro
         public string Name { get; set; }
     }
 
-    public class LroResponse : ProtoMsgFake<LroResponse> {
+    public class LroResponse : ProtoMsgFake<LroResponse>
+    {
         public class Types
         {
             public class Nested : ProtoMsgFake<Nested> { }

--- a/Google.Api.Generator.Tests/ProtoTests/MethodSignatures/MethodSignaturesFakes.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/MethodSignatures/MethodSignaturesFakes.cs
@@ -17,7 +17,6 @@ using Google.Protobuf.Collections;
 using Google.Protobuf.Reflection;
 using Grpc.Core;
 using System;
-using System.Collections.Generic;
 
 namespace Testing.MethodSignatures
 {

--- a/Google.Api.Generator.Tests/ProtoTests/MethodSignatures/Testing.MethodSignatures/MethodSignaturesClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/MethodSignatures/Testing.MethodSignatures/MethodSignaturesClient.g.cs
@@ -17,16 +17,16 @@
 #pragma warning disable CS8981
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
+using linq = System.Linq;
 using mel = Microsoft.Extensions.Logging;
-using sys = System;
+using proto = Google.Protobuf;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
-using linq = System.Linq;
 using st = System.Threading;
 using stt = System.Threading.Tasks;
+using sys = System;
 
 namespace Testing.MethodSignatures
 {

--- a/Google.Api.Generator.Tests/ProtoTests/Mixins/Testing.Mixins/MixinFakes.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Mixins/Testing.Mixins/MixinFakes.cs
@@ -14,7 +14,6 @@
 
 #pragma warning disable CS8981
 using Google.Protobuf.Reflection;
-using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using System;
 
@@ -46,7 +45,7 @@ namespace Testing.Mixins
             public MixinServiceClient(CallInvoker callInvoker) { }
             private CallInvoker CallInvoker => throw new NotImplementedException();
             public virtual AsyncUnaryCall<Response> MethodAsync(Request request, CallOptions options) => throw new NotImplementedException();
-            public virtual Response Method(Request request, CallOptions options) => throw new NotImplementedException();            
+            public virtual Response Method(Request request, CallOptions options) => throw new NotImplementedException();
         }
     }
 

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/PublishingSettingsFakes.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/PublishingSettingsFakes.cs
@@ -100,7 +100,7 @@ public partial class ServiceWithMethodSettings
         public virtual AsyncUnaryCall<Response> UnaryAutoPopulatedAsync(Request request, CallOptions options) => throw new NotImplementedException();
         public virtual Response UnaryAutoPopulated(Request request, CallOptions options) => throw new NotImplementedException();
         public virtual AsyncServerStreamingCall<Response> ServerStreamingAutoPopulated(Request request, CallOptions options) => throw new NotImplementedException();
-        public virtual AsyncClientStreamingCall<Request,Response> ClientStreamingAutoPopulated(CallOptions options) => throw new NotImplementedException();
+        public virtual AsyncClientStreamingCall<Request, Response> ClientStreamingAutoPopulated(CallOptions options) => throw new NotImplementedException();
         public virtual AsyncDuplexStreamingCall<Request, Response> BidiStreamingAutoPopulated(CallOptions options) => throw new NotImplementedException();
         public virtual AsyncUnaryCall<Operation> LroAutoPopulatedAsync(Request request, CallOptions options) => throw new NotImplementedException();
         public virtual Operation LroAutoPopulated(Request request, CallOptions options) => throw new NotImplementedException();
@@ -146,7 +146,7 @@ public partial class PaginatedRequest : ProtoMsgFake<PaginatedRequest>
 public partial class PaginatedResponse : ProtoMsgFake<PaginatedResponse>
 {
     public string NextPageToken { get; set; }
-    public RepeatedField<Response> Responses{ get; }
+    public RepeatedField<Response> Responses { get; }
 }
 
 public partial class ResourceRequest : ProtoMsgFake<ResourceRequest>

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/PackageApiMetadata.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/PackageApiMetadata.g.cs
@@ -16,8 +16,8 @@
 
 #pragma warning disable CS8981
 using gaxgrpc = Google.Api.Gax.Grpc;
-using lro = Google.LongRunning;
 using gpr = Google.Protobuf.Reflection;
+using lro = Google.LongRunning;
 using scg = System.Collections.Generic;
 
 namespace Testing.PublishingSettings

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/RenamedServiceNameClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/RenamedServiceNameClient.g.cs
@@ -17,15 +17,15 @@
 #pragma warning disable CS8981
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
 using mel = Microsoft.Extensions.Logging;
-using sys = System;
+using proto = Google.Protobuf;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
 using st = System.Threading;
 using stt = System.Threading.Tasks;
+using sys = System;
 
 namespace Testing.PublishingSettings
 {

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceCollectionExtensions.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceCollectionExtensions.g.cs
@@ -16,10 +16,10 @@
 
 #pragma warning disable CS8981
 using gaxgrpc = Google.Api.Gax.Grpc;
-using lro = Google.LongRunning;
 using gpr = Google.Protobuf.Reflection;
-using sys = System;
+using lro = Google.LongRunning;
 using scg = System.Collections.Generic;
+using sys = System;
 using tp = Testing.PublishingSettings;
 
 namespace Microsoft.Extensions.DependencyInjection

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithApiVersionClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithApiVersionClient.g.cs
@@ -17,15 +17,15 @@
 #pragma warning disable CS8981
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
 using mel = Microsoft.Extensions.Logging;
-using sys = System;
+using proto = Google.Protobuf;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
 using st = System.Threading;
 using stt = System.Threading.Tasks;
+using sys = System;
 
 namespace Testing.PublishingSettings
 {

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithHandwrittenSignaturesClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithHandwrittenSignaturesClient.g.cs
@@ -17,15 +17,15 @@
 #pragma warning disable CS8981
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
 using mel = Microsoft.Extensions.Logging;
-using sys = System;
+using proto = Google.Protobuf;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
 using st = System.Threading;
 using stt = System.Threading.Tasks;
+using sys = System;
 
 namespace Testing.PublishingSettings
 {

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithMethodSettingsClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithMethodSettingsClient.g.cs
@@ -17,17 +17,17 @@
 #pragma warning disable CS8981
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using lro = Google.LongRunning;
-using proto = Google.Protobuf;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
+using lro = Google.LongRunning;
 using mel = Microsoft.Extensions.Logging;
-using sys = System;
+using proto = Google.Protobuf;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
 using st = System.Threading;
 using stt = System.Threading.Tasks;
+using sys = System;
 
 namespace Testing.PublishingSettings
 {

--- a/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithResourcesClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/PublishingSettings/Testing.PublishingSettings/ServiceWithResourcesClient.g.cs
@@ -17,15 +17,15 @@
 #pragma warning disable CS8981
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
 using mel = Microsoft.Extensions.Logging;
-using sys = System;
+using proto = Google.Protobuf;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
 using st = System.Threading;
 using stt = System.Threading.Tasks;
+using sys = System;
 
 namespace Testing.PublishingSettings
 {

--- a/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames/ResourceNamesClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/ResourceNames/Testing.ResourceNames/ResourceNamesClient.g.cs
@@ -17,16 +17,16 @@
 #pragma warning disable CS8981
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using proto = Google.Protobuf;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
+using linq = System.Linq;
 using mel = Microsoft.Extensions.Logging;
-using sys = System;
+using proto = Google.Protobuf;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
-using linq = System.Linq;
 using st = System.Threading;
 using stt = System.Threading.Tasks;
+using sys = System;
 
 namespace Testing.ResourceNames
 {

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/ComplianceClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/ComplianceClient.g.cs
@@ -19,15 +19,15 @@ using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
 using gciv = Google.Cloud.Iam.V1;
 using gcl = Google.Cloud.Location;
-using proto = Google.Protobuf;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
 using mel = Microsoft.Extensions.Logging;
-using sys = System;
+using proto = Google.Protobuf;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
 using st = System.Threading;
 using stt = System.Threading.Tasks;
+using sys = System;
 
 namespace Google.Showcase.V1Beta1
 {

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/EchoClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/EchoClient.g.cs
@@ -19,19 +19,19 @@ using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
 using gciv = Google.Cloud.Iam.V1;
 using gcl = Google.Cloud.Location;
-using lro = Google.LongRunning;
-using proto = Google.Protobuf;
 using gr = Google.Rpc;
-using gsv = Google.Showcase.V1Beta1;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
+using gsv = Google.Showcase.V1Beta1;
+using lro = Google.LongRunning;
 using mel = Microsoft.Extensions.Logging;
-using sys = System;
+using proto = Google.Protobuf;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
 using st = System.Threading;
 using stt = System.Threading.Tasks;
+using sys = System;
 
 namespace Google.Showcase.V1Beta1
 {

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/IdentityClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/IdentityClient.g.cs
@@ -19,17 +19,17 @@ using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
 using gciv = Google.Cloud.Iam.V1;
 using gcl = Google.Cloud.Location;
-using proto = Google.Protobuf;
-using wkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
 using mel = Microsoft.Extensions.Logging;
-using sys = System;
+using proto = Google.Protobuf;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
 using st = System.Threading;
 using stt = System.Threading.Tasks;
+using sys = System;
+using wkt = Google.Protobuf.WellKnownTypes;
 
 namespace Google.Showcase.V1Beta1
 {

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/MessagingClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/MessagingClient.g.cs
@@ -19,18 +19,18 @@ using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
 using gciv = Google.Cloud.Iam.V1;
 using gcl = Google.Cloud.Location;
-using lro = Google.LongRunning;
-using proto = Google.Protobuf;
-using wkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
+using lro = Google.LongRunning;
 using mel = Microsoft.Extensions.Logging;
-using sys = System;
+using proto = Google.Protobuf;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
 using st = System.Threading;
 using stt = System.Threading.Tasks;
+using sys = System;
+using wkt = Google.Protobuf.WellKnownTypes;
 
 namespace Google.Showcase.V1Beta1
 {

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/PackageApiMetadata.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/PackageApiMetadata.g.cs
@@ -18,9 +18,9 @@
 using gaxgrpc = Google.Api.Gax.Grpc;
 using gciv = Google.Cloud.Iam.V1;
 using gcl = Google.Cloud.Location;
+using gpr = Google.Protobuf.Reflection;
 using lro = Google.LongRunning;
 using proto = Google.Protobuf;
-using gpr = Google.Protobuf.Reflection;
 using scg = System.Collections.Generic;
 
 namespace Google.Showcase.V1Beta1

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/SequenceServiceClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/SequenceServiceClient.g.cs
@@ -19,16 +19,16 @@ using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
 using gciv = Google.Cloud.Iam.V1;
 using gcl = Google.Cloud.Location;
-using proto = Google.Protobuf;
-using wkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
 using mel = Microsoft.Extensions.Logging;
-using sys = System;
+using proto = Google.Protobuf;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
 using st = System.Threading;
 using stt = System.Threading.Tasks;
+using sys = System;
+using wkt = Google.Protobuf.WellKnownTypes;
 
 namespace Google.Showcase.V1Beta1
 {

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -18,12 +18,12 @@
 using gaxgrpc = Google.Api.Gax.Grpc;
 using gciv = Google.Cloud.Iam.V1;
 using gcl = Google.Cloud.Location;
-using lro = Google.LongRunning;
-using proto = Google.Protobuf;
 using gpr = Google.Protobuf.Reflection;
 using gsv = Google.Showcase.V1Beta1;
-using sys = System;
+using lro = Google.LongRunning;
+using proto = Google.Protobuf;
 using scg = System.Collections.Generic;
+using sys = System;
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/TestingClient.g.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/TestingClient.g.cs
@@ -19,17 +19,17 @@ using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
 using gciv = Google.Cloud.Iam.V1;
 using gcl = Google.Cloud.Location;
-using proto = Google.Protobuf;
-using wkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;
 using grpcinter = Grpc.Core.Interceptors;
 using mel = Microsoft.Extensions.Logging;
-using sys = System;
+using proto = Google.Protobuf;
 using sc = System.Collections;
 using scg = System.Collections.Generic;
 using sco = System.Collections.ObjectModel;
 using st = System.Threading;
 using stt = System.Threading.Tasks;
+using sys = System;
+using wkt = Google.Protobuf.WellKnownTypes;
 
 namespace Google.Showcase.V1Beta1
 {

--- a/Google.Api.Generator.Tests/ProtoTests/Snippets/SnippetsClientFakes.cs
+++ b/Google.Api.Generator.Tests/ProtoTests/Snippets/SnippetsClientFakes.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
 using Google.LongRunning;
 using Google.Protobuf;

--- a/Google.Api.Generator.Utils.Tests/Formatting/WhitespaceFormatterTest.cs
+++ b/Google.Api.Generator.Utils.Tests/Formatting/WhitespaceFormatterTest.cs
@@ -348,7 +348,7 @@ namespace Google.Api.Generator.Utils.Formatting.Tests
         {
             var utilTestDir = Path.Combine(PathUtils.GetRepoRoot(), "Google.Api.Generator.Utils.Tests");
             return Path.Combine(utilTestDir, "Formatting", Path.GetFileName(filePath));
-        }            
+        }
 
         [Fact]
         public void ThisSourceFile()
@@ -359,7 +359,7 @@ namespace Google.Api.Generator.Utils.Formatting.Tests
             {
                 var ignoring =
                     line.Trim() == "// TEST_SOURCE_END" ? true :
-                    line.Trim() == "// TEST_SOURCE_START" ? false : (bool?)null;
+                    line.Trim() == "// TEST_SOURCE_START" ? false : (bool?) null;
                 if (!acc.ignoring && ignoring != true && !line.Trim().StartsWith("//"))
                 {
                     acc.lines.Add(line);

--- a/Google.Api.Generator.Utils.Tests/Formatting/XmlDocSplitterTest.cs
+++ b/Google.Api.Generator.Utils.Tests/Formatting/XmlDocSplitterTest.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Api.Generator.Utils.Formatting;
 using Google.Api.Generator.Utils.Roslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/Google.Api.Generator.Utils/Formatting/CodeFormatter.cs
+++ b/Google.Api.Generator.Utils/Formatting/CodeFormatter.cs
@@ -21,7 +21,7 @@ namespace Google.Api.Generator.Utils.Formatting
         public static CompilationUnitSyntax Format(CompilationUnitSyntax code)
         {
             var whitespace = new WhitespaceFormatter(maxLineLength: 120);
-            code = (CompilationUnitSyntax)whitespace.Visit(code);
+            code = (CompilationUnitSyntax) whitespace.Visit(code);
             code = PragmaWarningFormatter.Visit(code);
             // TODO: Line length formatting
             return code;

--- a/Google.Api.Generator.Utils/Formatting/PragmaWarningFormatter.cs
+++ b/Google.Api.Generator.Utils/Formatting/PragmaWarningFormatter.cs
@@ -31,7 +31,7 @@ namespace Google.Api.Generator.Utils.Formatting
 
             public override SyntaxNode VisitPragmaWarningDirectiveTrivia(PragmaWarningDirectiveTriviaSyntax node)
             {
-                node = (PragmaWarningDirectiveTriviaSyntax)base.VisitPragmaWarningDirectiveTrivia(node);
+                node = (PragmaWarningDirectiveTriviaSyntax) base.VisitPragmaWarningDirectiveTrivia(node);
                 node = node.WithPragmaKeyword(node.PragmaKeyword.WithTrailingTrivia(Space));
                 node = node.WithWarningKeyword(node.WarningKeyword.WithTrailingTrivia(Space));
                 node = node.WithDisableOrRestoreKeyword(node.DisableOrRestoreKeyword.WithTrailingTrivia(Space));
@@ -126,7 +126,7 @@ namespace Google.Api.Generator.Utils.Formatting
             }
             modifyPrevEol();
             code = code.ReplaceTokens(modifications.Keys, (orgtoken, _) => modifications[orgtoken]);
-            code = (CompilationUnitSyntax)new PragmaVisitor().Visit(code);
+            code = (CompilationUnitSyntax) new PragmaVisitor().Visit(code);
             return code;
         }
     }

--- a/Google.Api.Generator.Utils/Formatting/WhitespaceFormatter.cs
+++ b/Google.Api.Generator.Utils/Formatting/WhitespaceFormatter.cs
@@ -246,7 +246,7 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitMethodDeclaration(MethodDeclarationSyntax node)
         {
-            node = (MethodDeclarationSyntax)base.VisitMethodDeclaration(node);
+            node = (MethodDeclarationSyntax) base.VisitMethodDeclaration(node);
             node = node.WithLeadingTrivia(FormatXmlDoc(node.GetLeadingTrivia()).Append(_indentTrivia));
             node = node.WithModifiers(TokenList(node.Modifiers.Select(m => m.WithTrailingSpace())));
             node = node.WithReturnType(node.ReturnType.WithTrailingSpace());
@@ -267,7 +267,7 @@ namespace Google.Api.Generator.Utils.Formatting
                 ? _previousIndentTrivia
                 : _indentTrivia;
 
-            node = (AttributeListSyntax)base.VisitAttributeList(node);
+            node = (AttributeListSyntax) base.VisitAttributeList(node);
             if (lineBreak)
             {
                 node = node.WithCloseBracketToken(node.CloseBracketToken.WithTrailingTrivia(NewLine, indentTrivia));
@@ -277,7 +277,7 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitOperatorDeclaration(OperatorDeclarationSyntax node)
         {
-            node = (OperatorDeclarationSyntax)base.VisitOperatorDeclaration(node);
+            node = (OperatorDeclarationSyntax) base.VisitOperatorDeclaration(node);
             node = node.WithLeadingTrivia(FormatXmlDoc(node.GetLeadingTrivia()).Append(_indentTrivia));
             node = node.WithModifiers(TokenList(node.Modifiers.Select(m => m.WithTrailingSpace())));
             node = node.WithReturnType(node.ReturnType.WithTrailingSpace());
@@ -287,7 +287,7 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitArgumentList(ArgumentListSyntax node)
         {
-            node = (ArgumentListSyntax)base.VisitArgumentList(node);
+            node = (ArgumentListSyntax) base.VisitArgumentList(node);
             node = node.WithArguments(SeparatedList(node.Arguments, CommaSpaces(node.Arguments.Count - 1)));
             return node;
         }
@@ -301,7 +301,7 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitArgument(ArgumentSyntax node)
         {
-            node = (ArgumentSyntax)base.VisitArgument(node);
+            node = (ArgumentSyntax) base.VisitArgument(node);
             if (node.RefKindKeyword != null)
             {
                 node = node.WithRefKindKeyword(node.RefKindKeyword.WithTrailingSpace());
@@ -311,14 +311,14 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitNameColon(NameColonSyntax node)
         {
-            node = (NameColonSyntax)base.VisitNameColon(node);
+            node = (NameColonSyntax) base.VisitNameColon(node);
             node = node.WithColonToken(node.ColonToken.WithTrailingSpace());
             return node;
         }
 
         public override SyntaxNode VisitParameter(ParameterSyntax node)
         {
-            node = (ParameterSyntax)base.VisitParameter(node);
+            node = (ParameterSyntax) base.VisitParameter(node);
             if (node.Type != null)
             {
                 node = node.WithType(node.Type.WithTrailingSpace());
@@ -329,7 +329,7 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitParameterList(ParameterListSyntax node)
         {
-            node = (ParameterListSyntax)base.VisitParameterList(node);
+            node = (ParameterListSyntax) base.VisitParameterList(node);
             var separators = node.HasAnnotation(Annotations.LineBreakAnnotation)
                 ? CommaLineBreakIndents(node.Parameters.Count - 1)
                 : CommaSpaces(node.Parameters.Count - 1);
@@ -343,7 +343,7 @@ namespace Google.Api.Generator.Utils.Formatting
             var postTrivia = lineSplit ? TriviaList(NewLine, _indentTrivia, s_singleIndentTrivia) : TriviaList(Space);
             using (WithIndent(lineSplit))
             {
-                node = (ArrowExpressionClauseSyntax)base.VisitArrowExpressionClause(node);
+                node = (ArrowExpressionClauseSyntax) base.VisitArrowExpressionClause(node);
             }
             node = node.WithArrowToken(node.ArrowToken.WithLeadingSpace().WithTrailingTrivia(postTrivia));
             return node;
@@ -375,7 +375,7 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitAssignmentExpression(AssignmentExpressionSyntax node)
         {
-            node = (AssignmentExpressionSyntax)base.VisitAssignmentExpression(node);
+            node = (AssignmentExpressionSyntax) base.VisitAssignmentExpression(node);
             var noSpace = node.Right is InitializerExpressionSyntax initExpr && initExpr.Kind() == SyntaxKind.CollectionInitializerExpression;
             var operatorToken1 = noSpace ? node.OperatorToken.WithLeadingSpace() : node.OperatorToken.WithLeadingSpace().WithTrailingSpace();
             node = node.WithOperatorToken(operatorToken1);
@@ -384,14 +384,14 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitBinaryExpression(BinaryExpressionSyntax node)
         {
-            node = (BinaryExpressionSyntax)base.VisitBinaryExpression(node);
+            node = (BinaryExpressionSyntax) base.VisitBinaryExpression(node);
             node = node.WithOperatorToken(node.OperatorToken.WithLeadingSpace().WithTrailingSpace());
             return node;
         }
 
         public override SyntaxNode VisitFieldDeclaration(FieldDeclarationSyntax node)
         {
-            node = (FieldDeclarationSyntax)base.VisitFieldDeclaration(node);
+            node = (FieldDeclarationSyntax) base.VisitFieldDeclaration(node);
             node = node.WithLeadingTrivia(FormatXmlDoc(node.GetLeadingTrivia()).Append(_indentTrivia));
             node = node.WithModifiers(TokenList(node.Modifiers.Select(m => m.WithTrailingSpace())));
             return node;
@@ -399,21 +399,21 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitVariableDeclaration(VariableDeclarationSyntax node)
         {
-            node = (VariableDeclarationSyntax)base.VisitVariableDeclaration(node);
+            node = (VariableDeclarationSyntax) base.VisitVariableDeclaration(node);
             node = node.WithType(node.Type.WithTrailingSpace());
             return node;
         }
 
         public override SyntaxNode VisitEqualsValueClause(EqualsValueClauseSyntax node)
         {
-            node = (EqualsValueClauseSyntax)base.VisitEqualsValueClause(node);
+            node = (EqualsValueClauseSyntax) base.VisitEqualsValueClause(node);
             node = node.WithEqualsToken(node.EqualsToken.WithLeadingSpace().WithTrailingSpace());
             return node;
         }
 
         public override SyntaxNode VisitPropertyDeclaration(PropertyDeclarationSyntax node)
         {
-            node = (PropertyDeclarationSyntax)base.VisitPropertyDeclaration(node);
+            node = (PropertyDeclarationSyntax) base.VisitPropertyDeclaration(node);
             node = node.WithLeadingTrivia(FormatXmlDoc(node.GetLeadingTrivia()).Append(_indentTrivia));
             node = node.WithModifiers(TokenList(node.Modifiers.Select(m => m.WithTrailingSpace())));
             node = node.WithType(node.Type.WithTrailingSpace());
@@ -438,14 +438,14 @@ namespace Google.Api.Generator.Utils.Formatting
             {
                 using (WithIndent())
                 {
-                    node = (AccessorListSyntax)base.VisitAccessorList(node);
+                    node = (AccessorListSyntax) base.VisitAccessorList(node);
                 }
                 node = node.WithOpenBraceToken(node.OpenBraceToken.WithLeadingTrivia(NewLine, _indentTrivia).WithTrailingNewLine());
                 node = node.WithCloseBraceToken(node.CloseBraceToken.WithLeadingTrivia(_indentTrivia));
             }
             else
             {
-                node = (AccessorListSyntax)base.VisitAccessorList(node);
+                node = (AccessorListSyntax) base.VisitAccessorList(node);
                 node = node.WithOpenBraceToken(node.OpenBraceToken.WithLeadingSpace().WithTrailingSpace());
             }
             return node;
@@ -453,7 +453,7 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitAccessorDeclaration(AccessorDeclarationSyntax node)
         {
-            node = (AccessorDeclarationSyntax)base.VisitAccessorDeclaration(node);
+            node = (AccessorDeclarationSyntax) base.VisitAccessorDeclaration(node);
             if (node.Body != null)
             {
                 node = node.WithKeyword(node.Keyword.WithLeadingTrivia(_indentTrivia));
@@ -472,14 +472,14 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
         {
-            node = (ObjectCreationExpressionSyntax)base.VisitObjectCreationExpression(node);
+            node = (ObjectCreationExpressionSyntax) base.VisitObjectCreationExpression(node);
             node = node.WithNewKeyword(node.NewKeyword.WithTrailingSpace());
             return node;
         }
 
         public override SyntaxNode VisitArrayCreationExpression(ArrayCreationExpressionSyntax node)
         {
-            node = (ArrayCreationExpressionSyntax)base.VisitArrayCreationExpression(node);
+            node = (ArrayCreationExpressionSyntax) base.VisitArrayCreationExpression(node);
             node = node.WithNewKeyword(node.NewKeyword.WithTrailingSpace());
             return node;
         }
@@ -544,7 +544,7 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitReturnStatement(ReturnStatementSyntax node)
         {
-            node = (ReturnStatementSyntax)base.VisitReturnStatement(node);
+            node = (ReturnStatementSyntax) base.VisitReturnStatement(node);
             if (node.Expression != null)
             {
                 node = node.WithReturnKeyword(node.ReturnKeyword.WithTrailingSpace());
@@ -554,49 +554,49 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitAwaitExpression(AwaitExpressionSyntax node)
         {
-            node = (AwaitExpressionSyntax)base.VisitAwaitExpression(node);
+            node = (AwaitExpressionSyntax) base.VisitAwaitExpression(node);
             node = node.WithAwaitKeyword(node.AwaitKeyword.WithTrailingSpace());
             return node;
         }
 
         public override SyntaxNode VisitIfStatement(IfStatementSyntax node)
         {
-            node = (IfStatementSyntax)base.VisitIfStatement(node);
+            node = (IfStatementSyntax) base.VisitIfStatement(node);
             node = node.WithIfKeyword(node.IfKeyword.WithTrailingSpace());
             return node;
         }
 
         public override SyntaxNode VisitElseClause(ElseClauseSyntax node)
         {
-            node = (ElseClauseSyntax)base.VisitElseClause(node);
+            node = (ElseClauseSyntax) base.VisitElseClause(node);
             node = node.WithElseKeyword(node.ElseKeyword.WithLeadingTrivia(_indentTrivia));
             return node;
         }
 
         public override SyntaxNode VisitThrowStatement(ThrowStatementSyntax node)
         {
-            node = (ThrowStatementSyntax)base.VisitThrowStatement(node);
+            node = (ThrowStatementSyntax) base.VisitThrowStatement(node);
             node = node.WithThrowKeyword(node.ThrowKeyword.WithTrailingSpace());
             return node;
         }
 
         public override SyntaxNode VisitThrowExpression(ThrowExpressionSyntax node)
         {
-            node = (ThrowExpressionSyntax)base.VisitThrowExpression(node);
+            node = (ThrowExpressionSyntax) base.VisitThrowExpression(node);
             node = node.WithThrowKeyword(node.ThrowKeyword.WithTrailingSpace());
             return node;
         }
 
         public override SyntaxNode VisitTypeParameterList(TypeParameterListSyntax node)
         {
-            node = (TypeParameterListSyntax)base.VisitTypeParameterList(node);
+            node = (TypeParameterListSyntax) base.VisitTypeParameterList(node);
             node = node.WithParameters(SeparatedList(node.Parameters, CommaSpaces(node.Parameters.Count - 1)));
             return node;
         }
 
         public override SyntaxNode VisitTypeParameterConstraintClause(TypeParameterConstraintClauseSyntax node)
         {
-            node = (TypeParameterConstraintClauseSyntax)base.VisitTypeParameterConstraintClause(node);
+            node = (TypeParameterConstraintClauseSyntax) base.VisitTypeParameterConstraintClause(node);
             node = node.WithWhereKeyword(node.WhereKeyword.WithLeadingSpace().WithTrailingSpace());
             node = node.WithColonToken(node.ColonToken.WithLeadingSpace().WithTrailingSpace());
             node = node.WithConstraints(SeparatedList(node.Constraints, CommaSpaces(node.Constraints.Count - 1)));
@@ -605,14 +605,14 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitGenericName(GenericNameSyntax node)
         {
-            node = (GenericNameSyntax)base.VisitGenericName(node);
+            node = (GenericNameSyntax) base.VisitGenericName(node);
             node = node.WithTypeArgumentList(TypeArgumentList(SeparatedList(node.TypeArgumentList.Arguments, CommaSpaces(node.TypeArgumentList.Arguments.Count - 1))));
             return node;
         }
 
         public override SyntaxNode VisitConditionalExpression(ConditionalExpressionSyntax node)
         {
-            node = (ConditionalExpressionSyntax)base.VisitConditionalExpression(node);
+            node = (ConditionalExpressionSyntax) base.VisitConditionalExpression(node);
             node = node.WithQuestionToken(node.QuestionToken.WithLeadingSpace().WithTrailingSpace());
             node = node.WithColonToken(node.ColonToken.WithLeadingSpace().WithTrailingSpace());
             return node;
@@ -620,14 +620,14 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitDeclarationExpression(DeclarationExpressionSyntax node)
         {
-            node = (DeclarationExpressionSyntax)base.VisitDeclarationExpression(node);
+            node = (DeclarationExpressionSyntax) base.VisitDeclarationExpression(node);
             node = node.WithType(node.Type.WithTrailingSpace());
             return node;
         }
 
         public override SyntaxNode VisitSimpleLambdaExpression(SimpleLambdaExpressionSyntax node)
         {
-            node = (SimpleLambdaExpressionSyntax)base.VisitSimpleLambdaExpression(node);
+            node = (SimpleLambdaExpressionSyntax) base.VisitSimpleLambdaExpression(node);
             if (node.AsyncKeyword != null)
             {
                 node = node.WithAsyncKeyword(node.AsyncKeyword.WithTrailingSpace());
@@ -645,7 +645,7 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitParenthesizedLambdaExpression(ParenthesizedLambdaExpressionSyntax node)
         {
-            node = (ParenthesizedLambdaExpressionSyntax)base.VisitParenthesizedLambdaExpression(node);
+            node = (ParenthesizedLambdaExpressionSyntax) base.VisitParenthesizedLambdaExpression(node);
             if (node.AsyncKeyword != null)
             {
                 node = node.WithAsyncKeyword(node.AsyncKeyword.WithTrailingSpace());
@@ -663,7 +663,7 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitForEachStatement(ForEachStatementSyntax node)
         {
-            node = (ForEachStatementSyntax)base.VisitForEachStatement(node);
+            node = (ForEachStatementSyntax) base.VisitForEachStatement(node);
             node = node.WithForEachKeyword(node.ForEachKeyword.WithTrailingSpace());
             node = node.WithType(node.Type.WithTrailingSpace());
             node = node.WithInKeyword(node.InKeyword.WithLeadingSpace().WithTrailingSpace());
@@ -672,7 +672,7 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitForStatement(ForStatementSyntax node)
         {
-            node = (ForStatementSyntax)base.VisitForStatement(node);
+            node = (ForStatementSyntax) base.VisitForStatement(node);
             node = node.WithForKeyword(node.ForKeyword.WithTrailingSpace());
             node = node.WithFirstSemicolonToken(node.FirstSemicolonToken.WithTrailingSpace());
             node = node.WithSecondSemicolonToken(node.SecondSemicolonToken.WithTrailingSpace());
@@ -681,7 +681,7 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitWhileStatement(WhileStatementSyntax node)
         {
-            node = (WhileStatementSyntax)base.VisitWhileStatement(node);
+            node = (WhileStatementSyntax) base.VisitWhileStatement(node);
             node = node.WithWhileKeyword(node.WhileKeyword.WithTrailingSpace());
             return node;
         }
@@ -690,7 +690,7 @@ namespace Google.Api.Generator.Utils.Formatting
         {
             using (WithIndent())
             {
-                node = (EnumDeclarationSyntax)base.VisitEnumDeclaration(node);
+                node = (EnumDeclarationSyntax) base.VisitEnumDeclaration(node);
             }
             node = node.WithLeadingTrivia(FormatXmlDoc(node.GetLeadingTrivia()).Append(_indentTrivia));
             node = node.WithModifiers(TokenList(node.Modifiers.Select(m => m.WithTrailingSpace())));
@@ -710,7 +710,7 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitEnumMemberDeclaration(EnumMemberDeclarationSyntax node)
         {
-            node = (EnumMemberDeclarationSyntax)base.VisitEnumMemberDeclaration(node);
+            node = (EnumMemberDeclarationSyntax) base.VisitEnumMemberDeclaration(node);
             node = node.WithLeadingTrivia(FormatXmlDoc(node.GetLeadingTrivia()).Append(_indentTrivia));
             return node;
         }
@@ -719,7 +719,7 @@ namespace Google.Api.Generator.Utils.Formatting
         {
             using (WithIndent())
             {
-                node = (SwitchStatementSyntax)base.VisitSwitchStatement(node);
+                node = (SwitchStatementSyntax) base.VisitSwitchStatement(node);
             }
             node = node.WithSwitchKeyword(node.SwitchKeyword.WithTrailingSpace());
             node = node.WithCloseParenToken(node.CloseParenToken.WithTrailingNewLine());
@@ -730,7 +730,7 @@ namespace Google.Api.Generator.Utils.Formatting
 
         public override SyntaxNode VisitSwitchSection(SwitchSectionSyntax node)
         {
-            node = (SwitchSectionSyntax)base.VisitSwitchSection(node);
+            node = (SwitchSectionSyntax) base.VisitSwitchSection(node);
             var label = node.Labels.Single();
             var keywordTrailingTriv = label is DefaultSwitchLabelSyntax ? new SyntaxTrivia[] { } : new[] { Space };
             if (node.Statements.Count == 1)

--- a/Google.Api.Generator.Utils/Roslyn/RoslynBuilder.cs
+++ b/Google.Api.Generator.Utils/Roslyn/RoslynBuilder.cs
@@ -333,7 +333,7 @@ namespace Google.Api.Generator.Utils.Roslyn
 
         public static CheckedExpressionSyntax CheckedCast(TypeSyntax type, ExpressionSyntax expr) => CheckedExpression(SyntaxKind.CheckedExpression, CastExpression(type, expr));
 
-        public static CheckedExpressionSyntax CheckedCast(TypeSyntax type, PropertyDeclarationSyntax expr) =>  CheckedCast(type, IdentifierName(expr.Identifier));
+        public static CheckedExpressionSyntax CheckedCast(TypeSyntax type, PropertyDeclarationSyntax expr) => CheckedCast(type, IdentifierName(expr.Identifier));
 
         public static ArgumentsFunc<InvocationExpressionSyntax> Call(object method, params TypeSyntax[] genericArgs) => args =>
                 InvocationExpression(ToSimpleName(method, genericArgs), CreateArgList(args));

--- a/Google.Api.Generator.Utils/Roslyn/RoslynConverters.cs
+++ b/Google.Api.Generator.Utils/Roslyn/RoslynConverters.cs
@@ -47,7 +47,7 @@ namespace Google.Api.Generator.Utils.Roslyn
             long value => new[] { LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(value)) },
             uint value => new[] { LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(value)) },
             ulong value => new[] { LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(value)) },
-            char value => new[] {LiteralExpression(SyntaxKind.CharacterLiteralExpression, Literal(value)) },
+            char value => new[] { LiteralExpression(SyntaxKind.CharacterLiteralExpression, Literal(value)) },
             _ => throw new NotSupportedException($"Cannot handle ToExpressions({o.GetType()})"),
         };
 
@@ -174,7 +174,7 @@ namespace Google.Api.Generator.Utils.Roslyn
             name = name.WithoutTrivia();
             return genericArgs.Any() ?
                 GenericName(name, TypeArgumentList(SeparatedList(genericArgs))) :
-                (SimpleNameSyntax)IdentifierName(name);
+                (SimpleNameSyntax) IdentifierName(name);
         }
 
     }

--- a/Google.Api.Generator.Utils/Roslyn/RoslynExtensions.cs
+++ b/Google.Api.Generator.Utils/Roslyn/RoslynExtensions.cs
@@ -53,7 +53,7 @@ namespace Google.Api.Generator.Utils.Roslyn
         public static StatementSyntax ToStatement(this ExpressionSyntax expr) => ExpressionStatement(expr);
 
         public static MethodDeclarationSyntax WithExplicitInterfaceSpecifier(this MethodDeclarationSyntax method, TypeSyntax interfaceType) =>
-            method.WithExplicitInterfaceSpecifier(ExplicitInterfaceSpecifier((NameSyntax)interfaceType));
+            method.WithExplicitInterfaceSpecifier(ExplicitInterfaceSpecifier((NameSyntax) interfaceType));
 
         private static T WithBody<T>(IEnumerable<object> code, Func<ArrowExpressionClauseSyntax, T> fnExpr, Func<BlockSyntax, T> fnBlock)
         {
@@ -172,7 +172,7 @@ namespace Google.Api.Generator.Utils.Roslyn
             this LocalDeclarationStatementSyntax var, string method, bool obsolete, params TypeSyntax[] genericArgs) => args =>
                 InvocationExpression(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
                     IdentifierName(var.Declaration.Variables.Single().Identifier), ToSimpleName(method, genericArgs).MaybeWithPragmaDisableObsoleteWarning(obsolete)), CreateArgList(args));
-        
+
         public static RoslynBuilder.ArgumentsFunc<InvocationExpressionSyntax> Call(
             this LocalDeclarationStatementSyntax var, object method, params TypeSyntax[] genericArgs) => args =>
                 InvocationExpression(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
@@ -183,24 +183,24 @@ namespace Google.Api.Generator.Utils.Roslyn
                 expr is ThisExpressionSyntax ?
                     InvocationExpression(ToSimpleName(method, genericArgs), CreateArgList(args)) :
                     conditional ?
-                        (ExpressionSyntax)ConditionalAccessExpression(expr,
+                        (ExpressionSyntax) ConditionalAccessExpression(expr,
                              InvocationExpression(MemberBindingExpression(ToSimpleName(method, genericArgs)), CreateArgList(args))) :
                         InvocationExpression(MemberAccessExpression(
                             SyntaxKind.SimpleMemberAccessExpression, expr, ToSimpleName(method, genericArgs)), CreateArgList(args));
 
         public static RoslynBuilder.ArgumentsFunc<InvocationExpressionSyntax> Call(
-            this ExpressionSyntax expr, object method, params TypeSyntax[] genericArgs) => args => (InvocationExpressionSyntax)Call(expr, method, false, genericArgs)(args);
+            this ExpressionSyntax expr, object method, params TypeSyntax[] genericArgs) => args => (InvocationExpressionSyntax) Call(expr, method, false, genericArgs)(args);
 
         public static RoslynBuilder.ArgumentsFunc<ExpressionSyntax> Call(
             this ParameterSyntax param, object method, bool conditional, params TypeSyntax[] genericArgs) => args =>
                 conditional ?
-                    (ExpressionSyntax)ConditionalAccessExpression(IdentifierName(param.Identifier),
+                    (ExpressionSyntax) ConditionalAccessExpression(IdentifierName(param.Identifier),
                         InvocationExpression(MemberBindingExpression(ToSimpleName(method, genericArgs)), CreateArgList(args))) :
                     InvocationExpression(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
                         IdentifierName(param.Identifier), ToSimpleName(method, genericArgs)), CreateArgList(args));
 
         public static RoslynBuilder.ArgumentsFunc<InvocationExpressionSyntax> Call(
-            this ParameterSyntax param, object method, params TypeSyntax[] genericArgs) => args => (InvocationExpressionSyntax)Call(param, method, false, genericArgs)(args);
+            this ParameterSyntax param, object method, params TypeSyntax[] genericArgs) => args => (InvocationExpressionSyntax) Call(param, method, false, genericArgs)(args);
 
         public static RoslynBuilder.ArgumentsFunc<InvocationExpressionSyntax> Call(this PropertyDeclarationSyntax property, object method, params TypeSyntax[] genericArgs) => args =>
             InvocationExpression(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
@@ -235,7 +235,7 @@ namespace Google.Api.Generator.Utils.Roslyn
             MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, type, ToSimpleName(member));
 
         public static ExpressionSyntax Access(this ParameterSyntax obj, object member, bool conditional = false) => conditional ?
-            (ExpressionSyntax)ConditionalAccessExpression(IdentifierName(obj.Identifier), MemberBindingExpression(ToSimpleName(member))) :
+            (ExpressionSyntax) ConditionalAccessExpression(IdentifierName(obj.Identifier), MemberBindingExpression(ToSimpleName(member))) :
             MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, IdentifierName(obj.Identifier), ToSimpleName(member));
 
         public static MemberAccessExpressionSyntax Access(this LocalDeclarationStatementSyntax var, object member) =>
@@ -248,7 +248,7 @@ namespace Google.Api.Generator.Utils.Roslyn
             MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, IdentifierName(field.Declaration.Variables.Single().Identifier), ToSimpleName(member));
 
         public static ExpressionSyntax Access(this ExpressionSyntax expr, object member, bool conditional = false) => conditional ?
-            (ExpressionSyntax) ConditionalAccessExpression(expr, MemberBindingExpression(ToSimpleName(member)))  :
+            (ExpressionSyntax) ConditionalAccessExpression(expr, MemberBindingExpression(ToSimpleName(member))) :
             MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, expr, ToSimpleName(member));
 
         public static ExpressionSyntax ElementAccess(this LocalDeclarationStatementSyntax var, object element) =>
@@ -256,7 +256,7 @@ namespace Google.Api.Generator.Utils.Roslyn
                 BracketedArgumentList(SeparatedList(ToExpressions(element).Select(Argument))));
 
         public static ExpressionSyntax ElementAccess(this DeclarationExpressionSyntax decl, object element) =>
-            ElementAccessExpression(IdentifierName(((SingleVariableDesignationSyntax)decl.Designation).Identifier),
+            ElementAccessExpression(IdentifierName(((SingleVariableDesignationSyntax) decl.Designation).Identifier),
                 BracketedArgumentList(SeparatedList(ToExpressions(element).Select(Argument))));
 
         public static ExpressionSyntax ElementAccess(this ParameterSyntax var, object element) =>

--- a/Google.Api.Generator.Utils/Roslyn/XmlDoc.cs
+++ b/Google.Api.Generator.Utils/Roslyn/XmlDoc.cs
@@ -64,7 +64,7 @@ namespace Google.Api.Generator.Utils.Roslyn
                     return XmlSeeElement(NameMemberCref(v));
                 case MemberAccessExpressionSyntax v:
                     // Only for enum elements
-                    return XmlSeeElement(QualifiedCref((TypeSyntax)v.Expression, NameMemberCref(v.Name)));
+                    return XmlSeeElement(QualifiedCref((TypeSyntax) v.Expression, NameMemberCref(v.Name)));
                 default:
                     throw new NotSupportedException($"Cannot handle ToNode({o.GetType()})");
             }
@@ -95,7 +95,7 @@ namespace Google.Api.Generator.Utils.Roslyn
 
         public static XmlNodeSyntax Item(params object[] parts) => XmlElement("item", SingletonList<XmlNodeSyntax>(XmlElement("description", List(parts.Select(ToNode)))));
 
-        public static XmlNodeSyntax UL(params object[] items) => UL((IEnumerable<object>)items);
+        public static XmlNodeSyntax UL(params object[] items) => UL((IEnumerable<object>) items);
         public static XmlNodeSyntax UL<T>(IEnumerable<T> items) => BulletListOfItemNodes(items.Select(item => item is object[] array ? Item(array) : Item(item)).ToArray());
         public static XmlNodeSyntax BulletListOfItemNodes(params XmlNodeSyntax[] itemNodes) =>
             XmlElement(

--- a/Google.Api.Generator.Utils/SourceFileContext.cs
+++ b/Google.Api.Generator.Utils/SourceFileContext.cs
@@ -22,8 +22,8 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text.RegularExpressions;
-using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using static Google.Api.Generator.Utils.Roslyn.RoslynBuilder;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Google.Api.Generator.Utils
 {
@@ -352,7 +352,7 @@ namespace Google.Api.Generator.Utils
 
                     void RemoveNamespaceFromColliding(string ns)
                     {
-                        foreach(var tNs in collidingTypes.Where(ctNs => ctNs.Value.Contains(ns)).ToList())
+                        foreach (var tNs in collidingTypes.Where(ctNs => ctNs.Value.Contains(ns)).ToList())
                         {
                             RemoveTypeFromColliding(tNs.Key, ns);
                         }
@@ -363,7 +363,7 @@ namespace Google.Api.Generator.Utils
                         if (collidingTypes.TryGetValue(t, out var collidingTypeNamespaces) && collidingTypeNamespaces.Contains(ns))
                         {
                             if (collidingTypeNamespaces.Count == 2 || // If we remove one of the remaining two collisions...
-                                // or if after removal the remaining collisions are between unseen imported types...
+                                                                      // or if after removal the remaining collisions are between unseen imported types...
                                 !collidingTypeNamespaces.Any(ctNs => ctNs != ns && seenTypes.Any(typ => typ.Name == t && typ.Namespace == ctNs)))
                             {
                                 // ... then this type is not colliding anymore
@@ -386,7 +386,7 @@ namespace Google.Api.Generator.Utils
                     HashSet<string> unaliasedNamespaces,
                     Dictionary<string, HashSet<string>> collidingAliasedTypes,
                     Dictionary<string, HashSet<string>> nonCollidingAliasedTypes) =>
-                    (_aliasedNamespaces, _unaliasedNamespaces, _collidingAliasedTypes, _nonCollidingAliasedTypes) = 
+                    (_aliasedNamespaces, _unaliasedNamespaces, _collidingAliasedTypes, _nonCollidingAliasedTypes) =
                     (aliasedNamespaces, unaliasedNamespaces, collidingAliasedTypes, nonCollidingAliasedTypes);
 
                 public override SyntaxNode VisitIdentifierName(IdentifierNameSyntax node) =>

--- a/Google.Api.Generator.Utils/SourceFileContext.cs
+++ b/Google.Api.Generator.Utils/SourceFileContext.cs
@@ -99,7 +99,7 @@ namespace Google.Api.Generator.Utils
             public override CompilationUnitSyntax CreateCompilationUnit(NamespaceDeclarationSyntax ns)
             {
                 var usings = _namespaceAliases
-                    .OrderBy(x => x.Key)
+                    .OrderBy(x => x.Value)
                     .Select(x => UsingDirective(NameEquals(x.Value), IdentifierName(x.Key)));
                 var unit = CompilationUnit()
                     .AddUsings(usings.ToArray())

--- a/Google.Api.Generator.Utils/SystemExtensions.cs
+++ b/Google.Api.Generator.Utils/SystemExtensions.cs
@@ -23,10 +23,10 @@ namespace Google.Api.Generator.Utils
             toUpper is bool upper ? upper ? char.ToUpperInvariant(c) : char.ToLowerInvariant(c) : c;
 
         private static string Camelizer(string s, bool firstUpper, bool forceAllChars, bool? upperAfterDigit) =>
-            s.Aggregate((upper: (bool?)firstUpper, prev: '\0', sb: new StringBuilder()), (acc, c) =>
+            s.Aggregate((upper: (bool?) firstUpper, prev: '\0', sb: new StringBuilder()), (acc, c) =>
                 !char.IsLetterOrDigit(c) ?
                     (acc.sb.Length > 0 ? true : firstUpper, c, acc.sb) :
-                    (char.IsDigit(c) ? upperAfterDigit : forceAllChars ? (bool?)false : null, c,
+                    (char.IsDigit(c) ? upperAfterDigit : forceAllChars ? (bool?) false : null, c,
                         acc.sb.Append(MaybeForceCase(c, char.IsLower(acc.prev) && char.IsUpper(c) ? true : acc.upper))),
                 acc => acc.sb.ToString());
 

--- a/Google.Api.Generator/CodeGenerator.cs
+++ b/Google.Api.Generator/CodeGenerator.cs
@@ -343,7 +343,7 @@ namespace Google.Api.Generator
             {
                 return null;
             }
-            
+
             // Parsing straight from YAML to the proto representation of a service config is
             // difficult. Instead, we convert the YAML to JSON, and parse that.
             var deserializer = new Deserializer();
@@ -362,7 +362,7 @@ namespace Google.Api.Generator
             // an escaped double-quote. (The YAML/JSON conversion always generates spaces before values.)
             // This is undoubtedly hacky, but should be sufficient for now.
             json = json.Replace(" \"true\"", " true").Replace(" \"false\"", " false");
-            
+
             var parser = new JsonParser(JsonParser.Settings.Default.WithIgnoreUnknownFields(true));
             return parser.Parse<Service>(json);
         }

--- a/Google.Api.Generator/Generation/MetadataGenerator.cs
+++ b/Google.Api.Generator/Generation/MetadataGenerator.cs
@@ -51,13 +51,13 @@ namespace Google.Api.Generator.Generation
         private static ServiceForTransport ServiceForTransportMetadata(ServiceDetails serviceDetails) =>
             new ServiceForTransport
             {
-                Clients = 
-                { 
+                Clients =
+                {
 
                     [TransportKeyGrpc] = new ServiceAsClient
                         {
                             LibraryClient = serviceDetails.ClientAbstractTyp.Name,
-                            Rpcs = 
+                            Rpcs =
                             {
                                 new SortedDictionary<string, MethodList>(
                                     serviceDetails.Methods.ToDictionary(

--- a/Google.Api.Generator/Generation/MethodDetails.cs
+++ b/Google.Api.Generator/Generation/MethodDetails.cs
@@ -322,7 +322,7 @@ namespace Google.Api.Generator.Generation
             /// True e.g. for all implicit headers, and for the explicit headers where the field pattern is `**`.
             /// </summary>
             public bool FullFieldNoRegex => Extractions.Count == 1 && Extractions.Single().NoRegexMatchingNeeded;
-            
+
             /// <summary>
             /// A way to match-and-extract the value from a request's field.
             /// </summary>
@@ -340,7 +340,7 @@ namespace Google.Api.Generator.Generation
                     Type = HeaderType.Implicit,
                     Extractions = new List<FieldExtraction> { new FieldExtraction() { Fields = fields, NoRegexMatchingNeeded = true } }
                 };
-            
+
             public enum HeaderType
             {
                 Implicit = 0,
@@ -367,7 +367,7 @@ namespace Google.Api.Generator.Generation
             // Any LRO-returning methods within the LRO package itself should be treated normally. Anywhere else, they get special treatment.
             desc.OutputType.FullName == "google.longrunning.Operation" && desc.File.Package != "google.longrunning" ? new StandardLro(svc, desc) :
             !string.IsNullOrEmpty(desc.GetExtension(ExtendedOperationsExtensions.OperationService)) ? new NonStandardLro(svc, desc) :
-            (MethodDetails)new Normal(svc, desc));
+            (MethodDetails) new Normal(svc, desc));
 
         private static MethodDetails DetectPagination(ServiceDetails svc, MethodDescriptor desc)
         {
@@ -431,7 +431,7 @@ namespace Google.Api.Generator.Generation
             // - The repeated candidate should be the first in both orders
             // - There should be 0 or more than 1 map candidates, to disambiguate with DiREGapic single-map case
             //   OR The repeated candidate should have a field number of 1 
-            if (pageSizeCandidate.Name == "page_size" && repeatedCandidatesByNumOrder.Any() && repeatedCandidatesByDeclOrder[0] == repeatedCandidatesByNumOrder[0] && 
+            if (pageSizeCandidate.Name == "page_size" && repeatedCandidatesByNumOrder.Any() && repeatedCandidatesByDeclOrder[0] == repeatedCandidatesByNumOrder[0] &&
                 (repeatedCandidatesByNumOrder[0].FieldNumber == 1 || mapCandidates.Count != 1))
             {
                 return new Paginated(svc, desc, repeatedCandidatesByDeclOrder[0], pageSizeCandidate.FieldNumber, pageTokenCandidate.FieldNumber);
@@ -466,7 +466,7 @@ namespace Google.Api.Generator.Generation
             var errMsg = $"The method {desc.FullName} is selected as a pagination candidate " +
                          $"but the configuration of the item response field candidates " +
                          $"does not match any of the configurations we can generate.";
-                              
+
             throw new InvalidOperationException(errMsg);
 
             bool IsRepeatedCandidate(FieldDescriptor field) =>
@@ -536,11 +536,11 @@ namespace Google.Api.Generator.Generation
                 // float -> double conversion via string to avoid unpleasent results from unrepresentable floats (e.g. 1.3 -> 1.2999999523162842)
                 var multiplier = double.Parse(rp.BackoffMultiplier.ToString());
                 // gRPC uses maxAttempts = 0 to mean unlimited; GAX wants a positive number. int.MaxValue is fine.
-                int maxAttempts = rp.MaxAttempts == 0 ? int.MaxValue : (int)rp.MaxAttempts;
+                int maxAttempts = rp.MaxAttempts == 0 ? int.MaxValue : (int) rp.MaxAttempts;
                 // The retry filter here is irrelevant. We'll generate code with the right status codes later.
                 retry = RetrySettings.FromExponentialBackoff(maxAttempts, rp.InitialBackoff.ToTimeSpan(), rp.MaxBackoff.ToTimeSpan(), multiplier, error => false);
                 // `Google.Rpc.Code` and `Grpc.Core.StatusCode` enums are identically defined.
-                statusCodes = rp.RetryableStatusCodes.Select(x => (StatusCode)x).ToList();
+                statusCodes = rp.RetryableStatusCodes.Select(x => (StatusCode) x).ToList();
             }
             else
             {
@@ -557,7 +557,7 @@ namespace Google.Api.Generator.Generation
             if (routingRule != null)
             {
                 var precursors = routingRule.RoutingParameters.Select(ExtractHeaderPrecursor);
-                foreach (var headerGroup in  precursors.GroupBy(p => p.HeaderName))
+                foreach (var headerGroup in precursors.GroupBy(p => p.HeaderName))
                 {
                     yield return new RoutingHeader
                     {
@@ -600,7 +600,7 @@ namespace Google.Api.Generator.Generation
                         FieldPath = param.Field,
                         RegexString = $"^{ResourcePattern.DoubleWildcardResourceIdRegexStr}$",
                         HeaderName = param.Field,
-                        NoRegexMatchingNeeded = true 
+                        NoRegexMatchingNeeded = true
                     };
                 }
 
@@ -619,7 +619,7 @@ namespace Google.Api.Generator.Generation
                 return new ExplicitRoutingHeaderPrecursor
                 {
                     FieldPath = param.Field,
-                    RegexString =  patternRegex,
+                    RegexString = patternRegex,
                     HeaderName = parameterName,
                     NoRegexMatchingNeeded = pattern.IsDoubleWildcardPattern
                 };

--- a/Google.Api.Generator/Generation/PackageApiMetadataGenerator.cs
+++ b/Google.Api.Generator/Generation/PackageApiMetadataGenerator.cs
@@ -26,10 +26,10 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using iam = Google.Cloud.Iam.V1;
 using static Google.Api.Generator.Utils.Roslyn.Modifier;
 using static Google.Api.Generator.Utils.Roslyn.RoslynBuilder;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using iam = Google.Cloud.Iam.V1;
 
 namespace Google.Api.Generator.Generation
 {
@@ -103,7 +103,7 @@ namespace Google.Api.Generator.Generation
             if (httpOverrides.Any())
             {
                 var dictionaryInitializers = httpOverrides
-                    .Select(pair => new object[] { pair.Key, GetKeyValuePairValue(pair.Value)})
+                    .Select(pair => new object[] { pair.Key, GetKeyValuePairValue(pair.Value) })
                     .ToArray<object>();
                 var invocation = initializer.Call(nameof(ApiMetadata.WithHttpRuleOverrides))(New(ctx.Type<Dictionary<string, ByteString>>())().WithCollectionInitializer(dictionaryInitializers));
                 initializer = invocation.WithExpression(invocation.Expression.WithAdditionalAnnotations(Annotations.LineBreakAnnotation));

--- a/Google.Api.Generator/Generation/ResourceNamesGenerator.cs
+++ b/Google.Api.Generator/Generation/ResourceNamesGenerator.cs
@@ -14,8 +14,8 @@
 
 using Google.Api.Gax;
 using Google.Api.Generator.ProtoUtils;
-using Google.Api.Generator.Utils.Roslyn;
 using Google.Api.Generator.Utils;
+using Google.Api.Generator.Utils.Roslyn;
 using Google.Protobuf.Reflection;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
@@ -207,7 +207,7 @@ namespace Google.Api.Generator.Generation
                     var xmlDocReturns = XmlDoc.Returns("A new instance of ", _ctx.Type(_def.ResourceNameTyp), " constructed from the provided ids.");
                     yield return Method(Public | Static, _ctx.Type(_def.ResourceNameTyp), $"From{pattern.UpperName}")(pattern.PathElements.Select(x => x.Parameter).ToArray())
                         .WithBody(Return(New(_ctx.Type(_def.ResourceNameTyp))(
-                            pattern.PathElements.Select(x => (object)(x.Parameter.Identifier.ValueText, _ctx.Type(typeof(GaxPreconditions))
+                            pattern.PathElements.Select(x => (object) (x.Parameter.Identifier.ValueText, _ctx.Type(typeof(GaxPreconditions))
                                 .Call(nameof(GaxPreconditions.CheckNotNullOrEmpty))(x.Parameter, Nameof(x.Parameter))))
                                 .Prepend(_ctx.Type(ResourceNameTypeTyp).Access(pattern.UpperName)).ToArray())))
                         .WithXmlDoc(pattern.PathElements.Select(x => x.ParameterXmlDoc).Prepend(xmlDocSummary).Append(xmlDocReturns).ToArray());
@@ -230,7 +230,7 @@ namespace Google.Api.Generator.Generation
                         {
                             var dollarItems = x.Elements.Zip(x.Segment.Separators.Select(x => x.ToString()).Append(""), (element, sep) => (FormattableString)
                                 $"{Parens(_ctx.Type(typeof(GaxPreconditions)).Call(nameof(GaxPreconditions.CheckNotNullOrEmpty))(element.Parameter, Nameof(element.Parameter)))}{sep:raw}");
-                            return (object)Dollar(dollarItems.ToArray());
+                            return (object) Dollar(dollarItems.ToArray());
                         }
                         else
                         {
@@ -304,11 +304,11 @@ namespace Google.Api.Generator.Generation
                                             result.Assign(Null),
                                             Return(false));
                                         var args = Enumerable.Range(0, seg.Segment.ParameterCount).Select(i => splitResult.ElementAccess(i));
-                                        return ((object)new object[] { splitResult, splitIf }, args);
+                                        return ((object) new object[] { splitResult, splitIf }, args);
                                     }
                                     else
                                     {
-                                        return ((object)null, new[] { resourceName.ElementAccess(segmentIndex) });
+                                        return ((object) null, new[] { resourceName.ElementAccess(segmentIndex) });
                                     }
                                 });
                             var elements = codeAndArgs.SelectMany(x => x.args);
@@ -397,7 +397,7 @@ namespace Google.Api.Generator.Generation
                 if (!_def.Patterns[0].IsWildcard)
                 {
                     // Ctor for pattern[0]; only generate if first pattern is not a wildcard.
-                    var initParams = PatternDetails[0].PathElements.Select(x => (object)(x.Parameter.Identifier.ValueText,
+                    var initParams = PatternDetails[0].PathElements.Select(x => (object) (x.Parameter.Identifier.ValueText,
                         _ctx.Type(typeof(GaxPreconditions)).Call(nameof(GaxPreconditions.CheckNotNullOrEmpty))(x.Parameter, Nameof(x.Parameter))))
                         .Prepend(_ctx.Type(ResourceNameTypeTyp).Access(ResourceTypeEnum().Members[1]));
                     var xmlDocSummary = XmlDoc.Summary("Constructs a new instance of a ", _ctx.Type(_def.ResourceNameTyp),
@@ -429,8 +429,8 @@ namespace Google.Api.Generator.Generation
             private new MethodDeclarationSyntax ToString()
             {
                 var switchCases = PatternDetails.Select(pattern =>
-                    ((object)_ctx.Type(ResourceNameTypeTyp).Access(pattern.UpperName),
-                        (object)Return(pattern.PathTemplateField.Call(nameof(PathTemplate.Expand))(ExpandArgs(pattern)))))
+                    ((object) _ctx.Type(ResourceNameTypeTyp).Access(pattern.UpperName),
+                        (object) Return(pattern.PathTemplateField.Call(nameof(PathTemplate.Expand))(ExpandArgs(pattern)))))
                     .Prepend((_ctx.Type(ResourceNameTypeTyp).Access("Unparsed"), Return(UnparsedResourceNameProperty().Call(nameof(object.ToString))())));
                 return Method(Public | Override, _ctx.Type<string>(), nameof(object.ToString))()
                     .WithBody(
@@ -447,9 +447,9 @@ namespace Google.Api.Generator.Generation
                     {
                         if (x.Segment.IsComplex)
                         {
-                            var dollarItems = x.Elements.Zip(x.Segment.Separators, (element, sep) => (FormattableString)$"{element.Property}{sep:raw}")
-                                .Append((FormattableString)$"{x.Elements[^1].Property}");
-                            return (object)Dollar(dollarItems.ToArray());
+                            var dollarItems = x.Elements.Zip(x.Segment.Separators, (element, sep) => (FormattableString) $"{element.Property}{sep:raw}")
+                                .Append((FormattableString) $"{x.Elements[^1].Property}");
+                            return (object) Dollar(dollarItems.ToArray());
                         }
                         else
                         {
@@ -546,7 +546,7 @@ namespace Google.Api.Generator.Generation
                             var underlyingProperty = Property(DontCare, _ctx.TypeDontCare, field.UnderlyingPropertyName);
                             var xmlDocSummary = XmlDoc.Summary(_ctx.Type(def.ResourceNameTyp), "-typed view over the ", underlyingProperty, " resource name property.");
                             Func<object, object> getBodyFn = field.InnerDefs is object ?
-                                (Func<object, object>)(p => field.InnerDefs.Select(innerDef =>
+                                (Func<object, object>) (p => field.InnerDefs.Select(innerDef =>
                                 {
                                     var result = Local(_ctx.Type(innerDef.ResourceNameTyp), innerDef.FieldName);
                                     return If(_ctx.Type(innerDef.ResourceNameTyp).Call("TryParse")(p, OutVar(result)))
@@ -555,7 +555,7 @@ namespace Google.Api.Generator.Generation
                                     .Prepend(If(_ctx.Type<string>().Call(nameof(string.IsNullOrEmpty))(p)).Then(Return(Null)))
                                     .Append(Return(_ctx.Type<UnparsedResourceName>().Call(nameof(UnparsedResourceName.Parse))(p)))) :
                                 p => Return(_ctx.Type<string>().Call(nameof(string.IsNullOrEmpty))(p).ConditionalOperator(
-                                    Null, _ctx.Type(def.ResourceParserTyp).Call("Parse")(p, def.IsUnparsed ? null : (object)("allowUnparsed", true))));
+                                    Null, _ctx.Type(def.ResourceParserTyp).Call("Parse")(p, def.IsUnparsed ? null : (object) ("allowUnparsed", true))));
                             if (field.IsRepeated)
                             {
                                 var s = Parameter(null, "s");

--- a/Google.Api.Generator/Generation/ServiceAbstractClientClassCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceAbstractClientClassCodeGenerator.cs
@@ -68,7 +68,7 @@ namespace Google.Api.Generator.Generation
                 var shutdown = ShutdownDefaultChannelsAsync(channelPool, create, createAsync);
                 var grpcClient = GrpcClient();
                 cls = cls.AddMembers(
-                    defaultEndpoint, defaultScopes, serviceMetadata, channelPool, 
+                    defaultEndpoint, defaultScopes, serviceMetadata, channelPool,
                     createAsync, create, createFromCallInvoker, shutdown, grpcClient);
                 cls = cls.AddMembers(Mixins().ToArray());
                 var methods = ServiceMethodGenerator.Generate(_ctx, _svc, inAbstract: true);
@@ -81,7 +81,7 @@ namespace Google.Api.Generator.Generation
             AutoProperty(Public | Static, _ctx.Type<string>(), "DefaultEndpoint")
                 .WithInitializer($"{_svc.DefaultHost}:{_svc.DefaultPort}")
                 .WithXmlDoc(XmlDoc.Summary(
-                    $"The default endpoint for the {_svc.DocumentationName} service, " + 
+                    $"The default endpoint for the {_svc.DocumentationName} service, " +
                     $"which is a host of \"{_svc.DefaultHost}\" and a port of {_svc.DefaultPort}."));
 
         private PropertyDeclarationSyntax DefaultScopes() =>
@@ -105,7 +105,7 @@ namespace Google.Api.Generator.Generation
                 ApiTransports.Rest | ApiTransports.Grpc => BinaryExpression(SyntaxKind.BitwiseOrExpression, _ctx.Type<ApiTransports>().Access(nameof(ApiTransports.Grpc)), _ctx.Type<ApiTransports>().Access(nameof(ApiTransports.Rest))),
                 _ => throw new ArgumentException($"Unable to create service metadata for transports '{_svc.Transports}'")
             };
-            
+
             var apiMetadata = _ctx.Type(Typ.Manual(_svc.Namespace, PackageApiMetadataGenerator.ClassName)).Access(PackageApiMetadataGenerator.PropertyName);
             return AutoProperty(Public | Static, _ctx.Type<ServiceMetadata>(), "ServiceMetadata")
                 .WithInitializer(New(_ctx.Type<ServiceMetadata>())(serviceDescriptor, defaultEndpoint, defaultScopes, supportsScopedJwts, apiTransports, apiMetadata))

--- a/Google.Api.Generator/Generation/ServiceBuilderCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceBuilderCodeGenerator.cs
@@ -67,7 +67,7 @@ namespace Google.Api.Generator.Generation
                 .WithXmlDoc(XmlDoc.Summary("The settings to use for RPCs, or ", null, " for the default settings."));
 
         private ConstructorDeclarationSyntax ParameterlessConstructor() =>
-            Ctor(Public, _svc.BuilderTyp, BaseInitializer(_ctx.Type(_svc.ClientAbstractTyp).Access("ServiceMetadata")))()                
+            Ctor(Public, _svc.BuilderTyp, BaseInitializer(_ctx.Type(_svc.ClientAbstractTyp).Access("ServiceMetadata")))()
                 .WithXmlDoc(XmlDoc.Summary("Creates a new builder with default settings."))
                 .WithBlockBody();
 

--- a/Google.Api.Generator/Generation/ServiceCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceCodeGenerator.cs
@@ -13,20 +13,19 @@
 // limitations under the License.
 
 using Google.Api.Gax.Grpc;
-using Google.Api.Generator.Utils.Roslyn;
+using Google.Api.Generator.ProtoUtils;
 using Google.Api.Generator.Utils;
+using Google.Api.Generator.Utils.Roslyn;
 using Google.LongRunning;
-using Grpc.ServiceConfig;
+using Google.Protobuf.Reflection;
+using Grpc.Core;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Google.Api.Generator.ProtoUtils;
-using Google.Protobuf.Reflection;
 using static Google.Api.Generator.Utils.Roslyn.Modifier;
 using static Google.Api.Generator.Utils.Roslyn.RoslynBuilder;
-using Grpc.Core;
 
 namespace Google.Api.Generator.Generation
 {
@@ -101,11 +100,11 @@ namespace Google.Api.Generator.Generation
                 {
                     var underlyingProperty = Property(DontCare, ctx.TypeDontCare, "MaxResults");
 
-                    var getBody = ProtoTyp.Of(maxResMessage) == Typ.Of<int>() 
+                    var getBody = ProtoTyp.Of(maxResMessage) == Typ.Of<int>()
                         ? Return(underlyingProperty)
                         : Return(CheckedCast(ctx.Type<int>(), underlyingProperty));
 
-                    var assignFrom = ProtoTyp.Of(maxResMessage) == Typ.Of<int>() 
+                    var assignFrom = ProtoTyp.Of(maxResMessage) == Typ.Of<int>()
                         ? Value
                         : CheckedCast(ctx.Type(ProtoTyp.Of(maxResMessage)), Value);
                     var setBody = underlyingProperty.Assign(assignFrom);

--- a/Google.Api.Generator/Generation/ServiceCollectionExtensionsGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceCollectionExtensionsGenerator.cs
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Google.Api.Generator.Utils;
 using Google.Api.Generator.Utils.Roslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using static Google.Api.Generator.Utils.Roslyn.Modifier;
 using static Google.Api.Generator.Utils.Roslyn.RoslynBuilder;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;

--- a/Google.Api.Generator/Generation/ServiceImplClientClassGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceImplClientClassGenerator.cs
@@ -14,22 +14,20 @@
 
 using Google.Api.Gax.Grpc;
 using Google.Api.Generator.ProtoUtils;
-using Google.Api.Generator.Utils.Roslyn;
 using Google.Api.Generator.Utils;
+using Google.Api.Generator.Utils.Roslyn;
 using Google.LongRunning;
 using Google.Protobuf;
+using Google.Protobuf.Reflection;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using static Google.Api.Generator.Utils.Roslyn.Modifier;
 using static Google.Api.Generator.Utils.Roslyn.RoslynBuilder;
-using Microsoft.CodeAnalysis.CSharp;
-using Google.Protobuf.Reflection;
-using Microsoft.Extensions.Logging;
-using Google.Api.Gax;
 
 namespace Google.Api.Generator.Generation
 {
@@ -249,11 +247,11 @@ namespace Google.Api.Generator.Generation
                         // so we don't need to distinguish between them here.
                         fieldInitializer = fieldInitializer.Call(nameof(ApiCall<ProtoMsg, ProtoMsg>.WithExtractedGoogleRequestParam))(extractorSyntax);
                     }
-                    
+
                     return fieldInitializer;
-                    
+
                     ExpressionSyntax FullFieldAccess(IEnumerable<FieldDescriptor> extractionFields)
-                    {  
+                    {
                         var access = request.Access(FieldAccess(extractionFields.First()));
                         foreach (var field in extractionFields.Skip(1))
                         {

--- a/Google.Api.Generator/Generation/ServiceMethodGenerator.Signatures.cs
+++ b/Google.Api.Generator/Generation/ServiceMethodGenerator.Signatures.cs
@@ -15,8 +15,8 @@
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
 using Google.Api.Generator.ProtoUtils;
-using Google.Api.Generator.Utils.Roslyn;
 using Google.Api.Generator.Utils;
+using Google.Api.Generator.Utils.Roslyn;
 using Google.Protobuf;
 using Google.Protobuf.Reflection;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -97,7 +97,7 @@ namespace Google.Api.Generator.Generation
                         {
                             return field.IsRequired ?
                                 Ctx.Type(typeof(GaxPreconditions)).Call(nameof(GaxPreconditions.CheckNotNull))(param, Nameof(param)) :
-                                (object)param;
+                                (object) param;
                         }
                         else if (field.Typ.IsPrimitive || field.Typ.IsEnum)
                         {
@@ -109,25 +109,25 @@ namespace Google.Api.Generator.Generation
                                 Ctx.Type(typeof(GaxPreconditions)).Call(
                                     field.IsWrapperType ? nameof(GaxPreconditions.CheckNotNull) : nameof(GaxPreconditions.CheckNotNullOrEmpty))(
                                     param, Nameof(param)) :
-                                field.IsWrapperType ? param : (object)param.NullCoalesce("");
+                                field.IsWrapperType ? param : (object) param.NullCoalesce("");
                         }
                         else if (field.Typ.FullName == typeof(ByteString).FullName)
                         {
                             return field.IsRequired ?
                                 Ctx.Type(typeof(GaxPreconditions)).Call(nameof(GaxPreconditions.CheckNotNull))(param, Nameof(param)) :
-                                field.IsWrapperType ? param : (object)param.NullCoalesce(Ctx.Type<ByteString>().Access(nameof(ByteString.Empty)));
+                                field.IsWrapperType ? param : (object) param.NullCoalesce(Ctx.Type<ByteString>().Access(nameof(ByteString.Empty)));
                         }
                         else if (field.IsWrapperType)
                         {
                             return field.IsRequired ?
                                 param.NullCoalesce(Throw(New(Ctx.Type<ArgumentNullException>())(Nameof(param)))) :
-                                (object)param;
+                                (object) param;
                         }
                         else
                         {
                             return field.IsRequired ?
                                 Ctx.Type(typeof(GaxPreconditions)).Call(nameof(GaxPreconditions.CheckNotNull))(param, Nameof(param)) :
-                                (object)param;
+                                (object) param;
                         }
                     }
                 }
@@ -201,7 +201,7 @@ namespace Google.Api.Generator.Generation
                     {
                         return Method(Public | Virtual, Ctx.Type(returnTyp), methodName)(parameters.Select(x => x.Parameter).Append(finalParam).ToArray())
                                 .MaybeWithAttribute(MethodDetails.IsDeprecated || _sig.HasDeprecatedField, () => Ctx.Type<ObsoleteAttribute>())()
-                                .WithBody(This.Call(methodName)(parameters.Select(x => (object)x.Parameter).Append(
+                                .WithBody(This.Call(methodName)(parameters.Select(x => (object) x.Parameter).Append(
                                     Ctx.Type<CallSettings>().Call(nameof(CallSettings.FromCancellationToken))(finalParam))))
                                     .WithXmlDoc(parameters.Select(x => x.XmlDoc).Prepend(_def.SummaryXmlDoc).Append(finalParamXmlDoc).Append(returnsXmlDoc).ToArray());
                     }

--- a/Google.Api.Generator/Generation/ServiceMethodGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceMethodGenerator.cs
@@ -15,20 +15,20 @@
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
 using Google.Api.Generator.ProtoUtils;
-using Google.Api.Generator.Utils.Roslyn;
 using Google.Api.Generator.Utils;
+using Google.Api.Generator.Utils.Roslyn;
 using Google.LongRunning;
+using Google.Protobuf.Reflection;
 using Grpc.Core;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using static Google.Api.Generator.Utils.Roslyn.Modifier;
 using static Google.Api.Generator.Utils.Roslyn.RoslynBuilder;
-using System.Collections;
-using Google.Protobuf.Reflection;
 
 namespace Google.Api.Generator.Generation
 {
@@ -539,7 +539,7 @@ namespace Google.Api.Generator.Generation
                     .WithXmlDoc(SummaryXmlDoc, RequestXmlDoc, CallSettingsXmlDoc, ReturnsServerStreamingXmlDoc);
 
             public ClassDeclarationSyntax AbstractClientStreamClass =>
-                Class(Public | Abstract | Partial, MethodDetailsClientStream.AbstractStreamTyp, baseTypes: Ctx.Type(Typ.Generic(typeof(ClientStreamingBase<,>),MethodDetails.RequestTyp, MethodDetails.ResponseTyp)))
+                Class(Public | Abstract | Partial, MethodDetailsClientStream.AbstractStreamTyp, baseTypes: Ctx.Type(Typ.Generic(typeof(ClientStreamingBase<,>), MethodDetails.RequestTyp, MethodDetails.ResponseTyp)))
                     .WithXmlDoc(XmlDoc.Summary("Client streaming methods for ", AbstractClientStreamSyncRequestMethod, "."));
             public MethodDeclarationSyntax AbstractClientStreamSyncRequestMethod =>
                 Method(Public | Virtual, Ctx.Type(MethodDetailsClientStream.AbstractStreamTyp), MethodDetails.SyncMethodName)(CallSettingsParam, ClientStreamingSettingsParam)
@@ -582,7 +582,7 @@ namespace Google.Api.Generator.Generation
                     yield return If(populateCheck)
                         .Then(
                             requestParameter.Assign(requestParameter.Call("Clone")()),
-                            requestParameter.Access(field.CSharpPropertyName()).Assign(Ctx.Type(typeof(FieldFormats)).Call(nameof(FieldFormats.GenerateUuid4))()));                        
+                            requestParameter.Access(field.CSharpPropertyName()).Assign(Ctx.Type(typeof(FieldFormats)).Call(nameof(FieldFormats.GenerateUuid4))()));
                 }
             }
 
@@ -634,7 +634,7 @@ namespace Google.Api.Generator.Generation
                             XmlDoc.Param(writeBufferParam, "The ", writeBufferType, " instance associated with this streaming call.")
                         );
                 }
-                
+
                 MethodDeclarationSyntax ModifyRequest()
                 {
                     var requestParam = Parameter(Ctx.Type(MethodDetails.RequestTyp), "request");
@@ -646,16 +646,16 @@ namespace Google.Api.Generator.Generation
                         );
                 }
 
-                MethodDeclarationSyntax TryWriteAsync() => 
-                Method(Public | Override, Ctx.Type<Task>(), nameof (ClientStreamingBase<ProtoMsg, ProtoMsg>.TryWriteAsync))(messageParam)
+                MethodDeclarationSyntax TryWriteAsync() =>
+                Method(Public | Override, Ctx.Type<Task>(), nameof(ClientStreamingBase<ProtoMsg, ProtoMsg>.TryWriteAsync))(messageParam)
                     .WithBody(writeBufferField.Call(nameof(BufferedClientStreamWriter<ProtoMsg>.TryWriteAsync))(This.Call(modifyRequestMethod)(messageParam)));
 
                 MethodDeclarationSyntax WriteAsync() =>
                     Method(Public | Override, Ctx.Type<Task>(), nameof(ClientStreamingBase<ProtoMsg, ProtoMsg>.WriteAsync))(messageParam)
                         .WithBody(writeBufferField.Call(nameof(BufferedClientStreamWriter<ProtoMsg>.WriteAsync))(This.Call(modifyRequestMethod)(messageParam)));
-                
-                MethodDeclarationSyntax TryWriteAsyncWithOptions() => 
-                    Method(Public | Override, Ctx.Type<Task>(), nameof (ClientStreamingBase<ProtoMsg, ProtoMsg>.TryWriteAsync))(messageParam, optionsParam)
+
+                MethodDeclarationSyntax TryWriteAsyncWithOptions() =>
+                    Method(Public | Override, Ctx.Type<Task>(), nameof(ClientStreamingBase<ProtoMsg, ProtoMsg>.TryWriteAsync))(messageParam, optionsParam)
                         .WithBody(writeBufferField.Call(nameof(BufferedClientStreamWriter<ProtoMsg>.TryWriteAsync))(This.Call(modifyRequestMethod)(messageParam), optionsParam));
 
                 MethodDeclarationSyntax WriteAsyncWithOptions() =>

--- a/Google.Api.Generator/Generation/ServiceSettingsCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/ServiceSettingsCodeGenerator.cs
@@ -99,7 +99,7 @@ namespace Google.Api.Generator.Generation
             object CopySetting(PropertyDeclarationSyntax property)
             {
                 var assign = property.Assign(existing.Access(property));
-                return property.HasAnnotation(s_cloneSetting) ? assign.Call("Clone")() : (object)assign;
+                return property.HasAnnotation(s_cloneSetting) ? assign.Call("Clone")() : (object) assign;
             }
         }
 
@@ -138,8 +138,8 @@ namespace Google.Api.Generator.Generation
                         var retry = method.MethodRetry;
                         var retryExpression = _ctx.Type<RetrySettings>().Call(nameof(RetrySettings.FromExponentialBackoff))(
                             ("maxAttempts", retry.MaxAttempts),
-                            ("initialBackoff", _ctx.Type<TimeSpan>().Call(nameof(TimeSpan.FromMilliseconds))((int)retry.InitialBackoff.TotalMilliseconds)),
-                            ("maxBackoff", _ctx.Type<TimeSpan>().Call(nameof(TimeSpan.FromMilliseconds))((int)retry.MaxBackoff.TotalMilliseconds)),
+                            ("initialBackoff", _ctx.Type<TimeSpan>().Call(nameof(TimeSpan.FromMilliseconds))((int) retry.InitialBackoff.TotalMilliseconds)),
+                            ("maxBackoff", _ctx.Type<TimeSpan>().Call(nameof(TimeSpan.FromMilliseconds))((int) retry.MaxBackoff.TotalMilliseconds)),
                             ("backoffMultiplier", retry.BackoffMultiplier),
                             ("retryFilter", _ctx.Type<RetrySettings>().Call(nameof(RetrySettings.FilterForStatusCodes))(
                                             method.MethodRetryStatusCodes.Select(x => _ctx.Type<StatusCode>().Access(x))))
@@ -150,9 +150,9 @@ namespace Google.Api.Generator.Generation
                             _ctx.Type(typeof(CallSettingsExtensions)).Call(nameof(CallSettingsExtensions.WithRetry))(initializer, retryExpression);
                         xmlRemarks = XmlDoc.Remarks(
                             XmlDoc.UL(
-                                Invariant($"Initial retry delay: {(int)retry.InitialBackoff.TotalMilliseconds} milliseconds."),
+                                Invariant($"Initial retry delay: {(int) retry.InitialBackoff.TotalMilliseconds} milliseconds."),
                                 Invariant($"Retry delay multiplier: {retry.BackoffMultiplier}"),
-                                Invariant($"Retry maximum delay: {(int)retry.MaxBackoff.TotalMilliseconds} milliseconds."),
+                                Invariant($"Retry maximum delay: {(int) retry.MaxBackoff.TotalMilliseconds} milliseconds."),
                                 Invariant($"Maximum attempts: {(retry.MaxAttempts == int.MaxValue ? "Unlimited" : retry.MaxAttempts.ToString())}"),
                                 GetRetriableErrorCodeDocs().ToArray(),
                                 timeoutRemark));
@@ -220,19 +220,19 @@ namespace Google.Api.Generator.Generation
             AutoProperty(Public, _ctx.Type<OperationsSettings>(), method.LroSettingsName, hasSetter: true)
                 .WithInitializer(New(_ctx.Type<OperationsSettings>())().WithInitializer(
                     new ObjectInitExpr(nameof(OperationsSettings.DefaultPollSettings), New(_ctx.Type<PollSettings>())(
-                        _ctx.Type<Expiration>().Call(nameof(Expiration.FromTimeout))(_ctx.Type<TimeSpan>().Call(nameof(TimeSpan.FromHours))((int)s_lroDefaultPollSettings.Expiration.Timeout.Value.TotalHours)),
-                        _ctx.Type<TimeSpan>().Call(nameof(TimeSpan.FromSeconds))((int)s_lroDefaultPollSettings.Delay.TotalSeconds),
+                        _ctx.Type<Expiration>().Call(nameof(Expiration.FromTimeout))(_ctx.Type<TimeSpan>().Call(nameof(TimeSpan.FromHours))((int) s_lroDefaultPollSettings.Expiration.Timeout.Value.TotalHours)),
+                        _ctx.Type<TimeSpan>().Call(nameof(TimeSpan.FromSeconds))((int) s_lroDefaultPollSettings.Delay.TotalSeconds),
                         s_lroDefaultPollSettings.DelayMultiplier,
-                        _ctx.Type<TimeSpan>().Call(nameof(TimeSpan.FromSeconds))((int)s_lroDefaultPollSettings.MaxDelay.TotalSeconds)))))
+                        _ctx.Type<TimeSpan>().Call(nameof(TimeSpan.FromSeconds))((int) s_lroDefaultPollSettings.MaxDelay.TotalSeconds)))))
                 .WithXmlDoc(
                     XmlDoc.Summary("Long Running Operation settings for calls to ",
                         XmlDoc.C($"{_svc.ClientAbstractTyp.Name}.{method.SyncMethodName}"), " and ",
                         XmlDoc.C($"{_svc.ClientAbstractTyp.Name}.{method.AsyncMethodName}"), "."),
                     XmlDoc.Remarks("Uses default ", _ctx.Type<PollSettings>(), " of:", XmlDoc.UL(
-                        Invariant($"Initial delay: {(int)s_lroDefaultPollSettings.Delay.TotalSeconds} seconds."),
+                        Invariant($"Initial delay: {(int) s_lroDefaultPollSettings.Delay.TotalSeconds} seconds."),
                         Invariant($"Delay multiplier: {s_lroDefaultPollSettings.DelayMultiplier}"),
-                        Invariant($"Maximum delay: {(int)s_lroDefaultPollSettings.MaxDelay.TotalSeconds} seconds."),
-                        Invariant($"Total timeout: {(int)s_lroDefaultPollSettings.Expiration.Timeout.Value.TotalHours} hours."))))
+                        Invariant($"Maximum delay: {(int) s_lroDefaultPollSettings.MaxDelay.TotalSeconds} seconds."),
+                        Invariant($"Total timeout: {(int) s_lroDefaultPollSettings.Expiration.Timeout.Value.TotalHours} hours."))))
                 .WithAdditionalAnnotations(s_cloneSetting);
 
         private PropertyDeclarationSyntax BidiSettingsProperty(MethodDetails.BidiStreaming method) =>

--- a/Google.Api.Generator/Generation/SnippetCodeGenerator.cs
+++ b/Google.Api.Generator/Generation/SnippetCodeGenerator.cs
@@ -297,9 +297,9 @@ namespace Google.Api.Generator.Generation
             private SourceFileContext Ctx { get; }
             private ServiceDetails Svc { get; }
             private MethodDetails Method { get; }
-            private MethodDetails.Lro MethodLro => (MethodDetails.Lro)Method;
-            private MethodDetails.Paginated MethodPaginated => (MethodDetails.Paginated)Method;
-            private MethodDetails.IStreaming MethodStreaming => (MethodDetails.IStreaming)Method;
+            private MethodDetails.Lro MethodLro => (MethodDetails.Lro) Method;
+            private MethodDetails.Paginated MethodPaginated => (MethodDetails.Paginated) Method;
+            private MethodDetails.IStreaming MethodStreaming => (MethodDetails.IStreaming) Method;
             private bool IncludeDocMarkers { get; }
 
             // Common properties for "Call the client method, suppressing obsolete warnings if necessary".
@@ -382,7 +382,7 @@ namespace Google.Api.Generator.Generation
                     else
                     {
                         @default = pattern is null ?
-                            (object)New(Ctx.Type<UnparsedResourceName>())("a/wildcard/resource") :
+                            (object) New(Ctx.Type<UnparsedResourceName>())("a/wildcard/resource") :
                             Ctx.Type(resourceTyp).Call(FactoryMethodName(pattern))
                                 (pattern.Template.ParameterNames.Select(x => $"[{x.ToUpperInvariant()}]"));
                     }
@@ -444,7 +444,7 @@ namespace Google.Api.Generator.Generation
 
                 object Collection(object value, Typ typ) => topLevel ?
                     NewArray(Ctx.ArrayType(Typ.ArrayOf(typ ?? ProtoTyp.Of(fieldDesc).GenericArgTyps.First())))(value) :
-                    (object)CollectionInitializer(value);
+                    (object) CollectionInitializer(value);
 
                 string FactoryMethodName(ResourceDetails.Definition.Pattern pattern)
                 {
@@ -664,7 +664,7 @@ namespace Google.Api.Generator.Generation
 
             private MethodDeclarationSyntax SyncRequestMethod => Sync(Method.SyncSnippetMethodName, new[] { Method.RequestTyp },
                 InitRequestObject, Method.SyncReturnTyp is Typ.VoidTyp ?
-                    (object)SyncClientMethodCall(Request) :
+                    (object) SyncClientMethodCall(Request) :
                     Response.WithInitializer(SyncClientMethodCall(Request)));
 
             public SnippetDef SyncRequestSnippet => new SnippetDef(Method, true, Method.SyncSnippetMethodName, RequestClientMethodParameters, null,
@@ -672,7 +672,7 @@ namespace Google.Api.Generator.Generation
 
             private MethodDeclarationSyntax AsyncRequestMethod => Async(Method.AsyncSnippetMethodName, new[] { Method.RequestTyp },
                 InitRequestObject, Method.SyncReturnTyp is Typ.VoidTyp ?
-                    (object)Await(AsyncClientMethodCall(Request)) :
+                    (object) Await(AsyncClientMethodCall(Request)) :
                     Response.WithInitializer(Await(AsyncClientMethodCall(Request))));
 
             public SnippetDef AsyncRequestSnippet => new SnippetDef(Method, false, Method.AsyncSnippetMethodName, RequestClientMethodParameters, null,
@@ -803,15 +803,15 @@ namespace Google.Api.Generator.Generation
 
                 private MethodDeclarationSyntax SyncMethod => _def.Sync(SyncMethodName, _sig.Fields.Select(f => f.Typ),
                     InitRequestArgsNormal, Method.SyncReturnTyp is Typ.VoidTyp ?
-                        (object)SyncClientMethodCall(InitRequestArgsNormal.ToArray()) :
+                        (object) SyncClientMethodCall(InitRequestArgsNormal.ToArray()) :
                         _def.Response.WithInitializer(SyncClientMethodCall(InitRequestArgsNormal.ToArray())));
 
-                public SnippetDef SyncSnippet => new SnippetDef(Method, true, SyncMethodName, NormalClientMethodParameters, RegionTagOverloadDisambiguation, 
+                public SnippetDef SyncSnippet => new SnippetDef(Method, true, SyncMethodName, NormalClientMethodParameters, RegionTagOverloadDisambiguation,
                     (ctx, includeDocMarkers) => WithSourceFileContext(ctx).WithIncludeDocMarkers(includeDocMarkers).SyncMethod);
 
                 private MethodDeclarationSyntax AsyncMethod => _def.Async(AsyncMethodName, _sig.Fields.Select(f => f.Typ),
                     InitRequestArgsNormal, Method.SyncReturnTyp is Typ.VoidTyp ?
-                        (object)Await(AsyncClientMethodCall(InitRequestArgsNormal.ToArray())) :
+                        (object) Await(AsyncClientMethodCall(InitRequestArgsNormal.ToArray())) :
                         _def.Response.WithInitializer(Await(AsyncClientMethodCall(InitRequestArgsNormal.ToArray()))));
 
                 public SnippetDef AsyncSnippet => new SnippetDef(Method, false, AsyncMethodName, NormalClientMethodParameters, RegionTagOverloadDisambiguation,
@@ -871,7 +871,7 @@ namespace Google.Api.Generator.Generation
                                 : f.FieldResources.Where(resDetails => resDetails.ContainsWildcard != false).Select(x => (x.ResourceDefinition.ResourceNameTyp, f.ParameterName));
                             return overloads.SelectMany(overload => parameters.Select(parameter => overload.Add(parameter))).ToImmutableList();
                         }).ToList();
-                        return allOverloads.Select((parameters, index) => new ResourceName(sig, parameters, allOverloads.Count > 1 ? (int?)(index + 1) : null));
+                        return allOverloads.Select((parameters, index) => new ResourceName(sig, parameters, allOverloads.Count > 1 ? (int?) (index + 1) : null));
                     }
 
                     public ResourceName WithSourceFileContext(SourceFileContext ctx) =>
@@ -912,14 +912,14 @@ namespace Google.Api.Generator.Generation
                         _sig._sig.Fields.Zip(Typs, (f, typ) => f.IsRepeated && f.FieldResources is object ? Typ.Generic(typeof(IEnumerable<>), typ) : typ);
 
                     private MethodDeclarationSyntax SyncMethod => _sig._def.Sync(SyncMethodName, SnippetTyps, InitRequestArgs, Method.SyncReturnTyp is Typ.VoidTyp ?
-                        (object)_sig.SyncClientMethodCall(InitRequestArgs.ToArray()) :
+                        (object) _sig.SyncClientMethodCall(InitRequestArgs.ToArray()) :
                         _sig._def.Response.WithInitializer(_sig.SyncClientMethodCall(InitRequestArgs.ToArray())));
 
                     public SnippetDef SyncSnippet => new SnippetDef(Method, true, SyncMethodName, NormalClientMethodParameters, RegionTagOverloadDisambiguation,
                         (ctx, includeDocMarkers) => WithSourceFileContext(ctx).WithIncludeDocMarkers(includeDocMarkers).SyncMethod);
 
                     private MethodDeclarationSyntax AsyncMethod => _sig._def.Async(AsyncMethodName, SnippetTyps, InitRequestArgs, Method.SyncReturnTyp is Typ.VoidTyp ?
-                        (object)Await(_sig.AsyncClientMethodCall(InitRequestArgs.ToArray())) :
+                        (object) Await(_sig.AsyncClientMethodCall(InitRequestArgs.ToArray())) :
                         _sig._def.Response.WithInitializer(Await(_sig.AsyncClientMethodCall(InitRequestArgs.ToArray()))));
 
                     public SnippetDef AsyncSnippet => new SnippetDef(Method, false, AsyncMethodName, NormalClientMethodParameters, RegionTagOverloadDisambiguation,
@@ -967,7 +967,7 @@ namespace Google.Api.Generator.Generation
                 return Method.Signatures.Any(s => s.Fields.Select(x => x.Typ).Append(stringTyp).SequenceEqual(sigTyps));
             }
 
-            public IEnumerable<Signature> Signatures => Method.Signatures.Select((sig, i) => new Signature(this, sig, Method.Signatures.Count > 1 ? i : (int?)null));
+            public IEnumerable<Signature> Signatures => Method.Signatures.Select((sig, i) => new Signature(this, sig, Method.Signatures.Count > 1 ? i : (int?) null));
         }
     }
 

--- a/Google.Api.Generator/Program.cs
+++ b/Google.Api.Generator/Program.cs
@@ -194,7 +194,7 @@ namespace Google.Api.Generator
                 var commonResourcesConfigPaths = extraParams.GetValueOrDefault(nameCommonResourcesConfig);
                 var transports = ParseTransports(extraParams.GetValueOrDefault(nameTransport)?.SingleOrDefault());
                 var requestNumericEnumJsonEncoding = string.Equals(extraParams.GetValueOrDefault(nameRequestNumericEnumJsonEncoding)?.SingleOrDefault(), "true", StringComparison.OrdinalIgnoreCase);
-                
+
                 var logFile = extraParams.GetValueOrDefault(nameLogFile)?.SingleOrDefault();
                 Logging.ConfigureForFile(logFile);
 
@@ -204,7 +204,7 @@ namespace Google.Api.Generator
 
                 codeGenResponse = new CodeGeneratorResponse
                 {
-                    SupportedFeatures = (int)CodeGeneratorResponse.Types.Feature.Proto3Optional,
+                    SupportedFeatures = (int) CodeGeneratorResponse.Types.Feature.Proto3Optional,
                     File =
                     {
                         results.Select(x => new CodeGeneratorResponse.Types.File
@@ -251,7 +251,7 @@ namespace Google.Api.Generator
                         return parts;
                     })
                     .GroupBy(x => x[0])
-                    .ToDictionary(x => x.Key, x => (IReadOnlyList<string>)x.Select(y => y[1]).ToList());
+                    .ToDictionary(x => x.Key, x => (IReadOnlyList<string>) x.Select(y => y[1]).ToList());
             }
         }
 

--- a/Google.Api.Generator/ProtoUtils/ProtoCatalog.cs
+++ b/Google.Api.Generator/ProtoUtils/ProtoCatalog.cs
@@ -42,19 +42,19 @@ namespace Google.Api.Generator.ProtoUtils
             _msgs = allDescriptors.SelectMany(desc => desc.MessageTypes).SelectMany(MsgPlusNested).ToDictionary(x => x.FullName);
             _services = allDescriptors.SelectMany(desc => desc.Services).ToDictionary(x => x.FullName);
             _resourcesByFileName = ResourceDetails.LoadResourceDefinitionsByFileName(allDescriptors, commonResourcesConfigs, librarySettings).GroupBy(x => x.FileName)
-                .ToImmutableDictionary(x => x.Key, x => (IReadOnlyList<ResourceDetails.Definition>)x.ToImmutableList());
+                .ToImmutableDictionary(x => x.Key, x => (IReadOnlyList<ResourceDetails.Definition>) x.ToImmutableList());
             var allResources = _resourcesByFileName.Values.SelectMany(x => x);
             ValidateUniqueResourceTypeNames();
             var resourcesByUrt = allResources.ToDictionary(x => x.UnifiedResourceTypeName);
             var resourcesByPatternComparison = allResources
                 .SelectMany(def => def.Patterns.Where(x => !x.IsWildcard).Select(x => (x.Template.ParentComparisonString, def)))
                 .GroupBy(x => x.ParentComparisonString, x => x.def)
-                .ToImmutableDictionary(x => x.Key, x => (IReadOnlyList<ResourceDetails.Definition>)x.ToImmutableList());
+                .ToImmutableDictionary(x => x.Key, x => (IReadOnlyList<ResourceDetails.Definition>) x.ToImmutableList());
             _resourcesByFieldName = allDescriptors
                 .SelectMany(desc => desc.MessageTypes)
                 .SelectMany(MsgPlusNested)
                 .SelectMany(msg => msg.Fields.InFieldNumberOrder().Select(field =>
-                    (field, res: (IReadOnlyList<ResourceDetails.Field>)ResourceDetails.LoadResourceReference(
+                    (field, res: (IReadOnlyList<ResourceDetails.Field>) ResourceDetails.LoadResourceReference(
                         msg, field, resourcesByUrt, resourcesByPatternComparison, requiredFileDescriptors.Contains(msg.File)).ToList()))
                     .Where(x => x.res.Any()))
                 .ToDictionary(x => x.field.FullName, x => x.res);

--- a/Google.Api.Generator/ProtoUtils/ResourceDetails.cs
+++ b/Google.Api.Generator/ProtoUtils/ResourceDetails.cs
@@ -16,7 +16,6 @@ using Google.Api.Gax;
 using Google.Api.Generator.Utils;
 using Google.Protobuf.Reflection;
 using Google.Protobuf.WellKnownTypes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -179,13 +178,13 @@ namespace Google.Api.Generator.ProtoUtils
             var msgsFromProtoMsgs = descs
                 .SelectMany(fileDesc => fileDesc.MessageTypes
                     .SelectMany(GetMessagesAndSelf)
-                    .Select(msgDesc =>(fileDesc, msgDesc, resDesc: msgDesc.GetExtension(ResourceExtensions.Resource))))
+                    .Select(msgDesc => (fileDesc, msgDesc, resDesc: msgDesc.GetExtension(ResourceExtensions.Resource))))
                 .Where(x => x.resDesc != null)
                 .Select(x => (x.fileDesc, x.msgDesc, x.resDesc, shortName: GetShortName(x.resDesc)));
             var msgsFromFileAnnotation = descs
                 .SelectMany(fileDesc =>
                     fileDesc.GetExtension(ResourceExtensions.ResourceDefinition)
-                        .Select(resDesc => (fileDesc, msgDesc: (MessageDescriptor)null, resDesc, shortName: GetShortName(resDesc))));
+                        .Select(resDesc => (fileDesc, msgDesc: (MessageDescriptor) null, resDesc, shortName: GetShortName(resDesc))));
             var msgs = msgsFromProtoMsgs.Concat(msgsFromFileAnnotation).ToImmutableList();
             var ignoredTypes = (librarySettings?.DotnetSettings?.IgnoredResources ?? Enumerable.Empty<string>()).ToHashSet();
             return msgs

--- a/Google.Api.Generator/ProtoUtils/ResourcePattern.cs
+++ b/Google.Api.Generator/ProtoUtils/ResourcePattern.cs
@@ -156,7 +156,7 @@ namespace Google.Api.Generator.ProtoUtils
             public override IReadOnlyList<string> ParameterNames { get; }
             private IReadOnlyList<string> ParameterNamesWithSuffix { get; }
             public override string PathTemplateString => $"{{{(ParameterCount == 1 ? ParameterNamesWithSuffix[0] : string.Join('_', ParameterNames))}}}";
-            public override string RegexString => 
+            public override string RegexString =>
                 throw new NotImplementedException("Forming a regex string of a multivariate resource id segment is not implemented.");
             public override string Expand(IEnumerable<string> parameters) =>
                 parameters.First() + string.Join("", Separators.Zip(parameters.Skip(1), (s, p) => $"{s}{p}"));
@@ -170,16 +170,16 @@ namespace Google.Api.Generator.ProtoUtils
             {
                 Check(segment.First() == '{', $"'{{' expected at the beginning of the segment `{segment}`.");
                 Check(segment.IndexOf('}') != -1, $"missing '}}' in the segment `{segment}`.");
-                Check( segment.IndexOf('}') == segment.LastIndexOf('}'), $"extra '}}' in the segment `{segment}`.");
+                Check(segment.IndexOf('}') == segment.LastIndexOf('}'), $"extra '}}' in the segment `{segment}`.");
                 Check(segment.Last() == '}', $"'}}' expected to be at the end of the segment `{segment}`.");
                 PathTemplateString = segment;
 
                 var indexOfEquals = segment.IndexOf('=');
-                Check(indexOfEquals == segment.LastIndexOf('='), $"extra `=` in the segment `{segment}`." );
-                
-                string paramName = indexOfEquals == -1 
-                    ? segment.Substring(1, segment.Length-2)
-                    : segment.Substring(1, indexOfEquals-1);
+                Check(indexOfEquals == segment.LastIndexOf('='), $"extra `=` in the segment `{segment}`.");
+
+                string paramName = indexOfEquals == -1
+                    ? segment.Substring(1, segment.Length - 2)
+                    : segment.Substring(1, indexOfEquals - 1);
 
                 bool valid = Regex.IsMatch(paramName, "^[a-zA-Z][a-zA-Z0-9_.]*$");
                 Check(valid, $"parameter name '{paramName}' contains invalid characters.");
@@ -195,7 +195,7 @@ namespace Google.Api.Generator.ProtoUtils
                     : _givenPattern;
 
                 _effectivePattern = new ResourcePattern(effectiveParamPatternStr);
-                
+
                 void Check(bool cond, string msg)
                 {
                     if (!cond)
@@ -267,11 +267,11 @@ namespace Google.Api.Generator.ProtoUtils
         //
         // This pattern is used for `*` segments.
         public const string SingleWildcardRegexStr = "[^/]+";
-        
+
         public ResourcePattern(string pattern)
         {
             string remainder = Regex.Replace(pattern, "^/", string.Empty);
-            
+
             if (string.IsNullOrWhiteSpace(remainder))
             {
                 throw new ArgumentException($"Pattern '{pattern}' contains only leading slash and/or whitespace.");
@@ -363,8 +363,8 @@ namespace Google.Api.Generator.ProtoUtils
                 return Segments.Skip(1)
                     .Aggregate(first, (current, segment) => segment switch
                     {
-                       WildcardSegment { Pattern: "**" } => $"{current}{DoubleWildcardInPatternRegexStr}",
-                       _ => $"{current}/{segment.RegexString}"
+                        WildcardSegment { Pattern: "**" } => $"{current}{DoubleWildcardInPatternRegexStr}",
+                        _ => $"{current}/{segment.RegexString}"
                     });
             }
         }
@@ -374,7 +374,7 @@ namespace Google.Api.Generator.ProtoUtils
         /// </summary>
         public bool IsDoubleWildcardPattern => Segments.Count == 1 && Segments.Single() switch
         {
-            WildcardSegment  { Pattern: "**" } wcdId => true,
+            WildcardSegment { Pattern: "**" } wcdId => true,
             ResourceIdSegment { Pattern: "**" } resId => true,
             _ => false
         };


### PR DESCRIPTION
The test changes weren't quite a matter of running code cleanup, as a) code cleanup ignores generated files (g.cs); b) we still have some unused using alias directives present, so just "Remove and sort usings" in a file does the wrong thing too.

Obviously as part of rolling out this change, we'll need to regenerate everything and accept the one-off churn.