### PR TITLE
chore(actions): address zizmor findings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,7 @@
 name: Build
+
+permissions:
+  contents: read
 on: [push, pull_request]
 jobs:
   build:
@@ -7,12 +10,13 @@ jobs:
       DOTNET_NOLOGO: true
 
     steps:	
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:	
-        submodules: true	
+        submodules: true
+        persist-credentials: false	
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: 8.0.x
 


### PR DESCRIPTION
This PR is an auto-generated attempt to address zizmor findings. It may not catch everything, and should be reviewed by repository owners.

These changes were generated by running `zizmor --fix=all --gh-token=$(gh auth token) ./.github/workflows`, and then applying some fixes for any remaining issues reported by zizmor. See go/github-zizmor-help for instructions to install and run.

If this PR is unhelpful, feel free to close the PR and address separately. If it is helpful, feel free to approve and merge, or edit/modify as needed to get it to the right state. Repository owners must ultimately ensure compliance by 2026-07-13. The purpose of this PR is to provide some assistance with achieving that as a first pass. This will become a blocking check for new changes to github workflows on 2026-07-13 within the `googleapis` org.

There may be some ignored findings (with the comment `# zizmor: ignore[...]`), which you may fix if feasible.
