### PR TITLE
chore: Update to latest GAX

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,14 +11,13 @@
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     
     <!-- Google/gRPC packages -->
-    <PackageVersion Include="Google.Api.Gax" Version="4.8.0" />
-    <PackageVersion Include="Google.Api.Gax.Grpc" Version="4.8.0" />
-    <PackageVersion Include="Google.Api.Gax.Testing" Version="4.8.0" />
+    <PackageVersion Include="Google.Api.Gax" Version="4.9.0" />
+    <PackageVersion Include="Google.Api.Gax.Grpc" Version="4.9.0" />
+    <PackageVersion Include="Google.Api.Gax.Testing" Version="4.9.0" />
     <PackageVersion Include="Google.Apis" Version="1.68.0" />
     <PackageVersion Include="Google.Cloud.Iam.V1" Version="3.3.0" />
     <PackageVersion Include="Google.Cloud.Location" Version="2.3.0" />
     <PackageVersion Include="Google.LongRunning" Version="3.3.0" />
-    <PackageVersion Include="Google.Protobuf" Version="3.28.2" />
 
     <!-- Microsoft/System packages -->
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />

--- a/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1/Testing.Basic.V1.csproj
+++ b/Google.Api.Generator.Tests/ProtoTests/Basic.v1/Testing.Basic.V1/Testing.Basic.V1.csproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.9.0, 5.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" Condition="'$(TargetFramework)'=='net462'" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
   </ItemGroup>

--- a/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro/Testing.Lro.csproj
+++ b/Google.Api.Generator.Tests/ProtoTests/Lro/Testing.Lro/Testing.Lro.csproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.9.0, 5.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" Condition="'$(TargetFramework)'=='net462'" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
     <PackageReference Include="Google.LongRunning" Version="[3.3.0, 4.0.0)" />

--- a/Google.Api.Generator.Tests/ProtoTests/Mixins/Testing.Mixins/Testing.Mixins.csproj
+++ b/Google.Api.Generator.Tests/ProtoTests/Mixins/Testing.Mixins/Testing.Mixins.csproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.9.0, 5.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" Condition="'$(TargetFramework)'=='net462'" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.3.0, 3.0.0)" />

--- a/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/Google.Showcase.V1Beta1.csproj
+++ b/Google.Api.Generator.Tests/ProtoTests/Showcase/Google.Showcase.V1Beta1/Google.Showcase.V1Beta1.csproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.9.0, 5.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" Condition="'$(TargetFramework)'=='net462'" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.3.0, 3.0.0)" />

--- a/Google.Api.Generator/Generation/CsProjGenerator.cs
+++ b/Google.Api.Generator/Generation/CsProjGenerator.cs
@@ -23,7 +23,7 @@ namespace Google.Api.Generator.Generation
 {
     internal static class CsProjGenerator
     {
-        private const string GaxGrpcVersion = "[4.8.0, 5.0.0)";
+        private const string GaxGrpcVersion = "[4.9.0, 5.0.0)";
         private const string GrpcCoreVersion = "[2.46.6, 3.0.0)";
         private const string LroVersion = "[3.3.0, 4.0.0)";
         private const string IamVersion = "[3.3.0, 4.0.0)";

--- a/Google.Api.Generator/Google.Api.Generator.csproj
+++ b/Google.Api.Generator/Google.Api.Generator.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="Google.Cloud.Iam.V1" />
     <PackageReference Include="Google.Cloud.Location" />
     <PackageReference Include="Google.LongRunning" />
-    <PackageReference Include="Google.Protobuf" />
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Linq.Async" />
     <PackageReference Include="YamlDotNet" />


### PR DESCRIPTION
The direct Google.Protobuf dependency is no longer needed as the one in GAX is the latest.