### PR TITLE
fix: pass forward debugger properties on exception

### DIFF
--- a/Google.Api.Generator/Program.cs
+++ b/Google.Api.Generator/Program.cs
@@ -38,6 +38,9 @@ namespace Google.Api.Generator
         private const string nameTransport = "transport";
         private const string nameRequestNumericEnumJsonEncoding = "rest-numeric-enums";
         private const string nameLogFile = "log";
+        private const ulong CodeGeneratorResponseSupportedFeatures = (ulong) (CodeGeneratorResponse.Types.Feature.Proto3Optional | CodeGeneratorResponse.Types.Feature.SupportsEditions);
+        private const int CodeGeneratorResponseMinimumEdition = (int) Edition.Proto2;
+        private const int CodeGeneratorResponseMaximumEdition = (int) Edition._2023;
 
         private static IImmutableSet<string> s_validParameters = ImmutableHashSet.Create(
             nameGrpcServiceConfig,
@@ -204,9 +207,9 @@ namespace Google.Api.Generator
 
                 codeGenResponse = new CodeGeneratorResponse
                 {
-                    SupportedFeatures = (int) CodeGeneratorResponse.Types.Feature.Proto3Optional | (int) CodeGeneratorResponse.Types.Feature.SupportsEditions,
-                    MinimumEdition = (int) Edition.Proto2,
-                    MaximumEdition = (int) Edition._2023,
+                    SupportedFeatures = CodeGeneratorResponseSupportedFeatures,
+                    MinimumEdition = CodeGeneratorResponseMinimumEdition,
+                    MaximumEdition = CodeGeneratorResponseMaximumEdition,
                     File =
                     {
                         results.Select(x => new CodeGeneratorResponse.Types.File
@@ -222,6 +225,9 @@ namespace Google.Api.Generator
                 // On failure, send the error back to protoc.
                 codeGenResponse = new CodeGeneratorResponse
                 {
+                    SupportedFeatures = CodeGeneratorResponseSupportedFeatures,
+                    MinimumEdition = CodeGeneratorResponseMinimumEdition,
+                    MaximumEdition = CodeGeneratorResponseMaximumEdition,
                     Error = e.ToString()
                 };
                 Logging.LogError(e, "Generation failed");


### PR DESCRIPTION
 On exception we will get misleading error messages from protoc compiler if these are not passed forward. Note the specified properties are `[DebuggerNonUserCode]`:
 
 Before (has misleading message to add support for optional fields):
 ```
 2026-07-30T16:24:49.863Z Generating Google.Cloud.Sql.V1
google/cloud/sql/v1/cloud_sql_users.proto: is a proto3 file that contains optional fields, but code 
generator protoc-gen-gapic hasn't been updated to support optional fields in proto3. 
Please ask the owner of this code generator to support proto3 optional.
    --gapic_out: System.InvalidOperationException: Not all patterns can be matched to a parent
  resource for field CreateBackupRequest.parent
  
  ```

After:
```
2026-07-30T16:26:20.374Z Generating Google.Cloud.Sql.V1
    --gapic_out: System.InvalidOperationException: Not all patterns can be matched to a parent
  resource for field CreateBackupRequest.parent
```

b/540852437