### PR TITLE
fix: Disambiguate resource name collisions

### DIFF
--- a/Google.Api.Generator/ProtoUtils/ResourceDetails.cs
+++ b/Google.Api.Generator/ProtoUtils/ResourceDetails.cs
@@ -139,10 +139,11 @@ namespace Google.Api.Generator.ProtoUtils
                 // innerFields only non-null for the IResourceName property of child_type refs.
                 Descriptor = fieldDesc;
                 ResourceDefinition = resourceDef;
+                var unqualifiedName = (resourceDef.IsWildcardOnly ? "ResourceName" : resourceDef.ResourceNameTyp.Name) + (fieldDesc.IsRepeated ? "s" : "");
                 var requireIdentifier = !((fieldDesc.IsRepeated && fieldDesc.Name.ToLowerInvariant() == "names") ||
-                    (!fieldDesc.IsRepeated && fieldDesc.Name.ToLowerInvariant() == "name"));
-                ResourcePropertyName = (requireIdentifier ? $"{UnderlyingPropertyName}As" : "") +
-                    (resourceDef.IsWildcardOnly ? "ResourceName" : resourceDef.ResourceNameTyp.Name) + (fieldDesc.IsRepeated ? "s" : "");
+                    (!fieldDesc.IsRepeated && fieldDesc.Name.ToLowerInvariant() == "name")) ||
+                    fieldDesc.ContainingType.Fields.InDeclarationOrder().Any(f => f.CSharpPropertyName() == unqualifiedName);
+                ResourcePropertyName = (requireIdentifier ? $"{UnderlyingPropertyName}As" : "") + unqualifiedName;
                 InnerDefs = innerDefs;
                 ContainsWildcard = containsWildcard;
             }


### PR DESCRIPTION
For example, if an `Account` resource has `name` and `account_name` properties, we don't want to generate an `AccountName` property in GAPIC, as that collides with the one generated by protoc. Instead, we generate `NameAsAccountName`.

No tests for this edge case, but I've run the generator against the Merchant Accounts API (which flagged this up) and the result builds where it didn't before.

Fixes b/343924087