### PR TITLE
chore: Release GAPIC generator 1.4.35

### DIFF
--- a/Google.Api.Generator.Rest/Google.Api.Generator.Rest.csproj
+++ b/Google.Api.Generator.Rest/Google.Api.Generator.Rest.csproj
@@ -4,7 +4,7 @@
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <Version>1.4.34</Version>
+    <Version>1.4.35</Version>
     <Description>Tool used by Google .NET client library maintainers to generate Discovery-based (REST) libraries. While there is nothing "secret" in this package, it is unlikely to be useful to other developers. It is only published as a matter of convenience for other Google .NET repositories.</Description>
     <ToolCommandName>google-rest-generator</ToolCommandName>
   </PropertyGroup>

--- a/Google.Api.Generator/Google.Api.Generator.csproj
+++ b/Google.Api.Generator/Google.Api.Generator.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
 
-    <Version>1.4.34</Version>
+    <Version>1.4.35</Version>
     <Description>Tool used by Google .NET client library maintainers to generate GAPIC libraries. While there is nothing "secret" in this package, it is unlikely to be useful to other developers. It is only published as a matter of convenience for other Google .NET repositories.</Description>
     <ToolCommandName>google-gapic-generator</ToolCommandName>
     


### PR DESCRIPTION
Changes since 1.4.34:

- Fix use of .NET 8 in Bazel