### PR TITLE
fix: avoid bazel rules failing due to unexpected dotnet output

### DIFF
--- a/rules_csharp_gapic/csharp_compiler.bzl
+++ b/rules_csharp_gapic/csharp_compiler.bzl
@@ -63,6 +63,7 @@ export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 export DOTNET_NOLOGO=1
 export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+export DOTNET_SKIP_WORKLOAD_INTEGRITY_CHECK=1
 
 # Running this command twice, if the first invocation fails, try once more
 # [virost, 03/2021] temporarily until I figure out what causes intermittent Kokoro failures


### PR DESCRIPTION
The first run of "dotnet" in any given location includes output of:

> An issue was encountered verifying workloads. For more information,
> run "dotnet workload update"

... which is unhelpful when stdout is being used by protoc.

The DOTNET_SKIP_WORKLOAD_INTEGRITY_CHECK environment variable skips this check.