### PR TITLE
deps: Ignore renovate presets

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
     "config:base",
     ":disableDependencyDashboard"
   ],
+  "ignorePresets": [":ignoreModulesAndTests"],
   "ignorePaths": [
     "bazel_example/**",
     "Google.Api.Generators.Tests/ProtoTests/**",


### PR DESCRIPTION
These may introduce breaking changes without warnings. And currently, after one such occurrence, override our config. See renovatebot/renovate#31436